### PR TITLE
Improvements to OpenCV.Nx

### DIFF
--- a/lib/opencv_nx.ex
+++ b/lib/opencv_nx.ex
@@ -10,7 +10,7 @@ defmodule OpenCV.Nx do
   @compile {:no_warn_undefined, Nx}
 
   @doc """
-  Transform an OpenCV.Mat `#Reference` to `Nx.tensor`.
+  Transform an `OpenCV.Mat` reference to `Nx.tensor`.
 
   The resulting tensor is in the shape `{height, width, channels}`.
 

--- a/lib/opencv_nx.ex
+++ b/lib/opencv_nx.ex
@@ -7,7 +7,9 @@ defmodule OpenCV.Nx do
   list.
   """
 
-  @compile {:no_warn_undefined, Nx}
+  unless Code.ensure_loaded?(Nx) do
+    @compile {:no_warn_undefined, Nx}
+  end
 
   @doc """
   Transform an `OpenCV.Mat` reference to `Nx.tensor`.

--- a/lib/opencv_nx.ex
+++ b/lib/opencv_nx.ex
@@ -7,74 +7,66 @@ defmodule OpenCV.Nx do
   list.
   """
 
+  @compile {:no_warn_undefined, Nx}
+
   @doc """
-  Transform an OpenCV.Mat `#Reference` to `#Nx.tensor`
+  Transform an OpenCV.Mat `#Reference` to `Nx.tensor`.
+
+  The resulting tensor is in the shape `{width, height, channels}`.
+
   ### Example
+
   ```elixir
-  {:ok, mat} = OpenCV.imread("/path/to/exist/img.png")
-  nx_tensor = OpenCV.Nx.to_nx(mat)
-   #Nx.Tensor<
-      u8[1080][1920][3]
-      [[ ... pixel data ... ]]
-   >
+  iex> {:ok, mat} = OpenCV.imread("/path/to/exist/img.png")
+  iex> nx_tensor = OpenCV.Nx.to_nx(mat)
+  ...> #Nx.Tensor<
+  ...>    u8[1080][1920][3]
+  ...>    [[ ... pixel data ... ]]
+  ...> >
   ```
   """
   @doc namespace: :external
   @spec to_mat(reference()) :: {:ok, reference()} | {:error, String.t()}
   def to_nx(mat) do
-    if Code.ensure_loaded?(Nx) do
-      {:ok, mat_type} = OpenCV.Mat.type(mat)
-      {:ok, mat_shape} = OpenCV.Mat.shape(mat)
+    {:ok, mat_type} = OpenCV.Mat.type(mat)
+    {:ok, mat_shape} = OpenCV.Mat.shape(mat)
 
-      case OpenCV.Mat.to_binary(mat) do
-        {:ok, bin} ->
-          bin
-          |> Nx.from_binary(mat_type)
-          |> Nx.reshape(mat_shape)
+    case OpenCV.Mat.to_binary(mat) do
+      {:ok, bin} ->
+        bin
+        |> Nx.from_binary(mat_type)
+        |> Nx.reshape(mat_shape)
 
-        {:error, reason} ->
-          {:error, List.to_string(reason)}
+      {:error, reason} ->
+        {:error, List.to_string(reason)}
 
-        _ ->
-          {:error, "unknown error"}
-      end
-    else
-      {:error, ":nx is missing"}
+      _ ->
+        {:error, "unknown error"}
     end
   end
 
   @doc """
   Converts a tensor of `Nx` to `Mat` of evision (OpenCV).
+
+  If the tensor has three dimensions, it is expected
+  to have shape`{width, height, channels}`.
   """
   @doc namespace: :external
   @spec to_mat(Nx.t()) :: {:ok, reference()} | {:error, String.t()}
