### PR TITLE
More nx integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,59 @@
     when (is_reference(dx) or is_struct(dx)) and (is_reference(dy) or is_struct(dy)) and is_number(threshold1) and is_number(threshold2), do: # variant 1
     ```
 
+- Better integration with `:nx`.
+
+  ```elixir
+  iex> t = Nx.tensor([[[0,0,0], [255, 255, 255]]], type: :u8)
+  #Nx.Tensor<
+    u8[1][2][3]
+    [
+      [
+        [0, 0, 0],
+        [255, 255, 255]
+      ]
+    ]
+  >
+  iex> mat = Evision.imread!("test.png")
+  %Evision.Mat{
+    channels: 3,
+    dims: 2,
+    type: {:u, 8},
+    raw_type: 16,
+    shape: {1, 2, 3},
+    ref: #Reference<0.2067356221.74055707.218654>
+  }
+  iex> mat = Evision.Mat.channel_as_last_dim!(mat)
+  %Evision.Mat{
+    channels: 1,
+    dims: 3,
+    type: {:u, 8},
+    raw_type: 0,
+    shape: {1, 2, 3},
+    ref: #Reference<0.2067356221.74055698.218182>
+  }
+  iex> result = Evision.Mat.add!(t, mat)
+  %Evision.Mat{
+    channels: 1,
+    dims: 3,
+    type: {:u, 8},
+    raw_type: 0,
+    shape: {1, 2, 3},
+    ref: #Reference<0.2067356221.74055698.218184>
+  }
+  iex> Evision.Nx.to_nx!(result)
+  #Nx.Tensor<
+    u8[1][2][3]
+    Evision.Backend
+    [
+      [
+        [255, 255, 255],
+        [255, 255, 255]
+      ]
+    ]
+  >
+  ```
+
 ### Added
 - Added `Evision.Mat.literal/{1,2,3}` to create `Evision.Mat` from list literals.
 
@@ -203,6 +256,40 @@
     raw_type: 16,
     shape: {1, 3, 3},
     ref: #Reference<0.512519210.691404820.106293>
+  }
+  ```
+
+- Added `Evision.Mat.channel_as_last_dim/1`.
+
+  This function does the opposite as to `Evision.Mat.last_dim_as_channel/1`.
+
+  If the number of channels of the input Evision.Mat is greater than 1,
+  then this function would convert the input Evision.Mat with dims `dims=list(int())` to a `1`-channel Evision.Mat with dims `[dims | channels]`.
+
+  If the number of channels of the input Evision.Mat is equal to 1,
+  - if dims == shape, then nothing happens
+  - otherwise, a new Evision.Mat that has dims=`[dims | channels]` will be returned
+  
+  For example,
+
+  ```elixir
+  iex> mat = Evision.imread!("test.png")
+  %Evision.Mat{
+    channels: 3,
+    dims: 2,
+    type: {:u, 8},
+    raw_type: 16,
+    shape: {1, 2, 3},
+    ref: #Reference<0.2067356221.74055707.218654>
+  }
+  iex> mat = Evision.Mat.channel_as_last_dim!(mat)
+  %Evision.Mat{
+    channels: 1,
+    dims: 3,
+    type: {:u, 8},
+    raw_type: 0,
+    shape: {1, 2, 3},
+    ref: #Reference<0.2067356221.74055698.218182>
   }
   ```
 

