### PR TITLE
Implemented property setter for `cv::Ptr<>` wrapped types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
   ```
   arm64-apple-darwin => aarch64-apple-darwin
-  amd64-apple-darwin => x86_64-windows-msvc
+  amd64-windows-msvc => x86_64-windows-msvc
   ```
 
 ### Changed

--- a/c_src/erlcompat.hpp
+++ b/c_src/erlcompat.hpp
@@ -111,10 +111,7 @@ ERL_NIF_TERM evision_from(ErlNifEnv *env, const TYPE& src)                      
     static bool evision_##NAME##_getp(ErlNifEnv *env, ERL_NIF_TERM self, STORAGE * & dst)             \
     {                                                                                                 \
         evision_res<STORAGE> * VAR;                                                                   \
-        if (!enif_get_resource(env, self, evision_res<STORAGE>::type, (void **)&VAR))                 \
-            return enif_make_badarg(env);                                                             \
-        else                                                                                          \
-        {                                                                                             \
+        if (enif_get_resource(env, self, evision_res<STORAGE>::type, (void **)&VAR)) {                \
             dst = &(VAR->val);                                                                        \
             return true;                                                                              \
         }                                                                                             \
@@ -122,11 +119,10 @@ ERL_NIF_TERM evision_from(ErlNifEnv *env, const TYPE& src)                      
     }                                                                                                 \
     static ERL_NIF_TERM evision_##NAME##_Instance(ErlNifEnv *env, const STORAGE &r)                   \
     {                                                                                                 \
-        evision_res< STORAGE > * VAR;                                                                 \
-        VAR = (decltype(VAR))enif_alloc_resource(evision_res< STORAGE >::type,                        \
-                                sizeof(evision_res< STORAGE >));                                      \
-        if (!VAR)                                                                                     \
-            return evision::nif::error(env, "no memory");                                             \
+        evision_res<STORAGE> * VAR;                                                                   \
+        VAR = (decltype(VAR))enif_alloc_resource(evision_res<STORAGE>::type,                          \
+                                sizeof(evision_res<STORAGE>));                                        \
+        if (!VAR) return evision::nif::error(env, "no memory");                                       \
         new (&(VAR->val)) STORAGE(r);                                                                 \
         ERL_NIF_TERM ret = enif_make_resource(env, VAR);                                              \
         enif_release_resource(VAR);                                                                   \

--- a/py_src/class_info.py
+++ b/py_src/class_info.py
@@ -162,9 +162,14 @@ class ClassInfo(object):
                         name=self.name, cname=self.cname, member=pname,  membertype=p.tp, access=access_op,
                         storage_name=self.cname if self.issimple else "Ptr<{}>".format(self.cname)))
                 else:
-                    getset_code.write(ET.gen_template_set_prop.substitute(
+                    if self.issimple:
+                        getset_code.write(ET.gen_template_set_prop.substitute(
                         name=self.name, member=pname, membertype=p.tp, access=access_op, cname=self.cname,
-                        storage_name=self.cname if self.issimple else "Ptr<{}>".format(self.cname)))
+                        storage_name=self.cname))
+                    else:
+                        getset_code.write(ET.gen_template_set_prop_cv_ptr.substitute(
+                            name=self.name, member=pname, membertype=p.tp, access=access_op, cname=self.cname,
+                            storage_name="Ptr<{}>".format(self.cname)))
                 getset_inits.write(ET.gen_template_rw_prop_init.substitute(
                     name=self.name, member=pname,
                     storage_name=self.cname if self.issimple else "Ptr<{}>".format(self.cname)))

