### PR TITLE
Fixed namespace functions

### DIFF
--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -53,9 +53,14 @@ jobs:
           sudo apt-get install -y build-essential automake autoconf pkg-config bc m4 unzip zip curl git libssl-dev libncurses5-dev erlang-inets erlang-os-mon erlang-runtime-tools erlang-ssl erlang-dev python3 ca-certificates
           sudo apt-get install -y libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavresample-dev ffmpeg
 
-      - name: Compile and Test
+      - name: Mix Compile
         run: |
           export OPENCV_VER=${{ matrix.pair.opencv_ver }}
           export MIX_ENV=test
           mix deps.get
-          MAKE_BUILD_FLAGS="-j$(nproc)" mix test
+          MAKE_BUILD_FLAGS="-j$(nproc)" mix compile
+
+      - name: Mix Test
+        run: |
+          export OPENCV_VER=${{ matrix.pair.opencv_ver }}
+          mix test

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -41,9 +41,15 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
 
-      - name: Compile and Test
+      - name: Mix Compile
         run: |
           export OPENCV_VER=${{ matrix.pair.opencv_ver }}
+          export MIX_ENV=test
           mix deps.get
           NPROC="$(sysctl -a | grep 'hw.ncpu' | awk '{print $2}')"
-          MAKE_BUILD_FLAGS="-j${NPROC}" mix test
+          MAKE_BUILD_FLAGS="-j${NPROC}" mix compile
+
+      - name: Mix Test
+        run: |
+          export OPENCV_VER=${{ matrix.pair.opencv_ver }}
+          mix test

--- a/examples/dnn-detection-model.livemd
+++ b/examples/dnn-detection-model.livemd
@@ -88,15 +88,15 @@ defmodule DetectionModel do
       ])
 
     {:ok, mat} =
-      OpenCV.puttext(mat, text, [l, top], OpenCV.cv_FONT_HERSHEY_SIMPLEX(), 0.5, [0, 0, 255])
+      OpenCV.putText(mat, text, [l, top], OpenCV.cv_FONT_HERSHEY_SIMPLEX(), 0.5, [0, 0, 255])
 
     _visualise_pred(mat, labels, outs)
   end
 
   def postprocess(mat, detections, net, confidence_threshold) do
-    {:ok, out_layers} = OpenCV.DnnNet.getUnconnectedOutLayers(net)
-    {:ok, out_layer} = OpenCV.DnnNet.getLayer(net, Enum.at(out_layers, 0))
-    out_layer_type = OpenCV.DnnLayer.type(out_layer) |> IO.iodata_to_binary()
+    {:ok, out_layers} = OpenCV.DNN.Net.getUnconnectedOutLayers(net)
+    {:ok, out_layer} = OpenCV.DNN.Net.getLayer(net, Enum.at(out_layers, 0))
+    out_layer_type = OpenCV.DNN.Layer.type(out_layer) |> IO.iodata_to_binary()
     _postprocess(mat, detections, net, confidence_threshold, out_layer_type, [])
   end
 
@@ -162,13 +162,13 @@ defmodule DetectionModel do
 
   def predict(image_file, model, out_names, opts \\ []) do
     {:ok, mat} = OpenCV.imread(image_file)
-    {:ok, blob} = OpenCV.dnn_blobFromImage(mat, opts)
+    {:ok, blob} = OpenCV.DNN.blobFromImage(mat, opts)
 
     {:ok, model} =
-      OpenCV.DnnNet.setInput(model, blob, name: "", scalefactor: 1.0, mean: [0, 0, 0])
+      OpenCV.DNN.Net.setInput(model, blob, name: "", scalefactor: 1.0, mean: [0, 0, 0])
 
     start_time = :os.system_time(:millisecond)
-    {:ok, detections} = OpenCV.DnnNet.forward(model, outBlobNames: out_names)
+    {:ok, detections} = OpenCV.DNN.Net.forward(model, outBlobNames: out_names)
     end_time = :os.system_time(:millisecond)
     IO.puts("Inference time=>#{end_time - start_time} ms")
     {:ok, mat, detections}
@@ -176,12 +176,12 @@ defmodule DetectionModel do
 
   def get_model(params, config, framework \\ "") do
     {:ok, net} =