--- a/c_src/modules/evision_backend/abs.h
+++ b/c_src/modules/evision_backend/abs.h
@@ -15,9 +15,16 @@ static ERL_NIF_TERM evision_cv_mat_abs(ErlNifEnv *env, int argc, const ERL_NIF_T
 
     {
         Mat img;
+        Mat ret;
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
-            return evision::nif::ok(env, evision_from(env, Mat(cv::abs(img))));
+            int error_flag = false;
+            ERRWRAP2(ret = Mat(cv::abs(img)), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/add.h
+++ b/c_src/modules/evision_backend/add.h
@@ -22,8 +22,13 @@ static ERL_NIF_TERM evision_cv_mat_add(ErlNifEnv *env, int argc, const ERL_NIF_T
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
             Mat ret;
-            cv::add(l, r, ret, cv::noArray(), -1);
-            return ok(env, evision_from(env, ret));
+            int error_flag = false;
+            ERRWRAP2(cv::add(l, r, ret, cv::noArray(), -1), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 
@@ -52,9 +57,15 @@ static ERL_NIF_TERM evision_cv_mat_add_typed(ErlNifEnv *env, int argc, const ERL
             evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0))) {
             int type;
             if (!get_binary_type(t, l, 0, type)) return evision::nif::error(env, "not implemented for the given type");
+            
             Mat ret;
-            cv::add(lhs, rhs, ret, cv::noArray(), type);
-            return evision::nif::ok(env, evision_from(env, ret));
+            int error_flag = false;
+            ERRWRAP2(cv::add(lhs, rhs, ret, cv::noArray(), type), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/bitwise_and.h
+++ b/c_src/modules/evision_backend/bitwise_and.h
@@ -20,8 +20,13 @@ static ERL_NIF_TERM evision_cv_mat_bitwise_and(ErlNifEnv *env, int argc, const E
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
             Mat ret;
-            cv::bitwise_and(l, r, ret);
-            return evision::nif::ok(env, evision_from(env, ret));
+            int error_flag = false;
+            ERRWRAP2(cv::bitwise_and(l, r, ret), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/bitwise_not.h
+++ b/c_src/modules/evision_backend/bitwise_not.h
@@ -17,8 +17,15 @@ static ERL_NIF_TERM evision_cv_mat_bitwise_not(ErlNifEnv *env, int argc, const E
         Mat img;
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
-            Mat out = Mat(~img);
-            return evision::nif::ok(env, evision_from(env, out));
+            Mat ret;
+
+            int error_flag = false;
+            ERRWRAP2(ret = Mat(~img), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/bitwise_or.h
+++ b/c_src/modules/evision_backend/bitwise_or.h
@@ -20,8 +20,14 @@ static ERL_NIF_TERM evision_cv_mat_bitwise_or(ErlNifEnv *env, int argc, const ER
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
             Mat ret;
-            cv::bitwise_or(l, r, ret);
-            return evision::nif::ok(env, evision_from(env, ret));
+            
+            int error_flag = false;
+            ERRWRAP2(cv::bitwise_or(l, r, ret), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/bitwise_xor.h
+++ b/c_src/modules/evision_backend/bitwise_xor.h
@@ -20,8 +20,14 @@ static ERL_NIF_TERM evision_cv_mat_bitwise_xor(ErlNifEnv *env, int argc, const E
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
             Mat ret;
-            cv::bitwise_xor(l, r, ret);
-            return evision::nif::ok(env, evision_from(env, ret));
+
+            int error_flag = false;
+            ERRWRAP2(cv::bitwise_xor(l, r, ret), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/cmp.h
+++ b/c_src/modules/evision_backend/cmp.h
@@ -12,6 +12,7 @@ static ERL_NIF_TERM evision_cv_mat_cmp(ErlNifEnv *env, int argc, const ERL_NIF_T
     std::map<std::string, ERL_NIF_TERM> erl_terms;
     int nif_opts_index = 0;
     evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+    int error_flag = false;
 
     {
         Mat l;
@@ -34,13 +35,18 @@ static ERL_NIF_TERM evision_cv_mat_cmp(ErlNifEnv *env, int argc, const ERL_NIF_T
             }
 
             Mat ret;
-            cv::compare(l, r, ret, cmpop);
-            ret = ret / 255;
-            return evision::nif::ok(env, evision_from(env, ret));
+
+            ERRWRAP2(cv::compare(l, r, ret, cmpop), env, error_flag, error_term);
+            if (!error_flag) {
+                ERRWRAP2(ret = ret / 255, env, error_flag, error_term);
+                if (!error_flag) {
+                    return evision::nif::ok(env, evision_from(env, ret));
+                }
+            }
         }
     }
 
-    if (error_term != 0) return error_term;
+    if (error_flag) return error_term;
     else return evision::nif::error(env, "overload resolution failed");
 }
 

--- a/c_src/modules/evision_backend/divide.h
+++ b/c_src/modules/evision_backend/divide.h
@@ -12,6 +12,7 @@ static ERL_NIF_TERM evision_cv_mat_divide(ErlNifEnv *env, int argc, const ERL_NI
     std::map<std::string, ERL_NIF_TERM> erl_terms;
     int nif_opts_index = 0;
     evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+    int error_flag = false;
 
     {
         Mat l;
@@ -20,12 +21,17 @@ static ERL_NIF_TERM evision_cv_mat_divide(ErlNifEnv *env, int argc, const ERL_NI
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
             Mat ret;
-            cv::divide(l, r, ret, 1, -1);
-            return evision::nif::ok(env, evision_from(env, ret));
+
+            ERRWRAP2(cv::divide(l, r, ret, 1, -1), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 
-    if (error_term != 0) return error_term;
+    if (error_flag) return error_term;
     else return evision::nif::error(env, "overload resolution failed");
 }
 

--- a/c_src/modules/evision_backend/expm1.h
+++ b/c_src/modules/evision_backend/expm1.h
@@ -12,18 +12,27 @@ static ERL_NIF_TERM evision_cv_mat_expm1(ErlNifEnv *env, int argc, const ERL_NIF
     std::map<std::string, ERL_NIF_TERM> erl_terms;
     int nif_opts_index = 0;
     evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+    int error_flag = false;
 
     {
         Mat img;
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
-            Mat out;
-            cv::exp(img, out);
-            return evision::nif::ok(env, evision_from(env, Mat(out - 1)));
+            Mat ret;
+
+            ERRWRAP2(cv::exp(img, ret), env, error_flag, error_term);
+            if (!error_flag) {
+                ERRWRAP2(ret = Mat(ret - 1), env, error_flag, error_term);
+                if (!error_flag) {
+                    return evision::nif::ok(env, evision_from(env, ret));
+                }
+            }
+            cv::exp(img, ret);
+            return evision::nif::ok(env, evision_from(env, Mat(ret - 1)));
         }
     }
 
-    if (error_term != 0) return error_term;
+    if (error_flag) return error_term;
     else return evision::nif::error(env, "overload resolution failed");
 }
 

--- a/c_src/modules/evision_backend/eye.h
+++ b/c_src/modules/evision_backend/eye.h
@@ -23,8 +23,15 @@ static ERL_NIF_TERM evision_cv_mat_eye(ErlNifEnv *env, int argc, const ERL_NIF_T
             evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0))) {
             int type = 0;
             if (!get_binary_type(t, l, 1, type)) return evision::nif::error(env, "not implemented for the given type");
-            Mat out = Mat::eye(n, n, type);
-            return evision::nif::ok(env, evision_from(env, out));
+
+            Mat ret;
+            int error_flag = false;
+            ERRWRAP2(ret = Mat::eye(n, n, type), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/logical_and.h
+++ b/c_src/modules/evision_backend/logical_and.h
@@ -19,8 +19,14 @@ static ERL_NIF_TERM evision_cv_mat_logical_and(ErlNifEnv *env, int argc, const E
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
-            Mat ret = l & r;
-            return evision::nif::ok(env, evision_from(env, ret));
+            Mat ret;
+            int error_flag = false;
+            ERRWRAP2(ret = l & r, env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/logical_or.h
+++ b/c_src/modules/evision_backend/logical_or.h
@@ -19,8 +19,14 @@ static ERL_NIF_TERM evision_cv_mat_logical_or(ErlNifEnv *env, int argc, const ER
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
-            Mat ret = l | r;
-            return evision::nif::ok(env, evision_from(env, ret));
+            Mat ret;
+            int error_flag = false;
+            ERRWRAP2(ret = l | r, env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/logical_xor.h
+++ b/c_src/modules/evision_backend/logical_xor.h
@@ -19,8 +19,14 @@ static ERL_NIF_TERM evision_cv_mat_logical_xor(ErlNifEnv *env, int argc, const E
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
-            Mat ret = (l | r) & (l != r);
-            return evision::nif::ok(env, evision_from(env, ret));
+            Mat ret;
+            int error_flag = false;
+            ERRWRAP2(ret = (l | r) & (l != r), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/matrix_multiply.h
+++ b/c_src/modules/evision_backend/matrix_multiply.h
@@ -12,6 +12,7 @@ static ERL_NIF_TERM evision_cv_mat_matrix_multiply(ErlNifEnv *env, int argc, con
     std::map<std::string, ERL_NIF_TERM> erl_terms;
     int nif_opts_index = 0;
     evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+    int error_flag = false;
 
     {
         Mat lhs;
@@ -24,17 +25,25 @@ static ERL_NIF_TERM evision_cv_mat_matrix_multiply(ErlNifEnv *env, int argc, con
             evision_to_safe(env, evision_get_kw(env, erl_terms, "t"), t, ArgInfo("t", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0))) {
             int type;
+            Mat ret;
             if (get_binary_type(t, l, 0, type)) {
-                Mat ret = lhs * rhs;
-                ret.convertTo(ret, type);
-                return evision::nif::ok(env, evision_from(env, ret));
+                ERRWRAP2(ret = lhs * rhs, env, error_flag, error_term);
+                if (!error_flag) {
+                    ERRWRAP2(ret.convertTo(ret, type), env, error_flag, error_term);
+                    if (!error_flag) {
+                        return evision::nif::ok(env, evision_from(env, ret));
+                    }
+                }
             } else {
-                return evision::nif::ok(env, evision_from(env, Mat(lhs * rhs)));
+                ERRWRAP2(ret = Mat(lhs * rhs), env, error_flag, error_term);
+                if (!error_flag) {
+                    return evision::nif::ok(env, evision_from(env, ret));
+                }
             }
         }
     }
 
-    if (error_term != 0) return error_term;
+    if (error_flag) return error_term;
     else return evision::nif::error(env, "overload resolution failed");
 }
 

--- a/c_src/modules/evision_backend/multiply.h
+++ b/c_src/modules/evision_backend/multiply.h
@@ -20,8 +20,14 @@ static ERL_NIF_TERM evision_cv_mat_multiply(ErlNifEnv *env, int argc, const ERL_
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
             Mat ret;
-            cv::multiply(l, r, ret, 1, -1);
-            return evision::nif::ok(env, evision_from(env, ret));
+
+            int error_flag = false;
+            ERRWRAP2(cv::multiply(l, r, ret, 1, -1), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/reshape.h
+++ b/c_src/modules/evision_backend/reshape.h
@@ -19,8 +19,15 @@ static ERL_NIF_TERM evision_cv_mat_reshape(ErlNifEnv *env, int argc, const ERL_N
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "mat"), mat, ArgInfo("mat", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "shape"), shape, ArgInfo("shape", 0))) {
-            Mat out = mat.reshape(0, shape);
-            return evision::nif::ok(env, evision_from(env, out));
+            Mat ret;
+
+            int error_flag = false;
+            ERRWRAP2(ret = mat.reshape(0, shape), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/sign.h
+++ b/c_src/modules/evision_backend/sign.h
@@ -12,19 +12,26 @@ static ERL_NIF_TERM evision_cv_mat_sign(ErlNifEnv *env, int argc, const ERL_NIF_
     std::map<std::string, ERL_NIF_TERM> erl_terms;
     int nif_opts_index = 0;
     evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+    int error_flag = false;
 
     {
         Mat img;
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
-            img.setTo(1, img > 0);
-            img.setTo(0, img == 0);
-            img.setTo(-1, img < 0);
-            return evision::nif::ok(env, evision_from(env, img));
+            ERRWRAP2(img.setTo(1, img > 0), env, error_flag, error_term);
+            if (!error_flag) {
+                ERRWRAP2(img.setTo(0, img == 0), env, error_flag, error_term);
+                if (!error_flag) {
+                    ERRWRAP2(img.setTo(-1, img < 0), env, error_flag, error_term);
+                    if (!error_flag) {
+                        return evision::nif::ok(env, evision_from(env, img));
+                    }
+                }
+            }
         }
     }
 
-    if (error_term != 0) return error_term;
+    if (error_flag) return error_term;
     else return evision::nif::error(env, "overload resolution failed");
 }
 

--- a/c_src/modules/evision_backend/subtract.h
+++ b/c_src/modules/evision_backend/subtract.h
@@ -20,8 +20,14 @@ static ERL_NIF_TERM evision_cv_mat_subtract(ErlNifEnv *env, int argc, const ERL_
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0))) {
             Mat ret;
-            cv::subtract(l, r, ret, cv::noArray(), -1);
-            return evision::nif::ok(env, evision_from(env, ret));
+
+            int error_flag = false;
+            ERRWRAP2(cv::subtract(l, r, ret, cv::noArray(), -1), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision::nif::ok(env, evision_from(env, ret));
+            } else {
+                return error_term;
+            }
         }
     }
 

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1031,6 +1031,14 @@ defmodule Evision.Backend do
         result
       ])
     end
+
+    defp maybe_add_signature(result, %Evision.Mat{ref: _ref}) do
+      Inspect.Algebra.concat([
+        "Evision.Mat",
+        Inspect.Algebra.line(),
+        result
+      ])
+    end
   else
     defp maybe_add_signature(result, _tensor) do
       result

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -49,6 +49,10 @@ defmodule Evision.Mat do
     ref
   end
 
+  def __from_struct__(%Nx.Tensor{}=tensor) do
+    Evision.Internal.Structurise.from_struct(tensor)
+  end
+
   def __from_struct__(ref) when is_reference(ref) do
     ref
   end
@@ -444,6 +448,11 @@ defmodule Evision.Mat do
     {:ok, type}
   end
 
+  def type(mat) when is_struct(mat) do
+    mat = Evision.Internal.Structurise.from_struct(mat)
+    :evision_nif.mat_type(img: mat)
+  end
+
   def type(mat) when is_reference(mat) do
     :evision_nif.mat_type(img: mat)
   end
@@ -546,6 +555,11 @@ defmodule Evision.Mat do
     {:ok, shape}
   end
 
+  def shape(mat) when is_struct(mat) do
+    mat = Evision.Internal.Structurise.from_struct(mat)
+    :evision_nif.mat_shape(img: mat)
+  end
+
   def shape(mat) when is_reference(mat) do
     :evision_nif.mat_shape(img: mat)
   end
@@ -558,6 +572,11 @@ defmodule Evision.Mat do
   """
   def channels(%T{channels: channels}) do
     channels
+  end
+
+  def channels(mat) when is_struct(mat) do
+    mat = Evision.Internal.Structurise.from_struct(mat)
+    :evision_nif.mat_type(img: mat)
   end
 
   def channels(mat) when is_reference(mat) do
@@ -600,6 +619,11 @@ defmodule Evision.Mat do
   """
   def raw_type(%T{raw_type: raw_type}) do
     raw_type
+  end
+
+  def raw_type(mat) when is_struct(mat) do
+    mat = Evision.Internal.Structurise.from_struct(mat)
+    :evision_nif.mat_raw_type(img: mat)
   end
 
   def raw_type(mat) when is_reference(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -31,6 +31,7 @@ defmodule Evision.Mat do
 
   defstruct [:channels, :dims, :type, :raw_type, :shape, :ref]
   alias __MODULE__, as: T
+  @type t :: %{__struct__: atom()}
 
   @doc false
   def __make_struct__(%{:channels => channels, :dims => dims, :type => type, :raw_type => raw_type, :shape => shape, :ref => ref}) do
@@ -58,24 +59,25 @@ defmodule Evision.Mat do
   end
 
   if Code.ensure_loaded?(Kino.Render) do
-    defp is_2d_image(%Evision.Mat{dims: 2}), do: true
-    defp is_2d_image(%Evision.Mat{channels: c, shape: {_h, _w, c}}) when c in [1, 3, 4] do
-      true
-    end
+    defimpl Kino.Render do
+      defp is_2d_image(%Evision.Mat{dims: 2}), do: true
+      defp is_2d_image(%Evision.Mat{channels: c, shape: {_h, _w, c}}) when c in [1, 3, 4] do
+        true
+      end
 
-    defp is_2d_image(_), do: true
+      defp is_2d_image(_), do: true
 
-    @doc false
-    def to_livebook(mat) do
-      with true <- is_2d_image(mat),
-          {:ok, encoded} <- Evision.imencode(".png", mat) do
-        raw = Kino.Inspect.new(mat)
-        image = Kino.Image.new(encoded, :png)
-        tabs = Kino.Layout.tabs("Raw": raw, "Image": image)
-        Kino.Render.to_livebook(tabs)
-      else
-        _ ->
-          Kino.Output.inspect(mat)
+      def to_livebook(mat) do
+        with true <- is_2d_image(mat),
+            {:ok, encoded} <- Evision.imencode(".png", mat) do
+          raw = Kino.Inspect.new(mat)
+          image = Kino.Image.new(encoded, :png)
+          tabs = Kino.Layout.tabs("Raw": raw, "Image": image)
+          Kino.Render.to_livebook(tabs)
+        else
+          _ ->
+            Kino.Output.inspect(mat)
+        end
       end
     end
   end
@@ -729,6 +731,33 @@ defmodule Evision.Mat do
   end
 
   deferror(last_dim_as_channel(mat))
+
+  @doc """
+  This function does the opposite as to `Evision.Mat.last_dim_as_channel/1`.
+
+  If the number of channels of the input Evision.Mat is greater than 1,
+  then this function would convert the input Evision.Mat with dims `dims=list(int())` to a `1`-channel Evision.Mat with dims `[dims | channels]`.
+
+  If the number of channels of the input Evision.Mat is equal to 1,
+  - if dims == shape, then nothing happens
+  - otherwise, a new Evision.Mat that has dims=`[dims | channels]` will be returned
+  """
+  def channel_as_last_dim(mat) when is_struct(mat) do
+    mat = Evision.Internal.Structurise.from_struct(mat)
+    channel_as_last_dim(mat)
+  end
+
+  def channel_as_last_dim(mat) when is_reference(mat) do
+    {num_dims, _} = size!(mat)
+    shape = shape!(mat)
+    num_shape = tuple_size(shape)
+    if num_shape == num_dims do
+      mat
+    else
+      Evision.Mat.as_shape(mat, shape)
+    end
+  end
+  deferror(channel_as_last_dim(mat))
 
   @doc namespace: :"cv.Mat"
   def zeros(shape, type) when is_tuple(shape) do

--- a/lib/evision_structurise.ex
+++ b/lib/evision_structurise.ex
@@ -47,6 +47,11 @@ defmodule Evision.Internal.Structurise do
     ref
   end
 
+  def from_struct(%Nx.Tensor{}=tensor) do
+    %Evision.Mat{ref: ref} = Evision.Nx.to_mat!(tensor)
+    ref
+  end
+
   def from_struct(%{ref: ref}) do
     ref
   end


### PR DESCRIPTION
### Changed
- Better integration with `:nx`.

  ```elixir
  iex> t = Nx.tensor([[[0,0,0], [255, 255, 255]]], type: :u8)
  #Nx.Tensor<
    u8[1][2][3]
    [
      [
        [0, 0, 0],
        [255, 255, 255]
      ]
    ]
  >
  iex> mat = Evision.imread!("test.png")
  %Evision.Mat{
    channels: 3,
    dims: 2,
    type: {:u, 8},
    raw_type: 16,
    shape: {1, 2, 3},
    ref: #Reference<0.2067356221.74055707.218654>
  }
  iex> mat = Evision.Mat.channel_as_last_dim!(mat)
  %Evision.Mat{
    channels: 1,
    dims: 3,
    type: {:u, 8},
    raw_type: 0,
    shape: {1, 2, 3},
    ref: #Reference<0.2067356221.74055698.218182>
  }
  iex> result = Evision.Mat.add!(t, mat)
  %Evision.Mat{
    channels: 1,
    dims: 3,
    type: {:u, 8},
    raw_type: 0,
    shape: {1, 2, 3},
    ref: #Reference<0.2067356221.74055698.218184>
  }
  iex> Evision.Nx.to_nx!(result)
  #Nx.Tensor<
    u8[1][2][3]
    Evision.Backend
    [
      [
        [255, 255, 255],
        [255, 255, 255]
      ]
    ]
  >
  ```

### Added
- Added `Evision.Mat.channel_as_last_dim/1`.

  This function does the opposite as to `Evision.Mat.last_dim_as_channel/1`.

  If the number of channels of the input Evision.Mat is greater than 1,
  then this function would convert the input Evision.Mat with dims `dims=list(int())` to a `1`-channel Evision.Mat with dims `[dims | channels]`.

  If the number of channels of the input Evision.Mat is equal to 1,
  - if dims == shape, then nothing happens
  - otherwise, a new Evision.Mat that has dims=`[dims | channels]` will be returned
  
  For example,

  ```elixir
  iex> mat = Evision.imread!("test.png")
  %Evision.Mat{
    channels: 3,
    dims: 2,
    type: {:u, 8},
    raw_type: 16,
    shape: {1, 2, 3},
    ref: #Reference<0.2067356221.74055707.218654>
  }
  iex> mat = Evision.Mat.channel_as_last_dim!(mat)
  %Evision.Mat{
    channels: 1,
    dims: 3,
    type: {:u, 8},
    raw_type: 0,
    shape: {1, 2, 3},
    ref: #Reference<0.2067356221.74055698.218182>
  }
  ```