### PR TITLE
More mat functions

### DIFF
--- a/.github/workflows/linux-precompile-gnu.yml
+++ b/.github/workflows/linux-precompile-gnu.yml
@@ -91,7 +91,7 @@ jobs:
         id: cache-mix-compile
         uses: actions/cache@v3
         with:
-          key: precompile-${{ env.MIX_ENV }}-${{ runner.os }}-${{ matrix.pair.arch }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}--${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
+          key: precompile-${{ env.MIX_ENV }}-${{ runner.os }}-${{ matrix.pair.arch }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('py_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}--${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
           path: |
             ./_build
             ./c_src/headers.txt

--- a/.github/workflows/linux-precompile-musl.yml
+++ b/.github/workflows/linux-precompile-musl.yml
@@ -66,7 +66,7 @@ jobs:
         id: cache-mix-compile
         uses: actions/cache@v3
         with:
-          key: precompile-${{ env.MIX_ENV }}-${{ runner.os }}-x86_64-linux-musl-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
+          key: precompile-${{ env.MIX_ENV }}-${{ runner.os }}-x86_64-linux-musl-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('py_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
           path: |
             ./_build
             ./c_src/headers.txt

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -180,7 +180,7 @@ jobs:
         id: cache-mix-compile
         uses: actions/cache@v3
         with:
-          key: compile-ffmpeg-${{ runner.os }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
+          key: compile-ffmpeg-${{ runner.os }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('py_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
           path: |
             ./_build
             ./c_src/headers.txt

--- a/.github/workflows/macos-precompile.yml
+++ b/.github/workflows/macos-precompile.yml
@@ -60,7 +60,7 @@ jobs:
         id: cache-mix-compile
         uses: actions/cache@v3
         with:
-          key: precompile-${{ runner.os }}-${{ matrix.pair.arch }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}
+          key: precompile-${{ runner.os }}-${{ matrix.pair.arch }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('py_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}
           path: |
             ./_build
             ./c_src/headers.txt

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -85,7 +85,7 @@ jobs:
         id: cache-mix-compile
         uses: actions/cache@v3
         with:
-          key: compile-ffmpeg-${{ runner.os }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}
+          key: compile-ffmpeg-${{ runner.os }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('py_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile') }}-${{ env.OPENCV_VER }}
           path: |
             ./_build
             ./c_src/headers.txt

--- a/.github/workflows/windows-precompile.yml
+++ b/.github/workflows/windows-precompile.yml
@@ -59,7 +59,7 @@ jobs:
         id: cache-mix-compile
         uses: actions/cache@v3
         with:
-          key: precompile-${{ runner.os }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile.win') }}-${{ env.OPENCV_VER }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
+          key: precompile-${{ runner.os }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('py_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile.win') }}-${{ env.OPENCV_VER }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
           path: |
             ./_build
             ./c_src/headers.txt

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -89,7 +89,7 @@ jobs:
         id: cache-mix-compile
         uses: actions/cache@v3
         with:
-          key: compile-test-${{ runner.os }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile.win') }}-${{ env.OPENCV_VER }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
+          key: compile-test-${{ runner.os }}-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('c_src/**') }}-${{ hashFiles('py_src/**') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('Makefile.win') }}-${{ env.OPENCV_VER }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}
           path: |
             ./_build
             ./c_src/headers.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   - `Evision.Mat.total/{1,2,3}`.
 
 - Added OpenCV types:
+  - `Evision.cv_cn_shift/0`.
+  - `Evision.cv_depth_max/0`.
+  - `Evision.cv_mat_depth_mask/0`.
+  - `Evision.cv_maketype/2`.
   - `Evision.cv_8U/0`.
   - `Evision.cv_8UC/1`.
   - `Evision.cv_8UC1/0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 - Always use `Evision.Mat.from_binary_by_shape/3` for `Evision.Nx.to_mat`.
 - Check `cv::Mat::Mat.type()` when fetching the shape of a Mat.
   The number of channels will be included as the last dim of the shape if and only if `cv::Mat::Mat.type()` did not encode any channel information.
+- Added `Evision.Mat.last_dim_as_channel/1`.
+
+  This method convert a tensor-like `Mat` to a "valid 2D image" with its `channels` equals to `3` or `1`.
+
+- Added `Evision.Nx.to_mat/2`.
+
+  This method convert a `Nx.Tensor` to a `Mat`. The second argument indicates the wanted/actual shape of the tensor.
+
+- Added more Mat functions:
+  - `Evision.Mat.as_shape/2`.
+  - `Evision.Mat.size/1`.
+  - `Evision.Mat.channels/1`.
+  - `Evision.Mat.depth/1`.
+  - `Evision.Mat.raw_type/1`.
+  - `Evision.Mat.isSubmatrix/1`.
+  - `Evision.Mat.isContinuous/1`.
+  - `Evision.Mat.elemSize/1`.
+  - `Evision.Mat.elemSize1/1`.
+  - `Evision.Mat.total/{1,2,3}`.
 
 ## v0.1.4 (2022-09-10)
 - Default to `Evision.Backend` for `Evision.Nx.to_nx/2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v0.1.5-dev
-- Fix `Evision.Mat.transpose`: should call `shape!` instead of `shape`. Thanks to @kipcole9 ! #77
+- Fixed `Evision.Mat.transpose`: should call `shape!` instead of `shape`. Thanks to @kipcole9 ! #77
 - Always use `Evision.Mat.from_binary_by_shape/3` for `Evision.Nx.to_mat`.
 - Check `cv::Mat::Mat.type()` when fetching the shape of a Mat.
   The number of channels will be included as the last dim of the shape if and only if `cv::Mat::Mat.type()` did not encode any channel information.
@@ -27,15 +27,15 @@
 
 ## v0.1.4 (2022-09-10)
 - Default to `Evision.Backend` for `Evision.Nx.to_nx/2`.
-- Fix class inheritance issue in `py_src/class_info.py`.
-- Fix missing comma in example livebooks' `Mix.install`. @dbii
-- Add decision tree and random forest example.
+- Fixed class inheritance issue in `py_src/class_info.py`.
+- Fixed missing comma in example livebooks' `Mix.install`. @dbii
+- Added decision tree and random forest example.
 
 ## v0.1.3 (2022-09-01)
-- Fix issues in restoring files from precompiled package for macOS and Linux.
+- Fixed issues in restoring files from precompiled package for macOS and Linux.
   - Paths are now quoted. 
   - using `cp -RPf` on macOS while `cp -a` on Linux.
-- Fix `destroyAllWindows` in NIF.
+- Fixed `destroyAllWindows` in NIF.
   It was generated as 'erlang:destroyAllWindows/1' but it should be 'erlang:destroyAllWindows/0'.
 
 ## v0.1.2 (2022-08-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,56 @@
   - `Evision.Mat.elemSize1/1`.
   - `Evision.Mat.total/{1,2,3}`.
 
+- Added OpenCV types:
+  - `Evision.cv_8U/0`.
+  - `Evision.cv_8UC/1`.
+  - `Evision.cv_8UC1/0`.
+  - `Evision.cv_8UC2/0`.
+  - `Evision.cv_8UC3/0`.
+  - `Evision.cv_8UC4/0`.
+  - `Evision.cv_8S/0`.
+  - `Evision.cv_8SC/1`.
+  - `Evision.cv_8SC1/0`.
+  - `Evision.cv_8SC2/0`.
+  - `Evision.cv_8SC3/0`.
+  - `Evision.cv_8SC4/0`.
+  - `Evision.cv_16U/0`.
+  - `Evision.cv_16UC/1`.
+  - `Evision.cv_16UC1/0`.
+  - `Evision.cv_16UC2/0`.
+  - `Evision.cv_16UC3/0`.
+  - `Evision.cv_16UC4/0`.
+  - `Evision.cv_16S/0`.
+  - `Evision.cv_16SC/1`.
+  - `Evision.cv_16SC1/0`.
+  - `Evision.cv_16SC2/0`.
+  - `Evision.cv_16SC3/0`.
+  - `Evision.cv_16SC4/0`.
+  - `Evision.cv_32S/0`.
+  - `Evision.cv_32SC/1`.
+  - `Evision.cv_32SC1/0`.
+  - `Evision.cv_32SC2/0`.
+  - `Evision.cv_32SC3/0`.
+  - `Evision.cv_32SC4/0`.
+  - `Evision.cv_32F/0`.
+  - `Evision.cv_32FC/1`.
+  - `Evision.cv_32FC1/0`.
+  - `Evision.cv_32FC2/0`.
+  - `Evision.cv_32FC3/0`.
+  - `Evision.cv_32FC4/0`.
+  - `Evision.cv_64F/0`.
+  - `Evision.cv_64FC/1`.
+  - `Evision.cv_64FC1/0`.
+  - `Evision.cv_64FC2/0`.
+  - `Evision.cv_64FC3/0`.
+  - `Evision.cv_64FC4/0`.
+  - `Evision.cv_16F/0`.
+  - `Evision.cv_16FC/1`.
+  - `Evision.cv_16FC1/0`.
+  - `Evision.cv_16FC2/0`.
+  - `Evision.cv_16FC3/0`.
+  - `Evision.cv_16FC4/0`.
+
 ## v0.1.4 (2022-09-10)
 - Default to `Evision.Backend` for `Evision.Nx.to_nx/2`.
 - Fixed class inheritance issue in `py_src/class_info.py`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,6 @@ else()
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
         endif()
 
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -g3 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-declarations -Wno-unused-but-set-variable")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-declarations -Wno-unused-but-set-variable")
     endif()
 endif()

--- a/c_src/modules/evision_mat.h
+++ b/c_src/modules/evision_mat.h
@@ -516,17 +516,17 @@ static ERL_NIF_TERM evision_cv_mat_total(ErlNifEnv *env, int argc, const ERL_NIF
 
     {
         Mat img;
-        int start = -1;
-        int end = INT_MAX;
+        int start_dim = -1;
+        int end_dim = INT_MAX;
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "start"), start, ArgInfo("start", 0));
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "end"), end, ArgInfo("end", 0));
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "start_dim"), start_dim, ArgInfo("start_dim", 0));
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "end_dim"), end_dim, ArgInfo("end_dim", 0));
             size_t total_elems;
-            if (start == -1) {
+            if (start_dim == -1) {
                 total_elems = img.total();
             } else {
-                total_elems = img.total(start, end);
+                total_elems = img.total(start_dim, end_dim);
             }
             
             return enif_make_int64(env, total_elems);

--- a/c_src/modules/evision_mat.h
+++ b/c_src/modules/evision_mat.h
@@ -409,6 +409,266 @@ static ERL_NIF_TERM evision_cv_mat_dot(ErlNifEnv *env, int argc, const ERL_NIF_T
     else return evision::nif::error(env, "overload resolution failed");
 }
 
+// @evision c: mat_channels, evision_cv_mat_channels, 1
+// @evision nif: def mat_channels(_opts \\ []), do: :erlang.nif_error("Mat::channels not loaded")
+static ERL_NIF_TERM evision_cv_mat_channels(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            int channels = img.channels();
+            return enif_make_int64(env, channels);
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_depth, evision_cv_mat_depth, 1
+// @evision nif: def mat_depth(_opts \\ []), do: :erlang.nif_error("Mat::depth not loaded")
+static ERL_NIF_TERM evision_cv_mat_depth(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            int depth = img.depth();
+            return enif_make_int64(env, depth);
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_isSubmatrix, evision_cv_mat_isSubmatrix, 1
+// @evision nif: def mat_isSubmatrix(_opts \\ []), do: :erlang.nif_error("Mat::isSubmatrix not loaded")
+static ERL_NIF_TERM evision_cv_mat_isSubmatrix(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            bool isSubmatrix = img.isSubmatrix();
+            if (isSubmatrix) {
+                return evision::nif::atom(env, "true");
+            } else {
+                return evision::nif::atom(env, "false");
+            }
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_isContinuous, evision_cv_mat_isContinuous, 1
+// @evision nif: def mat_isContinuous(_opts \\ []), do: :erlang.nif_error("Mat::isContinuous not loaded")
+static ERL_NIF_TERM evision_cv_mat_isContinuous(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            bool isContinuous = img.isContinuous();
+            if (isContinuous) {
+                return evision::nif::atom(env, "true");
+            } else {
+                return evision::nif::atom(env, "false");
+            }
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_total, evision_cv_mat_total, 1
+// @evision nif: def mat_total(_opts \\ []), do: :erlang.nif_error("Mat::total not loaded")
+static ERL_NIF_TERM evision_cv_mat_total(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+        int start = -1;
+        int end = INT_MAX;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "start"), start, ArgInfo("start", 0));
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "end"), end, ArgInfo("end", 0));
+            size_t total_elems;
+            if (start == -1) {
+                total_elems = img.total();
+            } else {
+                total_elems = img.total(start, end);
+            }
+            
+            return enif_make_int64(env, total_elems);
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_elemSize, evision_cv_mat_elemSize, 1
+// @evision nif: def mat_elemSize(_opts \\ []), do: :erlang.nif_error("Mat::elemSize not loaded")
+static ERL_NIF_TERM evision_cv_mat_elemSize(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            return enif_make_int64(env, img.elemSize());
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_elemSize1, evision_cv_mat_elemSize1, 1
+// @evision nif: def mat_elemSize1(_opts \\ []), do: :erlang.nif_error("Mat::elemSize1 not loaded")
+static ERL_NIF_TERM evision_cv_mat_elemSize1(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            return enif_make_int64(env, img.elemSize1());
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_raw_type, evision_cv_mat_raw_type, 1
+// @evision nif: def mat_raw_type(_opts \\ []), do: :erlang.nif_error("Mat::raw_type not loaded")
+static ERL_NIF_TERM evision_cv_mat_raw_type(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            return enif_make_int64(env, img.type());
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_dims, evision_cv_mat_dims, 1
+// @evision nif: def mat_dims(_opts \\ []), do: :erlang.nif_error("Mat::dims not loaded")
+static ERL_NIF_TERM evision_cv_mat_dims(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            return enif_make_int64(env, img.dims);
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_size, evision_cv_mat_size, 1
+// @evision nif: def mat_size(_opts \\ []), do: :erlang.nif_error("Mat::size not loaded")
+static ERL_NIF_TERM evision_cv_mat_size(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
+            ERL_NIF_TERM p;
+            evision::nif::make_i32_list_from_c_array(env, img.size.dims(), img.size.p, p);
+            ERL_NIF_TERM dims = enif_make_int64(env, img.size.dims());
+            return enif_make_tuple2(env, dims, p);
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
+// @evision c: mat_as_shape, evision_cv_mat_as_shape, 1
+// @evision nif: def mat_as_shape(_opts \\ []), do: :erlang.nif_error("Mat::as_shape not loaded")
+static ERL_NIF_TERM evision_cv_mat_as_shape(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    ERL_NIF_TERM error_term = 0;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat img;
+        std::vector<int> as_shape;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "as_shape"), as_shape, ArgInfo("as_shape", 0))) {
+            Mat ret = Mat((int)as_shape.size(), as_shape.data(), img.depth(), img.data);
+            return evision::nif::ok(env, evision_from(env, ret.clone()));
+        }
+    }
+
+    if (error_term != 0) return error_term;
+    else return evision::nif::error(env, "overload resolution failed");
+}
+
 // @evision c: mat_last_dim_as_channel, evision_cv_mat_last_dim_as_channel, 1
 // @evision nif: def mat_last_dim_as_channel(_opts \\ []), do: :erlang.nif_error("Mat::last_dim_as_channel not loaded")
 static ERL_NIF_TERM evision_cv_mat_last_dim_as_channel(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {

--- a/c_src/nif_utils.hpp
+++ b/c_src/nif_utils.hpp
@@ -133,6 +133,101 @@ namespace evision
       return enif_make_string(env, string, ERL_NIF_LATIN1);
     }
 
+    template<typename T>
+    int make_f64_list_from_c_array(ErlNifEnv *env, size_t count, T *data, ERL_NIF_TERM &out) {
+      if (count == 0) {
+        out = enif_make_list_from_array(env, nullptr, 0);
+        return 0;
+      }
+
+      ERL_NIF_TERM *terms = (ERL_NIF_TERM *)enif_alloc(sizeof(ERL_NIF_TERM) * count);
+      if (terms == nullptr) {
+        return 1;
+      }
+      for (size_t i = 0; i < count; ++i) {
+        terms[i] = enif_make_double(env, (double)(data[i]));
+      }
+      out = enif_make_list_from_array(env, terms, (unsigned) count);
+      enif_free(terms);
+      return 0;
+    }
+
+    template<typename T>
+    int make_i64_list_from_c_array(ErlNifEnv *env, size_t count, T *data, ERL_NIF_TERM &out) {
+      if (count == 0) {
+        out = enif_make_list_from_array(env, nullptr, 0);
+        return 0;
+      }
+
+      ERL_NIF_TERM *terms = (ERL_NIF_TERM *)enif_alloc(sizeof(ERL_NIF_TERM) * count);
+      if (terms == nullptr) {
+        return 1;
+      }
+      for (size_t i = 0; i < count; ++i) {
+        terms[i] = enif_make_int64(env, (int64_t)(data[i]));
+      }
+      out = enif_make_list_from_array(env, terms, (unsigned) count);
+      enif_free(terms);
+      return 0;
+    }
+
+    template<typename T>
+    int make_u64_list_from_c_array(ErlNifEnv *env, size_t count, T *data, ERL_NIF_TERM &out) {
+      if (count == 0) {
+        out = enif_make_list_from_array(env, nullptr, 0);
+        return 0;
+      }
+
+      ERL_NIF_TERM *terms = (ERL_NIF_TERM *)enif_alloc(sizeof(ERL_NIF_TERM) * count);
+      if (terms == nullptr) {
+        return 1;
+      }
+      for (size_t i = 0; i < count; ++i) {
+        terms[i] = enif_make_uint64(env, (uint64_t)(data[i]));
+      }
+      out = enif_make_list_from_array(env, terms, (unsigned) count);
+      enif_free(terms);
+      return 0;
+    }
+
+    template<typename T>
+    int make_i32_list_from_c_array(ErlNifEnv *env, size_t count, T *data, ERL_NIF_TERM &out) {
+      if (count == 0) {
+        out = enif_make_list_from_array(env, nullptr, 0);
+        return 0;
+      }
+
+      ERL_NIF_TERM *terms = (ERL_NIF_TERM *)enif_alloc(sizeof(ERL_NIF_TERM) * count);
+      if (terms == nullptr) {
+          return 1;
+      }
+      for (size_t i = 0; i < count; ++i) {
+        terms[i] = enif_make_int(env, (int32_t)(data[i]));
+      }
+      out = enif_make_list_from_array(env, terms, (unsigned) count);
+      enif_free(terms);
+      return 0;
+    }
+
+    template<typename T>
+    int make_u32_list_from_c_array(ErlNifEnv *env, size_t count, T *data, ERL_NIF_TERM &out) {
+      if (count == 0) {
+        out = enif_make_list_from_array(env, nullptr, 0);
+        return 0;
+      }
+
+      ERL_NIF_TERM *terms = (ERL_NIF_TERM *)enif_alloc(sizeof(ERL_NIF_TERM) * count);
+      if (terms == nullptr) {
+        return 1;
+      }
+      for (size_t i = 0; i < count; ++i) {
+        terms[i] = enif_make_uint(env, (uint32_t)(data[i]));
+      }
+      out = enif_make_list_from_array(env, terms, (unsigned) count);
+      enif_free(terms);
+      return 0;
+    }
+
     // Atoms
 
     int get_atom(ErlNifEnv *env, ERL_NIF_TERM term, std::string &var)

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -496,6 +496,11 @@ defmodule Evision.Mat do
   deferror(total(mat, start_dim, end_dim))
 
   @doc namespace: :"cv.Mat"
+  @doc """
+  This function would convert the input tensor with dims `[height, width, dims]` to a `dims`-channel image with dims `[height, width]`.
+
+  Note that OpenCV has limitation on the number of channels. Currently the maximum number of channels is `512`.
+  """
   def last_dim_as_channel(mat) when is_reference(mat) do
     :evision_nif.mat_last_dim_as_channel(src: mat)
   end

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -477,7 +477,7 @@ defmodule Evision.Mat do
   The method returns the number of array elements (a number of pixels if the array represents an image).
   """
   def total(mat) when is_reference(mat) do
-    :evision_nif.mat_total(img: mat, start: -1, end: 0xFFFFFFFF)
+    :evision_nif.mat_total(img: mat, start_dim: -1, end_dim: 0xFFFFFFFF)
   end
 
   deferror(total(mat))
@@ -489,7 +489,7 @@ defmodule Evision.Mat do
   The method returns the number of elements within a certain sub-array slice with start_dim <= dim < end_dim
   """
   def total(mat, start_dim, end_dim \\ 0xFFFFFFFF) when is_reference(mat) do
-    :evision_nif.mat_total(img: mat, start: start_dim, end: end_dim)
+    :evision_nif.mat_total(img: mat, start_dim: start_dim, end_dim: end_dim)
   end
 
   deferror(total(mat, start_dim))

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -275,6 +275,10 @@ defmodule Evision.Mat do
   deferror(transpose(mat))
 
   @doc namespace: :"cv.Mat"
+  @doc """
+  This method returns the type-tuple used by Nx. To get the raw value of `cv::Mat.type()`, please use
+  `Evision.Mat.raw_type/1`.
+  """
   @spec type(reference()) :: {:ok, mat_type()} | {:error, String.t()}
   def type(mat) when is_reference(mat) do
     :evision_nif.mat_type(img: mat)
@@ -367,6 +371,129 @@ defmodule Evision.Mat do
   end
 
   deferror(shape(mat))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  The method returns the number of matrix channels.
+  """
+  def channels(mat) when is_reference(mat) do
+    :evision_nif.mat_channels(img: mat)
+  end
+
+  deferror(channels(mat))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  Returns the depth of a matrix element.
+
+  The method returns the identifier of the matrix element depth (the type of each individual channel).
+  For example, for a 16-bit signed element array, the method returns CV_16S. A complete list of
+  matrix types contains the following values:
+
+    -   CV_8U - 8-bit unsigned integers ( 0..255 )
+    -   CV_8S - 8-bit signed integers ( -128..127 )
+    -   CV_16U - 16-bit unsigned integers ( 0..65535 )
+    -   CV_16S - 16-bit signed integers ( -32768..32767 )
+    -   CV_32S - 32-bit signed integers ( -2147483648..2147483647 )
+    -   CV_32F - 32-bit floating-point numbers ( -FLT_MAX..FLT_MAX, INF, NAN )
+    -   CV_64F - 64-bit floating-point numbers ( -DBL_MAX..DBL_MAX, INF, NAN )
+
+  """
+  def depth(mat) when is_reference(mat) do
+    :evision_nif.mat_depth(img: mat)
+  end
+
+  deferror(depth(mat))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  Returns the type of a matrix.
+
+  As `Evision.Mat.type/1` returns the type used by Nx, this method gives the raw value of
+  `cv::Mat.type()`
+  """
+  def raw_type(mat) when is_reference(mat) do
+    :evision_nif.mat_raw_type(img: mat)
+  end
+
+  deferror(raw_type(mat))
+
+  @doc namespace: :"cv.Mat"
+  def isSubmatrix(mat) when is_reference(mat) do
+    :evision_nif.mat_isSubmatrix(img: mat)
+  end
+
+  deferror(isSubmatrix(mat))
+
+  @doc namespace: :"cv.Mat"
+  def isContinuous(mat) when is_reference(mat) do
+    :evision_nif.mat_isContinuous(img: mat)
+  end
+
+  deferror(isContinuous(mat))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  Returns the matrix element size in bytes.
+
+  The method returns the matrix element size in bytes. For example, if the matrix type is CV_16SC3,
+  the method returns 3\*sizeof(short) or 6.
+  """
+  def elemSize(mat) when is_reference(mat) do
+    :evision_nif.mat_elemSize(img: mat)
+  end
+
+  deferror(elemSize(mat))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  Returns the size of each matrix element channel in bytes.
+
+  The method returns the matrix element channel size in bytes, that is, it ignores the number of
+  channels. For example, if the matrix type is CV_16SC3 , the method returns sizeof(short) or 2.
+  """
+  def elemSize1(mat) when is_reference(mat) do
+    :evision_nif.mat_elemSize1(img: mat)
+  end
+
+  deferror(elemSize1(mat))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  Returns the `cv::MatSize` of the matrix.
+
+  The method returns a tuple `{dims, p}` where `dims` is the number of dimensions, and `p` is a list with `dims` elements.
+  """
+  def size(mat) when is_reference(mat) do
+    :evision_nif.mat_size(img: mat)
+  end
+
+  deferror(size(mat))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  Returns the total number of array elements.
+
+  The method returns the number of array elements (a number of pixels if the array represents an image).
+  """
+  def total(mat) when is_reference(mat) do
+    :evision_nif.mat_total(img: mat, start: -1, end: 0xFFFFFFFF)
+  end
+
+  deferror(total(mat))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  Returns the total number of array elements.
+
+  The method returns the number of elements within a certain sub-array slice with start_dim <= dim < end_dim
+  """
+  def total(mat, start_dim, end_dim \\ 0xFFFFFFFF) when is_reference(mat) do
+    :evision_nif.mat_total(img: mat, start: start_dim, end: end_dim)
+  end
+
+  deferror(total(mat, start_dim))
+  deferror(total(mat, start_dim, end_dim))
 
   @doc namespace: :"cv.Mat"
   def last_dim_as_channel(mat) when is_reference(mat) do
@@ -633,6 +760,33 @@ defmodule Evision.Mat do
   end
 
   deferror(reshape(mat, shape))
+
+  @doc namespace: :"cv.Mat"
+  @doc """
+  This method does not change the underlying data. It only changes the steps when accessing the matrix.
+
+  If intended to change the underlying data to the new shape, please use `Evision.Mat.reshape/2`.
+  """
+  def as_shape(mat, as_shape) when is_reference(mat) and is_tuple(as_shape) do
+    as_shape(mat, Tuple.to_list(as_shape))
+  end
+
+  def as_shape(mat, as_shape) when is_reference(mat) and is_list(as_shape) do
+    with {:ok, old_shape} <- Evision.Mat.shape(mat) do
+      if Tuple.product(old_shape) == Enum.product(as_shape) do
+        :evision_nif.mat_as_shape(
+          img: mat,
+          as_shape: as_shape
+        )
+      else
+        {:error, "Cannot treat mat with shape #{inspect(old_shape)} as the requested new shape #{inspect(as_shape)}: mismatching number of elements"}
+      end
+    else
+      error -> error
+    end
+  end
+
+  deferror(as_shape(mat, as_shape))
 
   def squeeze(mat) when is_reference(mat) do
     shape = Tuple.to_list(Evision.Mat.shape!(mat))

--- a/py_src/evision_templates.py
+++ b/py_src/evision_templates.py
@@ -4,6 +4,178 @@
 from string import Template
 
 
+# CV_* type macros
+gen_cv_types_erlang = """
+cv_8U() -> 0.
+cv_8S() -> 1.
+cv_16U() -> 2.
+cv_16S() -> 3.
+cv_32S() -> 4.
+cv_32F() -> 5.
+cv_64F() -> 6.
+cv_16F() -> 7.
+
+cv_cn_shift() -> 3.
+cv_depth_max() ->
+    1 bsl cv_cn_shift().
+cv_mat_depth_mask() ->
+    cv_depth_max() - 1.
+cv_maketype(Depth, Cn) ->
+    (Depth band cv_mat_depth_mask()) + ((Cn-1) bsl cv_cn_shift()).
+
+cv_8UC(Cn) ->
+    cv_maketype(cv_8U(), Cn).
+cv_8UC1() ->
+    cv_8UC(1).
+cv_8UC2() ->
+    cv_8UC(2).
+cv_8UC3() ->
+    cv_8UC(3).
+cv_8UC4() ->
+    cv_8UC(4).
+
+cv_8SC(Cn) ->
+    cv_maketype(cv_8S(), Cn).
+cv_8SC1() ->
+    cv_8SC(1).
+cv_8SC2() ->
+    cv_8SC(2).
+cv_8SC3() ->
+    cv_8SC(3).
+cv_8SC4() ->
+    cv_8SC(4).
+
+cv_16UC(Cn) ->
+    cv_maketype(cv_16U(), Cn).
+cv_16SU1() ->
+    cv_16UC(1).
+cv_16UC2() ->
+    cv_16UC(2).
+cv_16UC3() ->
+    cv_16UC(3).
+cv_16UC4() ->
+    cv_16UC(4).
+
+cv_16SC(Cn) ->
+    cv_maketype(cv_16S(), Cn).
+cv_16SC1() ->
+    cv_16SC(1).
+cv_16SC2() ->
+    cv_16SC(2).
+cv_16SC3() ->
+    cv_16SC(3).
+cv_16SC4() ->
+    cv_16SC(4).
+
+cv_32SC(Cn) ->
+    cv_maketype(cv_32S(), Cn).
+cv_32SC1() ->
+    cv_32SC(1).
+cv_32SC2() ->
+    cv_32SC(2).
+cv_32SC3() ->
+    cv_32SC(3).
+cv_32SC4() ->
+    cv_32SC(4).
+
+cv_32FC(Cn) ->
+    cv_maketype(cv_32F(), Cn).
+cv_32FC1() ->
+    cv_32FC(1).
+cv_32FC2() ->
+    cv_32FC(2).
+cv_32FC3() ->
+    cv_32FC(3).
+cv_32FC4() ->
+    cv_32FC(4).
+
+cv_64FC(Cn) ->
+    cv_maketype(cv_64F(), Cn).
+cv_64FC1() ->
+    cv_64FC(1).
+cv_64FC2() ->
+    cv_64FC(2).
+cv_64FC3() ->
+    cv_64FC(3).
+cv_64FC4() ->
+    cv_64FC(4).
+
+cv_16FC(Cn) ->
+    cv_maketype(cv_16F(), Cn).
+cv_16FC1() ->
+    cv_16FC(1).
+cv_16FC2() ->
+    cv_16FC(2).
+cv_16FC3() ->
+    cv_16FC(3).
+cv_16FC4() ->
+    cv_16FC(4).
+"""
+
+gen_cv_types_elixir = """
+  def cv_8U, do: 0
+  def cv_8S, do: 1
+  def cv_16U, do: 2
+  def cv_16S, do: 3
+  def cv_32S, do: 4
+  def cv_32F, do: 5
+  def cv_64F, do: 6
+  def cv_16F, do: 7
+
+  def cv_cn_shift, do: 3
+  def cv_depth_max, do: 1 <<< cv_cn_shift()
+  def cv_mat_depth_mask, do: cv_depth_max() - 1
+  def cv_maketype(depth, cn), do: (depth &&& cv_mat_depth_mask()) + ((cn - 1) <<< cv_cn_shift())
+
+  def cv_8UC(cn), do: cv_maketype(cv_8U(), cn)
+  def cv_8UC1, do: cv_8UC(1)
+  def cv_8UC2, do: cv_8UC(2)
+  def cv_8UC3, do: cv_8UC(3)
+  def cv_8UC4, do: cv_8UC(4)
+
+  def cv_8SC(cn), do: cv_maketype(cv_8S(), cn)
+  def cv_8SC1, do: cv_8SC(1)
+  def cv_8SC2, do: cv_8SC(2)
+  def cv_8SC3, do: cv_8SC(3)
+  def cv_8SC4, do: cv_8SC(4)
+
+  def cv_16UC(cn), do: cv_maketype(cv_16U(), cn)
+  def cv_16UC1, do: cv_16UC(1)
+  def cv_16UC2, do: cv_16UC(2)
+  def cv_16UC3, do: cv_16UC(3)
+  def cv_16UC4, do: cv_16UC(4)
+
+  def cv_16SC(cn), do: cv_maketype(cv_16S(), cn)
+  def cv_16SC1, do: cv_16SC(1)
+  def cv_16SC2, do: cv_16SC(2)
+  def cv_16SC3, do: cv_16SC(3)
+  def cv_16SC4, do: cv_16SC(4)
+
+  def cv_32SC(cn), do: cv_maketype(cv_32S(), cn)
+  def cv_32SC1, do: cv_32SC(1)
+  def cv_32SC2, do: cv_32SC(2)
+  def cv_32SC3, do: cv_32SC(3)
+  def cv_32SC4, do: cv_32SC(4)
+
+  def cv_32FC(cn), do: cv_maketype(cv_32F(), cn)
+  def cv_32FC1, do: cv_32FC(1)
+  def cv_32FC2, do: cv_32FC(2)
+  def cv_32FC3, do: cv_32FC(3)
+  def cv_32FC4, do: cv_32FC(4)
+
+  def cv_64FC(cn), do: cv_maketype(cv_64F(), cn)
+  def cv_64FC1, do: cv_64FC(1)
+  def cv_64FC2, do: cv_64FC(2)
+  def cv_64FC3, do: cv_64FC(3)
+  def cv_64FC4, do: cv_64FC(4)
+
+  def cv_16FC(cn), do: cv_maketype(cv_16F(), cn)
+  def cv_16FC1, do: cv_16FC(1)
+  def cv_16FC2, do: cv_16FC(2)
+  def cv_16FC3, do: cv_16FC(3)
+  def cv_16FC4, do: cv_16FC(4)
+"""
+
 # template for Elixir NIF
 gen_evision_nif_load_nif = """
   @moduledoc false

--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -983,9 +983,10 @@ class BeamWrapperGenerator(object):
         self.evision_elixir.write('  use Bitwise\n')
         self.evision_elixir.write('  import Kernel, except: [apply: 2, apply: 3, min: 2, max: 2]\n')
         self.evision_elixir.write('  import Evision.Errorize\n')
+        self.evision_elixir.write(ET.gen_cv_types_elixir)
         self.evision_elixir.deferror = {}
 
-        self.evision_nif_erlang.write('-module(evision_nif).\n-compile(nowarn_export_all).\n-compile([export_all]).\n\n{}\n'.format(ET.gen_evision_nif_load_nif_erlang))
+        self.evision_nif_erlang.write('-module(evision_nif).\n-compile(nowarn_export_all).\n-compile([export_all]).\n\n{}\n{}\n'.format(ET.gen_evision_nif_load_nif_erlang, ET.gen_cv_types_erlang))
         self.evision_erlang.write('-module(evision).\n-compile(nowarn_export_all).\n-compile([export_all]).\n\n')
 
         self.code_ns_reg.write('static ErlNifFunc nif_functions[] = {\n')

--- a/src/evision_mat.erl
+++ b/src/evision_mat.erl
@@ -2,14 +2,213 @@
 -compile(nowarn_export_all).
 -compile([export_all]).
 
+full(Shape, Number, {T, L}) when is_tuple(Shape) ->
+    ToShape = [element(I, Shape) || I <- lists:seq(1, tuple_size(Shape))],
+    evision_nif:mat_full([{number, Number}, {t, T}, {l, L}, {shape, ToShape}]).
+
+number(Number, Type) ->
+    full({1, 1}, Number, Type).
+
+at(Mat, Position) when is_reference(Mat), Position >= 0 ->
+    evision_nif:mat_at([{img, Mat}, {pos, Position}]).
+
+add(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_add([{l, Lhs}, {r, Rhs}]).
+
+add(Lhs, Rhs, {T, L}) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_add_typed([{l, Lhs}, {r, Rhs}, {t, T}, {l, L}]).
+
+subtract(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_subtract([{l, Lhs}, {r, Rhs}]).
+
+subtract(Lhs, Rhs, {T, L}) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_subtract_typed([{l, Lhs}, {r, Rhs}, {t, T}, {l, L}]).
+
+multiply(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_multiply([{l, Lhs}, {r, Rhs}]).
+
+multiply(Lhs, Rhs, {T, L}) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_multiply_typed([{l, Lhs}, {r, Rhs}, {t, T}, {l, L}]).
+
+matrix_multiply(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_matrix_multiply([{l, Lhs}, {r, Rhs}, {t, nil}, {l, 0}]).
+
+matrix_multiply(Lhs, Rhs, {T, L}) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_matrix_multiply([{l, Lhs}, {r, Rhs}, {t, T}, {l, L}]).
+
+divide(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_divide([{l, Lhs}, {r, Rhs}]).
+
+divide(Lhs, Rhs, {T, L}) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_divide_typed([{l, Lhs}, {r, Rhs}, {t, T}, {l, L}]).
+
+bitwise_and(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_bitwise_and([{l, Lhs}, {r, Rhs}]).
+
+bitwise_or(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_bitwise_or([{l, Lhs}, {r, Rhs}]).
+
+bitwise_xor(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_bitwise_xor([{l, Lhs}, {r, Rhs}]).
+
+cmp(Lhs, Rhs, Op) when is_reference(Lhs), is_reference(Rhs) ->
+    case lists:member(Op, [eq, gt, ge, lt, le, ne]) of
+        true ->
+            evision_nif:mat_cmp([{l, Lhs}, {r, Rhs}, {type, Op}]);
+        false ->
+            {error, "Unknown cmp opeator"}
+    end.
+
+logical_and(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_logical_and([{l, Lhs}, {r, Rhs}]).
+
+logical_or(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_logical_or([{l, Lhs}, {r, Rhs}]).
+
+logical_xor(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_logical_xor([{l, Lhs}, {r, Rhs}]).
+
+abs(Mat) when is_reference(Mat) ->
+    evision_nif:mat_abs([{img, Mat}]).
+
+expm1(Mat) when is_reference(Mat) ->
+    evision_nif:mat_expm1([{img, Mat}]).
+
+clip(Mat, Lower, Upper) when is_reference(Mat) ->
+    evision_nif:mat_clip([{img, Mat}, {lower, Lower}, {upper, Upper}]).
+
+transpose(Mat, Axes, AsShape) when is_reference(Mat) ->
+    TheShape = case is_tuple(AsShape) of
+        true ->
+            [element(I, AsShape) || I <- lists:seq(1, tuple_size(AsShape))];
+        false ->
+            AsShape
+    end,
+    Ndims = length(TheShape),
+    UniqAxes = lists:filter(fun(Elem) -> Elem < (Ndims + 1) end, lists:filter(fun(Elem) -> 0 < Elem end, lists:uniq(Axes))),
+    case length(UniqAxes) == Ndims of
+        true ->
+            evision_nif:mat_transpose([{img, Mat}, {axes, UniqAxes}, {as_shape, TheShape}]);
+        false ->
+            {error, "invalid transpose parameters"}
+    end.
+
+transpose(Mat, Axes) when is_reference(Mat) ->
+    {ok, Shape} = shape(Mat),
+    transpose(Mat, Axes, Shape).
+
+transpose(Mat) when is_reference(Mat) ->
+    {ok, Shape} = shape(Mat),
+    Ndims = tuple_size(Shape),
+    UniqAxes = lists:reverse(lists:seq(0, Ndims - 1)),
+    transpose(Mat, UniqAxes, Shape).
+
 type(Mat) when is_reference(Mat) ->
     evision_nif:mat_type([{img, Mat}]).
+
+bitwise_not(Mat) when is_reference(Mat) ->
+    {ok, {S, _}} = type(Mat),
+    case lists:member(S, [s, u]) of
+        true ->
+            evision_nif:bitwise_not([{img, Mat}]);
+        false ->
+            {error, "bitwise operators expect integer tensors as inputs and outputs an integer tensor"}
+    end.
+
+ceil(Mat) when is_reference(Mat) ->
+    evision_nif:mat_ceil([{img, Mat}]).
+
+floor(Mat) when is_reference(Mat) ->
+    evision_nif:mat_floor([{img, Mat}]).
+
+negate(Mat) when is_reference(Mat) ->
+    evision_nif:mat_negate([{img, Mat}]).
+
+round(Mat) when is_reference(Mat) ->
+    evision_nif:mat_round([{img, Mat}]).
+
+sign(Mat) when is_reference(Mat) ->
+    evision_nif:mat_sign([{img, Mat}]).
+
+setTo(Mat, Value, Mask) when is_reference(Mat), is_reference(Mask) ->
+    evision_nif:mat_set_to([{img, Mat}, {value, Value}, {mask, Mask}]).
+
+dot(Lhs, Rhs) when is_reference(Lhs), is_reference(Rhs) ->
+    evision_nif:mat_dot([{a, Lhs}, {b, Rhs}]).
 
 as_type(Mat, {T, L}) when is_reference(Mat), is_atom(T), L > 0 ->
     evision_nif:mat_as_type([{img, Mat}, {t, T}, {l, L}]).
 
 shape(Mat) when is_reference(Mat) ->
     evision_nif:mat_shape([{img, Mat}]).
+
+channels(Mat) when is_reference(Mat) ->
+    evision_nif:mat_channels([{img, Mat}]).
+
+depth(Mat) when is_reference(Mat) ->
+    evision_nif:mat_depth([{img, Mat}]).
+
+raw_type(Mat) when is_reference(Mat) ->
+    evision_nif:mat_raw_type([{img, Mat}]).
+
+isSubmatrix(Mat) when is_reference(Mat) ->
+    evision_nif:mat_isSubmatrix([{img, Mat}]).
+
+isContinuous(Mat) when is_reference(Mat) ->
+    evision_nif:mat_isContinuous([{img, Mat}]).
+
+elemSize(Mat) when is_reference(Mat) ->
+    evision_nif:mat_elemSize([{img, Mat}]).
+
+elemSize1(Mat) when is_reference(Mat) ->
+    evision_nif:mat_elemSize1([{img, Mat}]).
+
+size(Mat) when is_reference(Mat) ->
+    evision_nif:mat_size([{img, Mat}]).
+
+total(Mat) when is_reference(Mat) ->
+    evision_nif:mat_total([{img, Mat}, {start_dim, -1}, {end_dim, 4294967295}]).
+
+total(Mat, StartDim) when is_reference(Mat) ->
+    evision_nif:mat_total([{img, Mat}, {start_dim, StartDim}, {end_dim, 4294967295}]).
+
+total(Mat, StartDim, EndDim) when is_reference(Mat) ->
+    evision_nif:mat_total([{img, Mat}, {start_dim, StartDim}, {end_dim, EndDim}]).
+
+last_dim_as_channel(Mat) when is_reference(Mat) ->
+    evision_nif:mat_last_dim_as_channel([{src, Mat}]).
+
+zeros(Shape, {T, L}) when is_tuple(Shape) ->
+    MatShape = [element(I, Shape) || I <- lists:seq(1, tuple_size(Shape))],
+    evision_nif:mat_zeros([{shape, MatShape}, {t, T}, {l, L}]).
+
+ones(Shape, {T, L}) when is_tuple(Shape) ->
+    MatShape = [element(I, Shape) || I <- lists:seq(1, tuple_size(Shape))],
+    evision_nif:mat_ones([{shape, MatShape}, {t, T}, {l, L}]).
+
+reshape(Mat, Shape) when is_tuple(Shape) ->
+    MatShape = [element(I, Shape) || I <- lists:seq(1, tuple_size(Shape))],
+    evision_nif:mat_reshape([{mat, Mat}, {shape, MatShape}]);
+reshape(Mat, Shape) when is_list(Shape) ->
+    evision_nif:mat_reshape([{mat, Mat}, {shape, Shape}]).
+
+arange(From, To, Step, {T, L}) ->
+    {ok, Mat} = evision_nif:mat_arange([{from, From}, {to, To}, {step, Step}, {t, T}, {l, L}]),
+    {ok, {Length, _}} = shape(Mat),
+    reshape(Mat, {1, Length}).
+
+arange(From, To, Step, {T, L}, Shape) ->
+    {ok, Mat} = evision_nif:mat_arange([{from, From}, {to, To}, {step, Step}, {t, T}, {l, L}]),
+    reshape(Mat, Shape).
+
+to_batched(Mat, BatchSize, Leftover) ->
+    {ok, Shape} = shape(Mat),
+    MatShape = [element(I, Shape) || I <- lists:seq(1, tuple_size(Shape))],
+    evision_nif:mat_to_batched([{img, Mat}, {batch_size, BatchSize}, {as_shape, MatShape}, {leftover, Leftover}]).
+
+to_batched(Mat, BatchSize, AsShape, Leftover) ->
+    MatShape = [element(I, AsShape) || I <- lists:seq(1, tuple_size(AsShape))],
+    evision_nif:mat_to_batched([{img, Mat}, {batch_size, BatchSize}, {as_shape, MatShape}, {leftover, Leftover}]).
 
 clone(Mat) when is_reference(Mat) ->
     evision_nif:mat_clone([{img, Mat}]).
@@ -27,3 +226,34 @@ from_binary_by_shape(Bin, {T, L}, Shape) when is_binary(Bin), is_atom(T), L > 0,
     from_binary_by_shape(Bin, {T, L}, [element(I,Shape) || I <- lists:seq(1,tuple_size(Shape))]);
 from_binary_by_shape(Bin, {T, L}, Shape) when is_binary(Bin), is_atom(T), L > 0, is_list(Shape) ->
     evision_nif:mat_from_binary_by_shape([{b, Bin}, {t, T}, {l, L}, {shape, Shape}]).
+
+eye(N, {T, L}) when N > 0 ->
+    evision_nif:mat_eye([{n, N}, {t, T}, {l, L}]).
+
+as_shape(Mat, AsShape) when is_reference(Mat) ->
+    TheShape = [element(I,AsShape) || I <- lists:seq(1,tuple_size(AsShape))],
+    {ok, MatShape} = shape(Mat),
+    MatShapeList = [element(I,MatShape) || I <- lists:seq(1,tuple_size(MatShape))],
+    OldTotal = lists:foldl(fun(X, Prod) -> X * Prod end, 1, MatShapeList),
+    AsTotal = lists:foldl(fun(X, Prod) -> X * Prod end, 1, TheShape),
+    case OldTotal == AsTotal of
+        true ->
+            evision_nif:mat_as_shape([{img, Mat}, {as_shape, TheShape}]);
+        false ->
+            {error, "Cannot treat mat as the requested new shape: mismatching number of elements"}
+    end.
+
+squeeze(Mat) when is_reference(Mat) ->
+    {ok, MatShape} = shape(Mat),
+    MatShapeList = [element(I,MatShape) || I <- lists:seq(1,tuple_size(MatShape))],
+    MatShapeList1 = lists:filter(fun(Elem) -> Elem == 1 end, MatShapeList),
+    reshape(Mat, MatShapeList1).
+
+broadcast_to(Mat, ToShape) ->
+    ToShapeList = [element(I,ToShape) || I <- lists:seq(1,tuple_size(ToShape))],
+    evision_nif:mat_broadcast_to([{img, Mat}, {to_shape, ToShapeList}, {force_src_shape, []}]).
+
+broadcast_to(Mat, ToShape, ForceSrcShape) ->
+    ToShapeList = [element(I,ToShape) || I <- lists:seq(1,tuple_size(ToShape))],
+    ForceSrcShapeList = [element(I,ForceSrcShape) || I <- lists:seq(1,tuple_size(ForceSrcShape))],
+    evision_nif:mat_broadcast_to([{img, Mat}, {to_shape, ToShapeList}, {force_src_shape, ForceSrcShapeList}]).

--- a/test/opencv_test.exs
+++ b/test/opencv_test.exs
@@ -258,12 +258,12 @@ defmodule Evision.Test do
 
   test "Evision.Mat.depth" do
     img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
-    assert 0 == Evision.Mat.depth(img)
+    assert Evision.cv_8U() == Evision.Mat.depth(img)
   end
 
   test "Evision.Mat.raw_type" do
     img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
-    assert 16 == Evision.Mat.raw_type(img)
+    assert Evision.cv_8UC3() == Evision.Mat.raw_type(img)
   end
 
   test "Evision.Mat.isSubmatrix" do

--- a/test/opencv_test.exs
+++ b/test/opencv_test.exs
@@ -245,4 +245,58 @@ defmodule Evision.Test do
 
     {:ok, {112.0, 209.0, {2, 0}, {0, 1}}} = Evision.minMaxLoc(mat)
   end
+
+  test "Evision.Mat.size" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert {2, [2, 3]} == Evision.Mat.size(img)
+  end
+
+  test "Evision.Mat.channels" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert 3 == Evision.Mat.channels(img)
+  end
+
+  test "Evision.Mat.depth" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert 0 == Evision.Mat.depth(img)
+  end
+
+  test "Evision.Mat.raw_type" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert 16 == Evision.Mat.raw_type(img)
+  end
+
+  test "Evision.Mat.isSubmatrix" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert false == Evision.Mat.isSubmatrix(img)
+  end
+
+  test "Evision.Mat.isContinuous" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert true == Evision.Mat.isContinuous(img)
+  end
+
+  test "Evision.Mat.elemSize" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert 3 == Evision.Mat.elemSize(img)
+  end
+
+  test "Evision.Mat.elemSize1" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert 1 == Evision.Mat.elemSize1(img)
+  end
+
+  test "Evision.Mat.total/{1,2,3}" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    assert 6 == Evision.Mat.total(img)
+    assert 2 == Evision.Mat.total(img, 0, 1)
+    assert 3 == Evision.Mat.total(img, 1, 2)
+  end
+
+  test "Evision.Mat.as_shape" do
+    img = Evision.imread!(Path.join([__DIR__, "test.jpg"]))
+    new_img = Evision.Mat.as_shape!(img, {3, 2, 3})
+    assert {3, 2, 3} == Evision.Mat.shape!(new_img)
+    assert Evision.Mat.to_binary!(img) == Evision.Mat.to_binary!(new_img)
+  end
 end


### PR DESCRIPTION
- Added more Mat functions:
  - `Evision.Mat.as_shape/2`.
  - `Evision.Mat.size/1`.
  - `Evision.Mat.channels/1`.
  - `Evision.Mat.depth/1`.
  - `Evision.Mat.raw_type/1`.
  - `Evision.Mat.isSubmatrix/1`.
  - `Evision.Mat.isContinuous/1`.
  - `Evision.Mat.elemSize/1`.
  - `Evision.Mat.elemSize1/1`.
  - `Evision.Mat.total/{1,2,3}`.