### PR TITLE
Improve precompiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.9 (2022-10-08)
+### Bug Fixes
+- `Mix.Tasks.Compile.EvisionPrecompiled`: using `File.cp_r/2` instead of calling `cp -a` via `System.cmd/3`.
+- Fixed TLS warnings when downloading precompiled tarball file. Thanks to @kipcole9!
+
 ## v0.1.8 (2022-10-08)
 ### Changed
 - `CMake` and `make` (`nmake` if on Windows) will not be used to download and deploy precompiled binaries for Elixir users.
@@ -441,7 +446,7 @@
 - Check `cv::Mat::Mat.type()` when fetching the shape of a Mat.
   The number of channels will be included as the last dim of the shape if and only if `cv::Mat::Mat.type()` did not encode any channel information.
 
-### Fixed
+### Bug Fixes
 - Fixed `Evision.Mat.transpose`: should call `shape!` instead of `shape`. Thanks to @kipcole9 ! #77
 
 ### Added
@@ -524,7 +529,7 @@
 ### Changed
 - Default to `Evision.Backend` for `Evision.Nx.to_nx/2`.
 
-### Fixed
+### Bug Fixes
 - Fixed class inheritance issue in `py_src/class_info.py`.
 - Fixed missing comma in example livebooks' `Mix.install`. Thanks to @dbii.
 
@@ -533,7 +538,7 @@
 
 ## v0.1.3 (2022-09-01)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.3) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.3)
-### Fixed
+### Bug Fixes
 - Fixed issues in restoring files from precompiled package for macOS and Linux.
   - Paths are now quoted. 
   - using `cp -RPf` on macOS while `cp -a` on Linux.
@@ -542,7 +547,7 @@
 
 ## v0.1.2 (2022-08-26)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.2) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.2)
-### Fixed
+### Bug Fixes
 - Fixed transpose.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Then you can add `evision` as dependency in your `mix.exs`.
 ```elixir
 def deps do
   [
-    {:evision, "~> 0.1.8"}
+    {:evision, "~> 0.1.9"}
   ]
 end
 ```
@@ -205,7 +205,7 @@ The following environment variables can be set based on your needs.
 #### Important notes
 When using `:evision` from git, version "0.1.1" to "0.1.7" are available.
 
-Starting from `0.1.8` (included), using `:evision` from git is no longer supported (unless set `EVISION_PREFER_PRECOMPILED` to `false`) because we started to use checksum file to verify the integrity of the downloaded tarball file, and the checksum file is only tracked in the hex.pm package.
+Starting from `0.1.8` (included) and onwards, using `:evision` from git is no longer supported (unless set `EVISION_PREFER_PRECOMPILED` to `false`) because we started to use checksum file to verify the integrity of the downloaded tarball file, and the checksum file is only tracked in the hex.pm package.
 
 ```elixir
 def deps do
@@ -215,11 +215,11 @@ def deps do
 end
 ```
 
-It is recommended to use `:evision` from hex.pm. Currently "0.1.7" to "0.1.8" are available on hex.pm,
+It is recommended to use `:evision` from hex.pm. Currently "0.1.7" to "0.1.9" are available on hex.pm,
 ```elixir
 def deps do
   [
-    {:evision, "~> 0.1.8"}
+    {:evision, "~> 0.1.9"}
   ]
 end
 ```