--- a/py_src/evision_templates.py
+++ b/py_src/evision_templates.py
@@ -425,12 +425,12 @@ gen_template_get_prop_ptr = Template("""
 static ERL_NIF_TERM evision_${name}_get_${member}(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM self = argv[0];
-    ${storage_name}* self1_ptr = 0;
-    if (!evision_${name}_getp(env, self, self1_ptr) && !self1_ptr) {
-        return enif_make_badarg(env);
+    ${storage_name}* self_ptr = 0;
+    if (!evision_${name}_getp(env, self, self_ptr) && !self_ptr) {
+        return failmsgp(env, "cannot get `${storage_name}` from `self`: mismatched type or invalid resource?");
     }
-    
-    ${storage_name} &self2 = *self1_ptr;
+
+    ${storage_name} &self2 = *self_ptr;
     $cname* _self_ = dynamic_cast<$cname*>(self2.get());
     return evision_from(env, _self_->${member});
 }
@@ -440,12 +440,12 @@ gen_template_get_prop = Template("""
 static ERL_NIF_TERM evision_${name}_get_${member}(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM self = argv[0];
-    ${storage_name}* self1 = 0;
-    if (!evision_${name}_getp(env, self, self1) && !self1) {
-        return enif_make_badarg(env);
+    ${storage_name}* self_ptr = 0;
+    if (!evision_${name}_getp(env, self, self_ptr) && !self_ptr) {
+        return failmsgp(env, "cannot get `${storage_name}` from `self`: mismatched type or invalid resource?");
     }
-    
-    return evision_from(env, self1${access}${member});
+
+    return evision_from(env, self_ptr${access}${member});
 }
 """)
 
@@ -453,14 +453,16 @@ gen_template_get_prop_algo = Template("""
 static ERL_NIF_TERM evision_${name}_get_${member}(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM self = argv[0];
-    ${storage_name}* self1 = 0;
-    if (!evision_${name}_getp(env, self, self1)) {
-        return enif_make_badarg(env);
+    ${storage_name}* self_ptr = 0;
+    if (!evision_${name}_getp(env, self, self_ptr) && !self_ptr) {
+        return failmsgp(env, "cannot get `${storage_name}` from `self`: mismatched type or invalid resource?");
     }
-    
-    $cname* _self_algo_ = dynamic_cast<$cname*>(self1->get());
-    if (!_self_algo_)
+
+    $cname* _self_algo_ = dynamic_cast<$cname*>(self_ptr->get());
+    if (!_self_algo_) {
         return failmsgp(env, "Incorrect type of object (must be '${name}' or its derivative)");
+    }
+
     return evision_from(env, _self_algo_${access}${member});
 }
 """)
@@ -469,18 +471,40 @@ gen_template_set_prop = Template("""
 static ERL_NIF_TERM evision_${name}_set_${member}(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM self = argv[0];
-    ${storage_name}* self1 = 0;
-    if (!evision_${name}_getp(env, self, self1)) {
-        return enif_make_badarg(env);
-    }
-    return evision::nif::atom(env, "not implemented setter");
+    ${storage_name}* self_ptr = 0;
 
-    // if (!value)
-    // {
-    //     // todo: error("Cannot delete the ${member} attribute");
-    //     return -1;
-    // }
-    // return evision_to_safe(env, value, p->val${access}${member}, ArgInfo("value", false)) ? 0 : -1;
+    if (!evision_${name}_getp(env, self, self_ptr) && !self_ptr) {
+        return failmsgp(env, "cannot get `${storage_name}` from `self`: mismatched type or invalid resource?");
+    }
+
+    if (evision_to_safe(env, argv[1], self_ptr->${member}, ArgInfo("${member}", false))) {
+        return evision::nif::ok(env, self);
+    }
+
+    return failmsgp(env, "cannot assign new value, mismatched type?");
+}
+""")
+
+gen_template_set_prop_cv_ptr = Template("""
+static ERL_NIF_TERM evision_${name}_set_${member}(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    ERL_NIF_TERM self = argv[0];
+    ${storage_name}* self_ptr = 0;
+
+    if (!evision_${name}_getp(env, self, self_ptr) && !self_ptr) {
+        return failmsgp(env, "cannot get `${storage_name}` from `self`: mismatched type or invalid resource?");
+    }
+
+    ${storage_name} &_self_ = *self_ptr;
+
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    evision::nif::parse_arg(env, 1, argv, erl_terms);
+
+    if (evision_to_safe(env, evision_get_kw(env, erl_terms, "${member}"), _self_${access}${member}, ArgInfo("${member}", false))) {
+        return evision::nif::ok(env, self);
+    }
+
+    return failmsgp(env, "cannot assign new value, mismatched type?");
 }
 """)
 
@@ -488,23 +512,23 @@ gen_template_set_prop_algo = Template("""
 static ERL_NIF_TERM evision_${name}_set_${member}(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM self = argv[0];
-    ${storage_name}* self1 = 0;
-    if (!evision_${name}_getp(env, self, self1)) {
-        return enif_make_badarg(env);
+    ${storage_name}* self_ptr = 0;
+    if (!evision_${name}_getp(env, self, self_ptr) && !self_ptr) {
+        return failmsgp(env, "cannot get `${storage_name}` from `self`: mismatched type or invalid resource?");
     }
-    $cname* _self_algo_ = dynamic_cast<$cname*>(self1->get());
-    if (!_self_algo_)
-    {
-        failmsgp(env, "Incorrect type of object (must be '${name}' or its derivative)");
-        return -1;
+
+    $cname* _self_algo_ = dynamic_cast<$cname*>(self_ptr->get());
+    if (!_self_algo_) {
+        return failmsgp(env, "Incorrect type of object (must be '${name}' or its derivative)");
     }
-    if (evision_to_safe(env, argv[1], _self_algo_${access}${member}, ArgInfo("value", false))) {
+
+    if (evision_to_safe(env, argv[1], _self_algo_${access}${member}, ArgInfo("${member}", false))) {
         return evision::nif::ok(env, self);
     }
-    return evision::nif::atom(env, "error");
+
+    return failmsgp(env, "cannot assign new value, mismatched type?");
 }
 """)
-
 
 gen_template_prop_init = Template("""
     {(char*)"${member}", (getter)evision_${name}_get_${member}, NULL, (char*)"${member}", NULL},""")

--- a/py_src/evision_templates.py
+++ b/py_src/evision_templates.py
@@ -314,7 +314,7 @@ gen_template_check_self = Template("""
     ERL_NIF_TERM self = argv[0];
     ${cname} * self1 = 0;
     if (!evision_${name}_getp(env, self, self1)) {
-        return enif_make_badarg(env);
+        return failmsgp(env, "cannot get `${cname}` from `self`: mismatched type or invalid resource?");
     }
     ${pname} _self_ = ${cvt}(self1);
 """)
@@ -324,7 +324,7 @@ gen_template_safe_check_self = Template("""
     ${cname} self1;
     const ArgInfo selfArg("self", false);
     if (!evision_to_safe(env, self, self1, selfArg)) {
-        return enif_make_badarg(env);
+        return failmsgp(env, "cannot get `${cname}` from `self`: mismatched type or invalid resource?");
     }
     ${pname} _self_ = &self1;
 """)


### PR DESCRIPTION
### Changed
- Implemented property setter for `cv::Ptr<>` wrapped types. For example,

  ```elixir
  iex> k = Evision.KalmanFilter.kalmanFilter!(1, 1)
  #Reference<0.382162378.457572372.189094>
  iex> Evision.KalmanFilter.get_gain!(k) |> Evision.Nx.to_nx!
  #Nx.Tensor<
    f32[1][1]
    Evision.Backend
    [
      [0.0]
    ]
  >
  iex> Evision.KalmanFilter.set_gain!(k, Evision.Mat.literal!([1.0], :f32))
  #Reference<0.382162378.457572372.189094>
  iex> Evision.KalmanFilter.get_gain!(k) |> Evision.Nx.to_nx!
  #Nx.Tensor<
    f32[1][1]
    Evision.Backend
    [
      [1.0]
    ]
  >
  ```

- More detailed error message for property getter/setter. For example,

  - When setting a property that is type `A` and value passed to the setter is type `B`, and there is no known conversion from `B` to `A`, then it will return an error-tuple

    ```elixir 
    iex> k = Evision.KalmanFilter.kalmanFilter!(1, 1)
    iex> Evision.KalmanFilter.set_gain(k, :p)
    {:error, "cannot assign new value, mismatched type?"}
    iex> Evision.KalmanFilter.set_gain(k, :p)
    ** (RuntimeError) cannot assign new value, mismatched type?
        (evision 0.1.7-dev) lib/generated/evision_kalmanfilter.ex:175: Evision.KalmanFilter.set_gain!/2
        iex:7: (file)
    ```

  - For property getter/setter, if the `self` passed in is a different type than what is expected, an error-tuple will be returned

    ```elixir
    iex> mat = Evision.Mat.literal!([1.0], :f32)
    %Evision.Mat{
      channels: 1,
      dims: 2,
      type: {:f, 32},
      raw_type: 5,
      shape: {1, 1},
      ref: #Reference<0.1499445684.3682467860.58544>
    }
    iex> Evision.KalmanFilter.set_gain(mat, mat) 
    {:error,
    "cannot get `Ptr<cv::KalmanFilter>` from `self`: mismatched type or invalid resource?"}
    iex> Evision.KalmanFilter.set_gain!(mat, mat)
    ** (RuntimeError) cannot get `Ptr<cv::KalmanFilter>` from `self`: mismatched type or invalid resource?
        (evision 0.1.7-dev) lib/generated/evision_kalmanfilter.ex:175: Evision.KalmanFilter.set_gain!/2
        iex:2: (file)
    ```

- `evision_##NAME##_getp` (in `c_src/erlcompat.hpp`) should just return true or false. 
  
  Returning a `ERL_NIF_TERM` (`enif_make_badarg`) in the macro (when `enif_get_resource` fails) will prevent the caller from returning an error-tuple with detailed error message.