### PR TITLE
Smart cell fix and 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - [smartcell] register the model zoo smart cell (`Evision.SmartCell.Zoo`) on starting. Thanks to @josevalim.
+- [smartcell] make `:kino` and `:progress_bar` optional dependencies.
 
 ## v0.1.22 (2022-12-16)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.22) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.1.23-dev (2022-12-17)
 
 ### Fixed
-- [smartcell] fixed charset loading when initialise FP16/INT8 CRNN models. [#144](https://github.com/cocoa-xu/evision/issues/144)
+- [smartcell] fixed charset loading when initialising FP16/INT8 CRNN models. [#144](https://github.com/cocoa-xu/evision/issues/144)
 
 ### Changed
 - [smartcell] register the model zoo smart cell (`Evision.SmartCell.Zoo`) on starting. Thanks to @josevalim.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - [smartcell] fixed charset loading when initialise FP16/INT8 CRNN models. [#144](https://github.com/cocoa-xu/evision/issues/144)
 
+### Changed
+- [smartcell] register the model zoo smart cell (`Evision.SmartCell.Zoo`) on starting. Thanks to @josevalim.
+
 ## v0.1.22 (2022-12-16)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.22) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.23-dev (2022-12-17)
+
+### Fixed
+- [smartcell] fixed charset loading when initialise FP16/INT8 CRNN models. [#144](https://github.com/cocoa-xu/evision/issues/144)
+
 ## v0.1.22 (2022-12-16)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.22) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.22)
 

--- a/lib/evision/application.ex
+++ b/lib/evision/application.ex
@@ -1,0 +1,9 @@
+defmodule Evision.Application do
+  @moduledoc false
+  use Application
+
+  def start(_type, _args) do
+    if Code.ensure_loaded?(Kino), do: Evision.SmartCell.register_smartcells(Evision.SmartCell.Zoo)
+    Supervisor.start_link([], strategy: :one_for_one)
+  end
+end

--- a/lib/smartcell/evision_smartcell.ex
+++ b/lib/smartcell/evision_smartcell.ex
@@ -56,6 +56,10 @@ defmodule Evision.SmartCell do
       raise RuntimeError, """
       `:kino >= 0.7` is required to use smartcells in Livebook.
       Please add `{:kino, "~> 0.7"}` to the dependency list.
+
+      Note that `Evision.SmartCell.Zoo` has a another optional dependency,
+      `{:progress_bar,  "~> 2.0}`, which is used for displaying the
+      model download progress.
       """
     end
   end

--- a/lib/smartcell/simple_list.ex
+++ b/lib/smartcell/simple_list.ex
@@ -1,80 +1,85 @@
-defmodule Evision.SmartCell.SimpleList do
-  # code taken from
-  # https://github.com/livebook-dev/kino_bumblebee/blob/main/lib/kino/bumblebee/scored_list.ex
-
-  @moduledoc """
-  A kino for displaying a list of labels.
-  This kino is primarily used to present top classification predictions.
-  ## Examples
-      predictions =  [
-        "malamute",
-        "Siberian husky",
-        "Eskimo dog",
-        "Tibetan mastiff",
-        "German shepherd"
-      ]
-      Evision.SmartCell.SimpleList.new(predictions)
-  """
-
-  use Kino.JS
-
-  @type t :: Kino.JS.t()
-
-  @doc """
-  Creates a new kino displaying the given list of items.
-  Expects a list of tuples, each element being the label and its score.
-  """
-  @spec new(list({String.t(), number()})) :: t()
-  def new(items) when is_list(items) do
-    Kino.JS.new(__MODULE__, items)
+if !Code.ensure_loaded?(Kino.SmartCell) do
+  defmodule Evision.SmartCell.SimpleList do
   end
+else
+  defmodule Evision.SmartCell.SimpleList do
+    # code taken from
+    # https://github.com/livebook-dev/kino_bumblebee/blob/main/lib/kino/bumblebee/scored_list.ex
 
-  asset "main.js" do
+    @moduledoc """
+    A kino for displaying a list of labels.
+    This kino is primarily used to present top classification predictions.
+    ## Examples
+        predictions =  [
+          "malamute",
+          "Siberian husky",
+          "Eskimo dog",
+          "Tibetan mastiff",
+          "German shepherd"
+        ]
+        Evision.SmartCell.SimpleList.new(predictions)
     """
-    export function init(ctx, items) {
-      ctx.importCSS("main.css");
-      ctx.importCSS(
-        "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
-      );
-      ctx.root.innerHTML = `
-        <div class="app">
-          <ol class="list">
-            ${items.map((item) => (`
-              <li class="item">
-                <div class="label">
-                  <div>${item}</div>
-                </div>
-              </li>
-            `)).join("")}
-          </ol>
-        </div>
-      `;
-    }
-    """
-  end
 
-  asset "main.css" do
+    use Kino.JS
+
+    @type t :: Kino.JS.t()
+
+    @doc """
+    Creates a new kino displaying the given list of items.
+    Expects a list of tuples, each element being the label and its score.
     """
-    .app {
-      font-family: "JetBrains Mono", monospace;
-      font-size: 14px;
-      color: #8BA2FF;
-    }
-    .list {
-      padding: 0;
-      margin: 0;
-    }
-    .item {
-      display: flex;
-      justify-content: space-between;
-    }
-    .item:not(:first-child) {
-      margin-top: 16px;
-    }
-    .label {
-      flex-grow: 1;
-      margin-right: 8px;
-    }
-    """
+    @spec new(list({String.t(), number()})) :: t()
+    def new(items) when is_list(items) do
+      Kino.JS.new(__MODULE__, items)
+    end
+
+    asset "main.js" do
+      """
+      export function init(ctx, items) {
+        ctx.importCSS("main.css");
+        ctx.importCSS(
+          "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap"
+        );
+        ctx.root.innerHTML = `
+          <div class="app">
+            <ol class="list">
+              ${items.map((item) => (`
+                <li class="item">
+                  <div class="label">
+                    <div>${item}</div>
+                  </div>
+                </li>
+              `)).join("")}
+            </ol>
+          </div>
+        `;
+      }
+      """
+    end
+
+    asset "main.css" do
+      """
+      .app {
+        font-family: "JetBrains Mono", monospace;
+        font-size: 14px;
+        color: #8BA2FF;
+      }
+      .list {
+        padding: 0;
+        margin: 0;
+      }
+      .item {
+        display: flex;
+        justify-content: space-between;
+      }
+      .item:not(:first-child) {
+        margin-top: 16px;
+      }
+      .label {
+        flex-grow: 1;
+        margin-right: 8px;
+      }
+      """
+    end
   end
 end

--- a/lib/zoo/text_detection/db.ex
+++ b/lib/zoo/text_detection/db.ex
@@ -33,8 +33,8 @@ defmodule Evision.Zoo.TextDetection.DB do
       %{
         name: "Text Detector",
         params: [
-          %{field: "width", label: "Width", type: :number, default: config[:width], tooltip: "Multiplies of 32."},
-          %{field: "height", label: "Height", type: :number, default: config[:height], tooltip: "Multiplies of 32."},
+          %{field: "width", label: "Width", type: :number, default: config[:width], tooltip: "Multiples of 32."},
+          %{field: "height", label: "Height", type: :number, default: config[:height], tooltip: "Multiples of 32."},
           %{field: "binary_threshold", label: "Binary Threshold", type: :float, default: config[:binary_threshold]},
           %{field: "polygon_threshold", label: "Polygon Threshold", type: :float, default: config[:polygon_threshold]},
           %{field: "max_candidates", label: "Max Candidates", type: :number, default: config[:max_candidates]},

--- a/lib/zoo/text_recognition/crnn.ex
+++ b/lib/zoo/text_recognition/crnn.ex
@@ -288,25 +288,40 @@ defmodule Evision.Zoo.TextRecognition.CRNN do
     }
   end
 
-  def charset_info(:en) do
+  def charset_info(en) when en in [:en, :en_fp16, :en_int8] do
     {
       "https://raw.githubusercontent.com/opencv/opencv_zoo/master/models/text_recognition_crnn/charset_36_EN.txt",
       "text_recognition_CRNN_EN_2021sep_charset_36_EN.txt"
     }
   end
 
-  def charset_info(:ch) do
+  def charset_info(ch) when ch in [:ch, :ch_fp16, :ch_int8] do
     {
       "https://raw.githubusercontent.com/opencv/opencv_zoo/master/models/text_recognition_crnn/charset_94_CH.txt",
       "text_recognition_CRNN_CH_2021sep_charset_94_CH.txt"
     }
   end
 
-  def charset_info(:cn) do
+  def charset_info(cn) when cn in [:cn, :cn_int8] do
     {
       "https://raw.githubusercontent.com/opencv/opencv_zoo/master/models/text_recognition_crnn/charset_3944_CN.txt",
       "text_recognition_CRNN_CN_2021nov_charset_3944_CN.txt"
     }
+  end
+
+  def chartset_info(other) do
+    raise """
+    Cannot find predefined charset `#{inspect(other)}`.
+
+    However, you can load the charset that corresponds to your model and pass it when
+    calling `infer/`. The custom charset should be a list of characters. For example:
+
+      charset = String.split(File.read!("my-charset.txt"), "\n")
+      Evision.Zoo.TextRecognition.CRNN.infer(recognizer,
+        image, Enum.at(detections, 0),
+        charset: charset,
+        to_gray: lang == "en")
+    """
   end
 
   @doc """

--- a/lib/zoo/utils/http.ex
+++ b/lib/zoo/utils/http.ex
@@ -1,6 +1,8 @@
 defmodule Evision.Zoo.Utils.HTTP do
   @moduledoc false
 
+  @compile {:no_warn_undefined, ProgressBar}
+
   @type response :: %{status: status(), headers: headers(), body: binary()}
   @type status :: non_neg_integer()
   @type headers :: list(header())
@@ -94,7 +96,7 @@ defmodule Evision.Zoo.Utils.HTTP do
         part_size = byte_size(body_part)
         state = update_in(state.size, &(&1 + part_size))
 
-        if progress_bar_enabled?() &&
+        if Code.ensure_loaded?(ProgressBar) and progress_bar_enabled?() &&
              state.total_size && part_size != state.total_size do
           ProgressBar.render(state.size, state.total_size, suffix: :bytes)
         end

--- a/mix.exs
+++ b/mix.exs
@@ -779,7 +779,8 @@ defmodule Evision.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :inets, :ssl]
+      extra_applications: [:logger, :inets, :ssl],
+      mod: {Evision.Application, []}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Evision.MixProject.Metadata do
   @moduledoc false
 
   def app, do: :evision
-  def version, do: "0.1.22"
+  def version, do: "0.1.23-dev"
   def github_url, do: "https://github.com/cocoa-xu/evision"
   def opencv_version, do: "4.6.0"
   # only means compatible. need to write more tests

--- a/mix.exs
+++ b/mix.exs
@@ -912,13 +912,20 @@ defmodule Evision.MixProject do
       # compilation
       {:elixir_make, "~> 0.7", runtime: false},
       {:castore, "~> 0.1"},
+
       # runtime
       {:dll_loader_helper, "~> 0.1"},
       {:nx, "~> 0.4"},
-      {:progress_bar, "~> 2.0"},
-      {:kino, "~> 0.7"},
+
+      # optional
+      ## kino: for smart cells and better output in livebook
+      {:kino, "~> 0.7", optional: true},
+      ## progress_bar: for the model zoo smart cell
+      {:progress_bar, "~> 2.0", optional: true},
+
       # docs
       {:ex_doc, "~> 0.29", only: :docs, runtime: false},
+
       # test
       {:scidata, "~> 0.1", only: :test}
     ]


### PR DESCRIPTION
### Fixed
- [smartcell] fixed charset loading when initialising FP16/INT8 CRNN models. [#144](https://github.com/cocoa-xu/evision/issues/144)

### Changed
- [smartcell] register the model zoo smart cell (`Evision.SmartCell.Zoo`) on starting. Thanks to @josevalim.
- [smartcell] make `:kino` and `:progress_bar` optional dependencies.