-      OpenCV.dnn_readNet_model(params,
+      OpenCV.DNN.readNetModel(params,
         config: config,
         framework: framework
       )
 
-    {:ok, out_names} = OpenCV.DnnNet.getUnconnectedOutLayersNames(net)
+    {:ok, out_names} = OpenCV.DNN.Net.getUnconnectedOutLayersNames(net)
     {:ok, net, out_names}
   end
 end

--- a/examples/dnn-googlenet.livemd
+++ b/examples/dnn-googlenet.livemd
@@ -175,7 +175,7 @@ classes =
 
 ```elixir
 {:ok, model} =
-  OpenCV.dnn_readNet_model("bvlc_googlenet.caffemodel",
+  OpenCV.DNN.readNetModel("bvlc_googlenet.caffemodel",
     config: "bvlc_googlenet.prototxt",
     framework: ""
   )
@@ -194,7 +194,7 @@ classes =
 # "3: OpenCV implementation, "
 # "4: VKCOM, "
 # "5: CUDA
-{:ok, model} = OpenCV.DnnNet.setPreferableBackend(model, 0)
+{:ok, model} = OpenCV.DNN.Net.setPreferableBackend(model, 0)
 
 # "0: CPU target (by default), "
 # "1: OpenCL, "
@@ -203,7 +203,7 @@ classes =
 # "4: Vulkan, "
 # "6: CUDA, "
 # "7: CUDA fp16 (half-float preprocess)
-{:ok, model} = OpenCV.DnnNet.setPreferableTarget(model, 0)
+{:ok, model} = OpenCV.DNN.Net.setPreferableTarget(model, 0)
 ```
 
 ```output
@@ -216,14 +216,14 @@ classes =
 {:ok, mat} = OpenCV.imread("space_shuttle.jpg")
 
 {:ok, blob} =
-  OpenCV.dnn_blobFromImage(mat,
+  OpenCV.DNN.blobFromImage(mat,
     scalefactor: 1,
     swapRB: true,
     mean: [-104, -117, -123],
     size: [224, 224]
   )
 
-{:ok, model} = OpenCV.DnnNet.setInput(model, blob, name: "", scalefactor: 1.0, mean: [0, 0, 0])
+{:ok, model} = OpenCV.DNN.Net.setInput(model, blob, name: "", scalefactor: 1.0, mean: [0, 0, 0])
 ```
 
 ```output
@@ -234,7 +234,7 @@ classes =
 
 ```elixir
 start_time = :os.system_time(:millisecond)
-{:ok, pred} = OpenCV.DnnNet.forward(model, outputName: "")
+{:ok, pred} = OpenCV.DNN.Net.forward(model, outputName: "")
 end_time = :os.system_time(:millisecond)
 "Inference time=>#{end_time - start_time} ms"
 ```

--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -1470,6 +1470,25 @@ class PythonWrapperGenerator(object):
                     module_func_name = module_func_name[len(evision_nif_prefix):]
                 else:
                     module_func_name = name
+                if wname != 'cv':
+                    namespace_func = wname + '_' + name
+                    if namespace_func != module_func_name:
+                        return
+                elif name and len(name) > 0 and not ('a' <= name[0] <= 'z'):
+                    if module_func_name.startswith(name + '_') or module_func_name.endswith('_create'):
+                        return
+                    elif module_func_name.startswith('CascadeClassifier') \
+                            or module_func_name.startswith('HOGDescriptor') \
+                            or module_func_name.startswith('KeyPoint') \
+                            or module_func_name.startswith('UMat_') \
+                            or module_func_name.startswith('VideoWriter_'):
+                        return
+                    else:
+                        # print(wname, '<|>', name, '<|>', module_func_name, '<|>', separated_ns, is_ns)
+                        _ = 0
+                else:
+                    # print(wname, '<>', name, '<>', module_func_name, '<>', separated_ns, is_ns)
+                    _ = 0
             else:
                 module_func_name = name
                 # if this function is an instance method of a C++ class

--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -1485,6 +1485,22 @@ class PythonWrapperGenerator(object):
                 writer, _ = self.get_module_writer(wname, wname=wname, name=name, is_ns=is_ns)
                 if module_func_name.startswith(wname+'_'):
                     module_func_name = module_func_name[len(wname)+1:]
+                if '_' in module_func_name:
+                    return
+                else:
+                    if len(module_func_name) > 0 and not ('a' <= module_func_name <= 'z'):
+                        if len(module_func_name) >= 2 and not ('a' <= module_func_name[1] <= 'z'):
+                            func_name_mapping = {
+                                'NMSBoxes': 'nmsBoxes',
+                                'NMSBoxesRotated': 'nmsBoxesRotated'
+                            }
+                            if module_func_name in func_name_mapping:
+                                module_func_name = func_name_mapping.get(module_func_name)
+                            else:
+                                print(f'NOTICE:function name in namespace[{wname}]:{module_func_name}')
+                                module_func_name = module_func_name.lower()
+                        else:
+                            module_func_name = module_func_name.lower()
             else:
                 if separated_ns is not None and len(separated_ns) > 1:
                     prefix = "_".join(separated_ns[:-1]) + '_'
@@ -1547,10 +1563,11 @@ class PythonWrapperGenerator(object):
                                 return
                         module_func_name = module_func_name.lower()
 
-            if module_func_name == "dnn_readNet":
-                module_func_name = "dnn_readNet_" + arglist[0][0]
+            if module_func_name == "readNet":
+                read_net_var = arglist[0][0]
+                module_func_name = f"readNet{read_net_var[0].upper()}{read_net_var[1:]}"
             if func_name.startswith(evision_nif_prefix + "dnn") and module_func_name == "forward":
-                sign = evision_nif_prefix + "dnn_forward"
+                sign = evision_nif_prefix + "forward"
             if func_name.startswith(evision_nif_prefix + "dnn_dnn_net") and (module_func_name == "getLayerShapes" or module_func_name == "getLayersShapes"):
                 sign = evision_nif_prefix + "dnn_dnn_net_" + module_func_name
             if unique_signatures.get(sign, None) is True:


### PR DESCRIPTION
This PR fixes #24, for example,

Before:
`OpenCV.dnn_blobFromImage`

After:
`OpenCV.DNN.blobFromImage`