### PR TITLE
Added missing comma in Mix.install block

### DIFF
--- a/examples/dnn-detection-model.livemd
+++ b/examples/dnn-detection-model.livemd
@@ -18,7 +18,7 @@
 # If you are using the pre-built nerves firmware
 # you can comment out the following installation step
 Mix.install([
-  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"}
+  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"},
   {:kino, "~> 0.6"}
 ])
 ```

--- a/examples/imread.livemd
+++ b/examples/imread.livemd
@@ -18,7 +18,7 @@
 # If you are using the pre-built nerves firmware
 # you can comment out the following installation step
 Mix.install([
-  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"}
+  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"},
   {:kino, "~> 0.6"}
 ])
 ```

--- a/examples/ml-svm.livemd
+++ b/examples/ml-svm.livemd
@@ -20,7 +20,7 @@
 # If you are using the pre-built nerves firmware
 # you can comment out the following installation step
 Mix.install([
-  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"}
+  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"},
   {:kino, "~> 0.6"}
 ])
 ```

--- a/examples/pca.livemd
+++ b/examples/pca.livemd
@@ -18,7 +18,7 @@
 # If you are using the pre-built nerves firmware
 # you can comment out the following installation step
 Mix.install([
-  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"}
+  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"},
   {:kino, "~> 0.6"}
 ])
 

--- a/examples/photo-hdr.livemd
+++ b/examples/photo-hdr.livemd
@@ -18,7 +18,7 @@
 # If you are using the pre-built nerves firmware
 # you can comment out the following installation step
 Mix.install([
-  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"}
+  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"},
   {:kino, "~> 0.6"}
 ])
 

--- a/examples/stitching.livemd
+++ b/examples/stitching.livemd
@@ -18,7 +18,7 @@
 # If you are using the pre-built nerves firmware
 # you can comment out the following installation step
 Mix.install([
-  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"}
+  {:evision, "~> 0.1.3", github: "cocoa-xu/evision", tag: "v0.1.3"},
   {:kino, "~> 0.6"}
 ])
 ```


### PR DESCRIPTION
Some of the examples are missing a comma in the Mix.install block.