### PR TITLE
Tag functions as CPU/IO bound

### DIFF
--- a/c_src/opencv.cpp
+++ b/c_src/opencv.cpp
@@ -23,6 +23,10 @@
 
 #define F(NAME, ARITY)    \
   {#NAME, ARITY, NAME, 0}
+#define F_CPU(NAME, ARITY)    \
+  {#NAME, ARITY, NAME, ERL_NIF_DIRTY_JOB_CPU_BOUND}
+#define F_IO(NAME, ARITY)    \
+  {#NAME, ARITY, NAME, ERL_NIF_DIRTY_JOB_IO_BOUND}
 
 #include "opencv2/opencv_modules.hpp"
 #include "opencv2/core.hpp"

--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -25,25 +25,26 @@ special_handling_funcs = ["{}{}".format(evision_nif_prefix, name) for name in [
 ]
 io_bound_funcs = [
     # read
-    'imread',
-    'imreadmulti',
-    'readOpticalFlow',
-    'readFromModelOptimizer',
-    'readNet',
-    'readNetFromCaffe',
-    'readNetFromDarknet',
-    'readNetFromModelOptimizer',
-    'readNetFromONNX',
-    'readNetFromTensorflow',
-    'readNetFromTorch',
-    'readTensorFromONNX',
-    'readTorchBlob',
-    'load_static',
+    'evision_cv_dnn_dnn_Net_readFromModelOptimizer_static',
+    'evision_cv_imread',
+    'evision_cv_imreadmulti',
+    'evision_cv_readOpticalFlow',
+    'evision_cv_dnn_Net_readFromModelOptimizer',
+    'evision_cv_dnn_readNet',
+    'evision_cv_dnn_readNetFromCaffe',
+    'evision_cv_dnn_readNetFromDarknet',
+    'evision_cv_dnn_readNetFromModelOptimizer',
+    'evision_cv_dnn_readNetFromONNX',
+    'evision_cv_dnn_readNetFromTensorflow',
+    'evision_cv_dnn_readNetFromTorch',
+    'evision_cv_dnn_readTensorFromONNX',
+    'evision_cv_dnn_readTorchBlob',
     # write
-    'write',
-    'imwrite',
-    'imwritemulti',
-    'writeOpticalFlow'
+    'evision_cv_FileStorage_writeComment',
+    'evision_cv_imwrite',
+    'evision_cv_imwritemulti',
+    'evision_cv_writeOpticalFlow',
+    'evision_cv_dnn_writeTextGraph',
 ]
 opencv_ex_fixes = [
   """
@@ -828,7 +829,9 @@ class FuncInfo(object):
         fname = self.get_wrapper_name()
         if fname in special_handling_funcs:
             return ""
-        if 'read' in fname or 'write' in fname or fname in io_bound_funcs:
+        if fname.endswith('_read') or fname.endswith('_load_static') or \
+                fname.endswith('_write') or fname.endswith('_save') or \
+                fname in io_bound_funcs:
             nif_function_decl = f'    F_IO({fname}, {func_arity}),\n'
         else:
             nif_function_decl = f'    F_CPU({fname}, {func_arity}),\n'

--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -1906,7 +1906,9 @@ class PythonWrapperGenerator(object):
                             parts = line[len("// @evision c: "):].split(',')
                             if len(parts) == 2:
                                 func_name = parts[0].strip()
-                                if 'read' in func_name or 'write' in func_name or func_name in io_bound_funcs:
+                                if func_name.endswith('_read') or func_name.endswith('_load_static') or \
+                                        func_name.endswith('_write') or func_name.endswith('_save') or \
+                                        func_name in io_bound_funcs:
                                     self.code_ns_reg.write(f'    F_IO({func_name}, {parts[1].strip()}),\n')
                                 else:
                                     self.code_ns_reg.write(f'    F_CPU({func_name}, {parts[1].strip()}),\n')


### PR DESCRIPTION
Functions are tagged as IO-bound if
- `read` or `write` appears in the function name
- the function name appears in the `io_bound_funcs` list (in `py_src/gen2.py`)

Otherwise, they are tagged as CPU-bound except for getter/setter methods.