### PR TITLE
[Evision.Mat/Kino.Render] make rendering settings adjustable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,31 @@
 # Changelog
 
-## v0.1.16 (main)
-[Browse the Repository](https://github.com/cocoa-xu/evision)
+## v0.1.16 (2022-10-30)
+[Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.16) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.16)
 
 ## Fixes
-- [deps] revert changes in v0.1.15, `:kino` will be an optional dependency, if we use `if` before `defmodule`.
+- [deps] `:kino` will be an optional dependency, if we use `if` before `defmodule`. This reverts the changes in in v0.1.15. 
+  
+  Thanks @josevalim for helping me figuring out why using `if` before `defmodule` would solve the problem. More details can be found [here](https://cocoa-research.works/2022/10/conditional-compliation-with-if-and-use-in-elixir/).
+
+## Changes
+- [config.exs] Added configurable parameters related to rendering `Evision.Mat` in Kino. (They are optional and can also be adjusted in runtime)
+
+  - `config :evision, kino_render_image_encoding: :png`
+  - `config :evision, kino_render_image_max_size: {8192, 8192}`
+  - `config :evision, kino_render_tab_order: [:image, :raw, :numerical]`
+
+## Added
+- [Evision.Mat] Added a few functions related to Kino.Render
+
+  | Function | Description |
+  |:---------|:------------|
+  |`Evision.Mat.kino_render_tab_order/0` | Get preferred order of Kino.Layout tabs for `Evision.Mat` in Livebook. |
+  |`Evision.Mat.set_kino_render_tab_order/1` | Set preferred order of Kino.Layout tabs for `Evision.Mat` in Livebook. |
+  |`Evision.Mat.kino_render_image_max_size/0` | Get the maximum allowed image size to render in Kino. |
+  |`Evision.Mat.set_kino_render_image_max_size/1` | Set the maximum allowed image size to render in Kino. |
+  |`Evision.Mat.kino_render_image_encoding/0` | Get preferred image encoding when rendering in Kino. |
+  |`Evision.Mat.set_kino_render_image_encoding/1` | Set preferred image encoding when rendering in Kino. |
 
 ## v0.1.15 (2022-10-26)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.15) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.15)

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,4 +8,63 @@ config :evision,
   }
 
 config :evision, display_inline_image_iterm2: true
+
+# Only valid when `display_inline_image_iterm2` is `true` and using in iTerm2
+##
+## Maximum size for the image to be rendered in iTerm2, {height, width}
+##
+## Image will not be displayed if either its height or width exceeds these limits.
 config :evision, display_inline_image_max_size: {8192, 8192}
+
+# Only valid when `:kino` >= 0.7 and using in livebook
+#
+## Image Encoding Type
+##
+## When rendering a 2D image with Kino in Livebook
+## the image will first be encoded into either :png or :jpeg
+##
+## - :png usually has better quality because it is lossless compression,
+##    however, it uses more bandwidth to transfer
+##
+## - :jpeg require less bandwidth to pass from the backend to the livebook frontend,
+##    but it is lossy compression
+##
+## The default value is :png
+config :evision, kino_render_image_encoding: :png
+
+# Only valid when `:kino` >= 0.7 and using in livebook
+#
+## Maximum size for the image to be rendered in Kino, {height, width}
+##
+## Image will not be rendered in Kino if either its height or width exceeds these limits.
+config :evision, kino_render_image_max_size: {8192, 8192}
+
+# Only valid when `:kino` >= 0.7 and using in livebook
+#
+## Configure the order of Kino.Render tabs in livebook
+## Default order is `[:image, :raw, :numerical]`
+##   and the corresponding tabs will be:
+##   Image | Raw | Numerical
+##
+## Note that the `:image` tab will be ignored if the `Evision.Mat` is not a 2D image.
+##
+## Also, it's possible to specify any combination (any subset) of these tabs,
+##   including the empty one, `[]`, and in that case, the output content in the livebook
+##   cell will be the same as `:raw` but without any tabs
+##   -- simply put, `[]` means to only do the basic inspect and not use Kino.Layout.tabs
+##
+## **It's worth noting that `[] != nil`, because `nil` is default return value when `kino_render_tab_order`**
+## **is not configured -- hence evision will use the default order, `[:image, :raw, :numerical]` in such case**
+##
+## When only specifying one type, i.e., `[:image]`, `[:raw]` or `[:numerical]`,
+##   only one tab will be there
+##
+## Furthermore, when `kino_render_tab_order` is configured to `[:image]`, and the
+##   `Evision.Mat` is not a 2D image,
+##   then it will automatically fallback to `:raw`
+##   -- simply put, `:image` in this case (only specifying one type) means:
+##      display the Evision.Mat as an image whenever possible, and fallback to `:raw`
+##      if it's not a 2D image
+config :evision, kino_render_tab_order: [
+  :image, :raw, :numerical
+]

--- a/mix.exs
+++ b/mix.exs
@@ -2,8 +2,8 @@ defmodule Evision.MixProject.Metadata do
   @moduledoc false
 
   def app, do: :evision
-  def version, do: "0.1.16-dev"
-  def last_released_version, do: "0.1.15"
+  def version, do: "0.1.16"
+  def last_released_version, do: "0.1.16"
   def github_url, do: "https://github.com/cocoa-xu/evision"
   def opencv_version, do: "4.6.0"
   # only means compatible. need to write more tests
@@ -18,6 +18,7 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
   alias Evision.MixProject.Metadata
 
   @available_versions [
+    "0.1.16",
     "0.1.15",
     "0.1.14",
     "0.1.13",


### PR DESCRIPTION
## Changes
- [config.exs] Added configurable parameters related to rendering `Evision.Mat` in Kino. (They are optional and can also be adjusted in runtime)

  - `config :evision, kino_render_image_encoding: :png`
  - `config :evision, kino_render_image_max_size: {8192, 8192}`
  - `config :evision, kino_render_tab_order: [:image, :raw, :numerical]`

## Added
- [Evision.Mat] Added a few functions related to Kino.Render

  | Function | Description |
  |:---------|:------------|
  |`Evision.Mat.kino_render_tab_order/0` | Get preferred order of Kino.Layout tabs for `Evision.Mat` in Livebook. |
  |`Evision.Mat.set_kino_render_tab_order/1` | Set preferred order of Kino.Layout tabs for `Evision.Mat` in Livebook. |
  |`Evision.Mat.kino_render_image_max_size/0` | Get the maximum allowed image size to render in Kino. |
  |`Evision.Mat.set_kino_render_image_max_size/1` | Set the maximum allowed image size to render in Kino. |
  |`Evision.Mat.kino_render_image_encoding/0` | Get preferred image encoding when rendering in Kino. |
  |`Evision.Mat.set_kino_render_image_encoding/1` | Set preferred image encoding when rendering in Kino. |
