### PR TITLE
Possibly fixed typespec

### DIFF
--- a/py_src/helper.py
+++ b/py_src/helper.py
@@ -1086,7 +1086,7 @@ manual_type_spec_map = {
     'Size2i': '{number(), number()}',
     'Size2f': '{number(), number()}',
     'Size2d': '{number(), number()}',
-    'Scalar': '{number()} | {number(), number()} | {number() | number() | number()} | {number(), number(), number(), number()}',
+    'Scalar': '{number()} | {number(), number()} | {number(), number(), number()} | {number(), number(), number(), number()}',
     'cv::Point': '{number(), number()}',
     'Point': '{number(), number()}',
     'Point2i': '{integer(), integer()}',


### PR DESCRIPTION
Diagnosing a Dialyzer error in the Elixir Discord, we came across this typespec that _seems_ to make little sense (a one-element tuple that is a number or a number or a number). Considering the surrounding specs, I assumed it should be a three-element tuple instead with numbers as values. I'm not familiar with the library's problem domain though, so maybe this type is not acceptable, in which case, please promptly throw this PR in the trash. :)