-  def to_mat(nil, _), do: {:error, "tensor is nil"}
-
-  def to_mat(t) do
-    if Code.ensure_loaded?(Nx) do
-      shape = Nx.shape(t)
-      l_shape = Tuple.to_list(shape)
-      if Enum.count(l_shape) == 3 do
-        {rows, cols, channels} = shape
-        to_mat(Nx.to_binary(t), Nx.type(t), cols, rows, channels)
-      else
-        case OpenCV.Mat.from_binary_by_shape(Nx.to_binary(t), Nx.type(t), Nx.shape(t)) do
-          {:ok, mat} ->
-            {:ok, mat}
-
-          {:error, reason} ->
-            {:error, List.to_string(reason)}
-
-          _ ->
-            {:error, "unknown error"}
+  def to_mat(t) when is_struct(t, Nx.Tensor) do
+    case Nx.shape(t) do
+      {width, height, channels} ->
+        to_mat(Nx.to_binary(t), Nx.type(t), width, height, channels)
+    
+      shape ->
+        case OpenCV.Mat.from_binary_by_shape(Nx.to_binary(t), Nx.type(t), shape) do
+          {:ok, mat} -> {:ok, mat}
+          {:error, reason} -> {:error, List.to_string(reason)}
+          _ -> {:error, "unknown error"}
         end
-      end
-    else
-      {:error, ":nx is missing"}
     end
   end
 
-  @doc false
   @spec to_mat(
           binary(),
           {atom(), pos_integer()},
@@ -82,7 +74,7 @@ defmodule OpenCV.Nx do
           pos_integer(),
           pos_integer()
         ) :: {:ok, reference()} | {:error, charlist()}
-  def to_mat(binary, type, cols, rows, channels) do
+  defp to_mat(binary, type, cols, rows, channels) do
     case OpenCV.Mat.from_binary(binary, type, cols, rows, channels) do
       {:ok, mat} ->
         {:ok, mat}

--- a/lib/opencv_nx.ex
+++ b/lib/opencv_nx.ex
@@ -55,8 +55,8 @@ defmodule OpenCV.Nx do
   @spec to_mat(Nx.t()) :: {:ok, reference()} | {:error, String.t()}
   def to_mat(t) when is_struct(t, Nx.Tensor) do
     case Nx.shape(t) do
-      {width, height, channels} ->
-        to_mat(Nx.to_binary(t), Nx.type(t), width, height, channels)
+      {height, width, channels} ->
+        to_mat(Nx.to_binary(t), Nx.type(t), height, width, channels)
     
       shape ->
         case OpenCV.Mat.from_binary_by_shape(Nx.to_binary(t), Nx.type(t), shape) do

--- a/lib/opencv_nx.ex
+++ b/lib/opencv_nx.ex
@@ -58,7 +58,7 @@ defmodule OpenCV.Nx do
   def to_mat(t) when is_struct(t, Nx.Tensor) do
     case Nx.shape(t) do
       {height, width, channels} ->
-        to_mat(Nx.to_binary(t), Nx.type(t), height, width, channels)
+        to_mat(Nx.to_binary(t), Nx.type(t), width, height, channels)
     
       shape ->
         case OpenCV.Mat.from_binary_by_shape(Nx.to_binary(t), Nx.type(t), shape) do

--- a/lib/opencv_nx.ex
+++ b/lib/opencv_nx.ex
@@ -12,7 +12,7 @@ defmodule OpenCV.Nx do
   @doc """
   Transform an OpenCV.Mat `#Reference` to `Nx.tensor`.
 
-  The resulting tensor is in the shape `{width, height, channels}`.
+  The resulting tensor is in the shape `{height, width, channels}`.
 
   ### Example
 
@@ -49,7 +49,7 @@ defmodule OpenCV.Nx do
   Converts a tensor of `Nx` to `Mat` of evision (OpenCV).
 
   If the tensor has three dimensions, it is expected
-  to have shape`{width, height, channels}`.
+  to have shape`{height, width, channels}`.
   """
   @doc namespace: :external
   @spec to_mat(Nx.t()) :: {:ok, reference()} | {:error, String.t()}


### PR DESCRIPTION
* Do not emit warnings compiling without Nx
* Document the shape that is expected and returned
* Raise if called and Nx is missing