@@ -269,7 +269,7 @@ export EVISION_PREFER_PRECOMPILED=false
 For livebook users, 
 ```elixir
 Mix.install([
-  {:evision, "~> 0.1.8"}
+  {:evision, "~> 0.1.9"}
 ], system_env: [
   {"EVISION_PREFER_PRECOMPILED", "false"}
 ])

--- a/examples/cifar10.livemd
+++ b/examples/cifar10.livemd
@@ -11,7 +11,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:req, "~> 0.3"},
   {:torchx, "~> 0.3"},
   {:nx, "~> 0.3", override: true},

--- a/examples/densenet121_benchmark.livemd
+++ b/examples/densenet121_benchmark.livemd
@@ -7,7 +7,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:kino, "~> 0.7"},
   {:req, "~> 0.3"}
 ])

--- a/examples/dnn-detection-model.livemd
+++ b/examples/dnn-detection-model.livemd
@@ -11,7 +11,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:req, "~> 0.3"},
   {:kino, "~> 0.7"}
 ])

--- a/examples/dnn-googlenet.livemd
+++ b/examples/dnn-googlenet.livemd
@@ -13,7 +13,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:kino, "~> 0.7"},
   {:req, "~> 0.3"}
 ])

--- a/examples/imread.livemd
+++ b/examples/imread.livemd
@@ -11,7 +11,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:req, "~> 0.3"},
   {:kino, "~> 0.7"}
 ])

--- a/examples/ml-decision_tree_and_random_forest.livemd
+++ b/examples/ml-decision_tree_and_random_forest.livemd
@@ -7,7 +7,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:evision_smartcell, "~> 0.1", github: "cocoa-xu/evision_smartcell"},
   {:scidata, "~> 0.1"},
   {:kino, "~> 0.7"},

--- a/examples/ml-svm.livemd
+++ b/examples/ml-svm.livemd
@@ -11,7 +11,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:req, "~> 0.3"},
   {:kino, "~> 0.7"}
 ])

--- a/examples/pca.livemd
+++ b/examples/pca.livemd
@@ -11,7 +11,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:req, "~> 0.3"},
   {:kino, "~> 0.7"}
 ])

--- a/examples/photo-hdr.livemd
+++ b/examples/photo-hdr.livemd
@@ -11,7 +11,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:req, "~> 0.3"},
   {:kino, "~> 0.7"}
 ])

--- a/examples/stitching.livemd
+++ b/examples/stitching.livemd
@@ -11,7 +11,7 @@
 # System.put_env("EVISION_PREFER_PRECOMPILED", "false")
 
 Mix.install([
-  {:evision, "~> 0.1.8"},
+  {:evision, "~> 0.1.9"},
   {:req, "~> 0.3"},
   {:kino, "~> 0.7"}
 ])

--- a/mix.exs
+++ b/mix.exs
@@ -2,8 +2,8 @@ defmodule Evision.MixProject.Metadata do
   @moduledoc false
 
   def app, do: :evision
-  def version, do: "0.1.8"
-  def last_released_version, do: "0.1.8"
+  def version, do: "0.1.9"
+  def last_released_version, do: "0.1.9"
   def github_url, do: "https://github.com/cocoa-xu/evision"
   def opencv_version, do: "4.6.0"
   # only means compatible. need to write more tests
@@ -18,6 +18,7 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
   alias Evision.MixProject.Metadata
 
   @available_versions [
+    "0.1.9",
     "0.1.8",
     "0.1.7",
     "0.1.6",

--- a/mix.exs
+++ b/mix.exs
@@ -157,6 +157,160 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
     available_for_target?
   end
 
+  # https_opts and related code are taken from
+  # https://github.com/elixir-cldr/cldr_utils/blob/master/lib/cldr/http/http.ex
+  @certificate_locations [
+    # Configured cacertfile
+    System.get_env("ELIXIR_MAKE_CACERT"),
+
+    # Populated if hex package CAStore is configured
+    if(Code.ensure_loaded?(CAStore), do: CAStore.file_path()),
+
+    # Populated if hex package certfi is configured
+    if(Code.ensure_loaded?(:certifi),
+      do: :certifi.cacertfile() |> List.to_string()
+    ),
+
+    # Debian/Ubuntu/Gentoo etc.
+    "/etc/ssl/certs/ca-certificates.crt",
+
+    # Fedora/RHEL 6
+    "/etc/pki/tls/certs/ca-bundle.crt",
+
+    # OpenSUSE
+    "/etc/ssl/ca-bundle.pem",
+
+    # OpenELEC
+    "/etc/pki/tls/cacert.pem",
+
+    # CentOS/RHEL 7
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+
+    # Open SSL on MacOS
+    "/usr/local/etc/openssl/cert.pem",
+
+    # MacOS & Alpine Linux
+    "/etc/ssl/cert.pem"
+  ]
+  |> Enum.reject(&is_nil/1)
+
+  @doc false
+  def certificate_store do
+    @certificate_locations
+    |> Enum.find(&File.exists?/1)
+    |> raise_if_no_cacertfile!
+    |> :erlang.binary_to_list()
+  end
+
+  defp raise_if_no_cacertfile!(nil) do
+    raise RuntimeError, """
+    No certificate trust store was found.
+    Tried looking for: #{inspect(@certificate_locations)}
+    A certificate trust store is required in
+    order to download locales for your configuration.
+    Since elixir_make could not detect a system
+    installed certificate trust store one of the
+    following actions may be taken:
+    1. Install the hex package `castore`. It will
+      be automatically detected after recompilation.
+    2. Install the hex package `certifi`. It will
+      be automatically detected after recomilation.
+    3. Specify the location of a certificate trust store
+      by configuring it in `config.exs`:
+        config :elixir_make,
+        cacertfile: "/path/to/cacertfile",
+        ...
+    """
+  end
+
+  defp raise_if_no_cacertfile!(file) do
+    file
+  end
+
+  defp https_opts(hostname) do
+    if secure_ssl?() do
+      [
+        ssl: [
+          verify: :verify_peer,
+          cacertfile: certificate_store(),
+          depth: 4,
+          ciphers: preferred_ciphers(),
+          versions: protocol_versions(),
+          eccs: preferred_eccs(),
+          reuse_sessions: true,
+          server_name_indication: hostname,
+          secure_renegotiate: true,
+          customize_hostname_check: [
+            match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+          ]
+        ]
+      ]
+    else
+      [
+        ssl: [
+          verify: :verify_none,
+          server_name_indication: hostname,
+          secure_renegotiate: true,
+          reuse_sessions: true,
+          versions: protocol_versions(),
+          ciphers: preferred_ciphers(),
+          versions: protocol_versions()
+        ]
+      ]
+    end
+  end
+
+  def preferred_ciphers do
+    preferred_ciphers = [
+      # Cipher suites (TLS 1.3): TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+      %{cipher: :aes_128_gcm, key_exchange: :any, mac: :aead, prf: :sha256},
+      %{cipher: :aes_256_gcm, key_exchange: :any, mac: :aead, prf: :sha384},
+      %{cipher: :chacha20_poly1305, key_exchange: :any, mac: :aead, prf: :sha256},
+      # Cipher suites (TLS 1.2): ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:
+      # ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:
+      # ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+      %{cipher: :aes_128_gcm, key_exchange: :ecdhe_ecdsa, mac: :aead, prf: :sha256},
+      %{cipher: :aes_128_gcm, key_exchange: :ecdhe_rsa, mac: :aead, prf: :sha256},
+      %{cipher: :aes_256_gcm, key_exchange: :ecdh_ecdsa, mac: :aead, prf: :sha384},
+      %{cipher: :aes_256_gcm, key_exchange: :ecdh_rsa, mac: :aead, prf: :sha384},
+      %{cipher: :chacha20_poly1305, key_exchange: :ecdhe_ecdsa, mac: :aead, prf: :sha256},
+      %{cipher: :chacha20_poly1305, key_exchange: :ecdhe_rsa, mac: :aead, prf: :sha256},
+      %{cipher: :aes_128_gcm, key_exchange: :dhe_rsa, mac: :aead, prf: :sha256},
+      %{cipher: :aes_256_gcm, key_exchange: :dhe_rsa, mac: :aead, prf: :sha384}
+    ]
+
+    :ssl.filter_cipher_suites(preferred_ciphers, [])
+  end
+
+  def protocol_versions do
+    if otp_version() < 25 do
+      [:"tlsv1.2"]
+    else
+      [:"tlsv1.2", :"tlsv1.3"]
+    end
+  end
+
+  def otp_version do
+    :erlang.system_info(:otp_release) |> List.to_integer()
+  end
+
+  def preferred_eccs do
+    # TLS curves: X25519, prime256v1, secp384r1
+    preferred_eccs = [:secp256r1, :secp384r1]
+    :ssl.eccs() -- :ssl.eccs() -- preferred_eccs
+  end
+
+  def secure_ssl? do
+    case System.get_env("ELIXIR_MAKE_UNSAFE_HTTPS") do
+      nil -> true
+      "FALSE" -> false
+      "false" -> false
+      "nil" -> false
+      "NIL" -> false
+      _other -> true
+    end
+  end
+
   def download!(url, save_as, overwrite \\ false)
 
   def download!(url, save_as, false) do
@@ -168,11 +322,14 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
   end
 
   def download!(url, save_as, true) do
-    http_opts = []
     opts = [body_format: :binary]
     arg = {url, []}
 
-    case :httpc.request(:get, arg, http_opts, opts) do
+    # https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets
+    # TODO: This may no longer be necessary from Erlang/OTP 26.0 or later.
+    http_options = https_opts(String.to_charlist(URI.parse(url).host))
+
+    case :httpc.request(:get, arg, http_options, opts) do
       {:ok, {{_, 200, _}, _, body}} ->
         File.write!(save_as, body)
         checksum(save_as)
@@ -344,7 +501,7 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
     end
 
     Logger.info("Copying priv directory: #{cached_priv_dir} => #{app_priv}")
-    with {"", 0} <- File.cp_r(cached_priv_dir, app_priv) do
+    with {:ok, _} <- File.cp_r(cached_priv_dir, app_priv) do
       :ok
     else
       {msg, code} ->
@@ -354,7 +511,7 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
     end
 
     Logger.info("Copying generated Elixir binding files: #{cached_elixir_dir} => #{generated_elixir_dir}")
-    with {"", 0} <- File.cp_r(cached_elixir_dir, generated_elixir_dir) do
+    with {:ok, _} <- File.cp_r(cached_elixir_dir, generated_elixir_dir) do
       :ok
     else
       {msg, code} ->

--- a/mix.exs
+++ b/mix.exs
@@ -344,7 +344,7 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
     end
 
     Logger.info("Copying priv directory: #{cached_priv_dir} => #{app_priv}")
-    with {"", 0} <- System.cmd("cp", ["-a", cached_priv_dir, app_priv]) do
+    with {"", 0} <- File.cp_r(cached_priv_dir, app_priv) do
       :ok
     else
       {msg, code} ->
@@ -354,7 +354,7 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
     end
 
     Logger.info("Copying generated Elixir binding files: #{cached_elixir_dir} => #{generated_elixir_dir}")
-    with {"", 0} <- System.cmd("cp", ["-a", cached_elixir_dir, generated_elixir_dir]) do
+    with {"", 0} <- File.cp_r(cached_elixir_dir, generated_elixir_dir) do
       :ok
     else
       {msg, code} ->

--- a/src/evision.app.src
+++ b/src/evision.app.src
@@ -1,6 +1,6 @@
 {application, evision,
  [{description, "OpenCV-Erlang/Elixir binding."},
-  {vsn, "0.1.8"},
+  {vsn, "0.1.9"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
### Bug Fixes
- `Mix.Tasks.Compile.EvisionPrecompiled`: using `File.cp_r/2` instead of calling `cp -a` via `System.cmd/3`.
- Fixed TLS warnings when downloading precompiled tarball file. Thanks to @kipcole9!