### PR TITLE
Added support for using `Nx.Tensor` or `Evision.Mat` in `Evision.DNN.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.1.31 (2022-04-17)
+
+### Changed
+- [Evision.DNN] Added support for passing `Nx.Tensor` or `Evision.Mat` as the input argument of `bboxes` in `Evision.DNN.nmsBoxes/{4,5}`.
+
+  ```elixir
+  iex> Evision.DNN.nmsBoxes([{0,1,2,3}], [1], 0.4, 0.3)
+  [0]
+  iex> Evision.DNN.nmsBoxes(Nx.tensor([[0,1,2,3]]), [1], 0.4, 0.3)
+  [0]
+  iex> Evision.DNN.nmsBoxes(Evision.Mat.literal([[0,1,2,3]], :f64), [1], 0.4, 0.3)
+  [0]
+  ```
+
 ## v0.1.30 (2022-03-24)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.30) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.30)
 

--- a/c_src/evision.cpp
+++ b/c_src/evision.cpp
@@ -1683,6 +1683,52 @@ static bool evision_to_generic_vec(ErlNifEnv *env, ERL_NIF_TERM obj, std::vector
 }
 
 template <>
+inline bool evision_to_generic_vec(ErlNifEnv *env, ERL_NIF_TERM obj, std::vector<cv::Rect2d>& value, const ArgInfo& info)
+{
+    if (evision::nif::check_nil(env, obj)) {
+        return true;
+    }
+
+    if (!enif_is_list(env, obj)) {
+        ErlNifBinary data;
+        if (enif_inspect_binary(env, obj, &data)) {
+            const size_t rect2d_size = sizeof(double) * 4;
+            if (data.size > 0 && data.size % rect2d_size == 0) {
+                size_t num_elements = data.size / rect2d_size;
+                value.resize(num_elements);
+                memcpy(value.data(), data.data, data.size);
+                return true;
+            }
+        }
+        return false;
+    }
+    unsigned n = 0;
+    if (!enif_get_list_length(env, obj, &n)) {
+        return false;
+    }
+    // printf("arg: %s, list length: %d\r\n", info.name, n);
+
+    value.resize(n);
+    ERL_NIF_TERM head, tail, arr = obj;
+    for (size_t i = 0; i < n; i++)
+    {
+        cv::Rect2d inner_val;
+        if (!enif_get_list_cell(env, arr, &head, &tail)) {
+            return false;
+        }
+
+        if (!evision_to(env, head, inner_val, info)) {
+            return false;
+        }
+
+        value[i] = inner_val;
+        arr = tail;
+    }
+
+    return true;
+}
+
+template <>
 inline bool evision_to_generic_vec(ErlNifEnv *env, ERL_NIF_TERM obj, std::vector<std::vector<int>>& value, const ArgInfo& info)
 {
     if (evision::nif::check_nil(env, obj)) {
@@ -2288,6 +2334,7 @@ static int convert_to_char(ErlNifEnv *env, ERL_NIF_TERM o, char *dst, const ArgI
 #include "modules/evision_imdecode.h"
 #include "modules/evision_backend/backend.h"
 #include "modules/evision_videocapture.h"
+// #include "modules/evision_dnn.h"
 
 /************************************************************************/
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Evision.MixProject.Metadata do
   @moduledoc false
 
   def app, do: :evision
-  def version, do: "0.1.30"
+  def version, do: "0.1.31"
   def github_url, do: "https://github.com/cocoa-xu/evision"
   def opencv_version, do: "4.7.0"
   # only means compatible. need to write more tests

--- a/py_src/fixes.py
+++ b/py_src/fixes.py
@@ -27,3 +27,187 @@ imdecode(Buf, Flags) ->
   evision_internal_structurise:to_struct(Ret).
 """
     ]
+
+
+def evision_elixir_module_fixes(): 
+    return {"DNN": [
+        ("""
+    @doc \"\"\"
+    Performs non maximum suppression given boxes and corresponding scores.
+
+    ##### Positional Arguments
+    - **bboxes**: `[Rect2d]`, `Nx.Tensor`, `Evision.Mat.t`.
+
+        a set of bounding boxes to apply NMS.
+
+    - **scores**: `[float]`.
+
+        a set of corresponding confidences.
+
+    - **score_threshold**: `float`.
+
+        a threshold used to filter boxes by score.
+
+    - **nms_threshold**: `float`.
+
+        a threshold used in non maximum suppression.
+
+    ##### Keyword Arguments
+    - **eta**: `float`.
+
+        a coefficient in adaptive threshold formula: \\f$nms\\_threshold_{i+1}=eta\\cdot nms\\_threshold_i\\f$.
+
+    - **top_k**: `int`.
+
+        if `>0`, keep at most @p top_k picked indices.
+
+    ##### Return
+    - **indices**: `[int]`.
+
+        the kept indices of bboxes after NMS.
+
+    Python prototype (for reference only):
+    ```python3
+    NMSBoxes(bboxes, scores, score_threshold, nms_threshold[, eta[, top_k]]) -> indices
+    ```
+    \"\"\"
+    @spec nmsBoxes(list({number(), number(), number(), number()}) | Evision.Mat.t() | Nx.Tensor.t(), list(number()), number(), number(), [{atom(), term()},...] | nil) :: list(integer()) | {:error, String.t()}
+    def nmsBoxes(bboxes, scores, score_threshold, nms_threshold, opts) when is_list(bboxes) and is_list(scores) and is_float(score_threshold) and is_float(nms_threshold) and (opts == nil or (is_list(opts) and is_tuple(hd(opts))))
+    do
+      positional = [
+        bboxes: Evision.Internal.Structurise.from_struct(bboxes),
+        scores: Evision.Internal.Structurise.from_struct(scores),
+        score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
+        nms_threshold: Evision.Internal.Structurise.from_struct(nms_threshold)
+      ]
+      :evision_nif.dnn_NMSBoxes(positional ++ Evision.Internal.Structurise.from_struct(opts || []))
+      |> __to_struct__()
+    end
+
+    def nmsBoxes(bboxes, scores, score_threshold, nms_threshold, opts) when (is_struct(bboxes, Evision.Mat) or is_struct(bboxes, Nx.Tensor)) and is_list(scores) and is_float(score_threshold) and is_float(nms_threshold) and (opts == nil or (is_list(opts) and is_tuple(hd(opts))))
+    do
+        case bboxes.shape do
+            {_, 4} ->
+                positional = [
+                    bboxes: Evision.Mat.to_binary(Evision.Internal.Structurise.from_struct(bboxes)),
+                    scores: Evision.Internal.Structurise.from_struct(scores),
+                    score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
+                    nms_threshold: Evision.Internal.Structurise.from_struct(nms_threshold)
+                ]
+                :evision_nif.dnn_NMSBoxes(positional ++ Evision.Internal.Structurise.from_struct(opts || []))
+                |> __to_struct__()
+            invalid_shape ->
+                {:error, "Expected a tensor or a mat with shape `{n, 4}`, got `#{inspect(invalid_shape)}`"}
+        end
+    end
+
+    @doc \"\"\"
+    Performs non maximum suppression given boxes and corresponding scores.
+
+    ##### Positional Arguments
+    - **bboxes**: `[Rect2d]`.
+
+        a set of bounding boxes to apply NMS.
+
+    - **scores**: `[float]`.
+
+        a set of corresponding confidences.
+
+    - **score_threshold**: `float`.
+
+        a threshold used to filter boxes by score.
+
+    - **nms_threshold**: `float`.
+
+        a threshold used in non maximum suppression.
+
+    ##### Keyword Arguments
+    - **eta**: `float`.
+
+        a coefficient in adaptive threshold formula: \\f$nms\\_threshold_{i+1}=eta\\cdot nms\\_threshold_i\\f$.
+
+    - **top_k**: `int`.
+
+        if `>0`, keep at most @p top_k picked indices.
+
+    ##### Return
+    - **indices**: `[int]`.
+
+        the kept indices of bboxes after NMS.
+
+    Python prototype (for reference only):
+    ```python3
+    NMSBoxes(bboxes, scores, score_threshold, nms_threshold[, eta[, top_k]]) -> indices
+    ```
+    \"\"\"
+    @spec nmsBoxes(list({number(), number(), number(), number()}) | Evision.Mat.t() | Nx.Tensor.t(), list(number()), number(), number()) :: list(integer()) | {:error, String.t()}
+    def nmsBoxes(bboxes, scores, score_threshold, nms_threshold) when is_list(bboxes) and is_list(scores) and is_float(score_threshold) and is_float(nms_threshold)
+    do
+        positional = [
+            bboxes: Evision.Internal.Structurise.from_struct(bboxes),
+            scores: Evision.Internal.Structurise.from_struct(scores),
+            score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
+            nms_threshold: Evision.Internal.Structurise.from_struct(nms_threshold)
+        ]
+        :evision_nif.dnn_NMSBoxes(positional)
+        |> __to_struct__()
+    end
+
+    def nmsBoxes(bboxes, scores, score_threshold, nms_threshold) when (is_struct(bboxes, Evision.Mat) or is_struct(bboxes, Nx.Tensor)) and is_list(scores) and is_float(score_threshold) and is_float(nms_threshold)
+    do
+        case bboxes.shape do
+            {_, 4} ->
+                bboxes = case bboxes.__struct__ do
+                    Nx.Tensor ->
+                        Nx.as_type(bboxes, :f64)
+                    Evision.Mat ->
+                        Evision.Mat.as_type(bboxes, :f64)
+                    _ ->
+                        raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
+                end
+                positional = [
+                    bboxes: Evision.Mat.to_binary(Evision.Internal.Structurise.from_struct(bboxes)),
+                    scores: Evision.Internal.Structurise.from_struct(scores),
+                    score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
+                    nms_threshold: Evision.Internal.Structurise.from_struct(nms_threshold)
+                ]
+                :evision_nif.dnn_NMSBoxes(positional)
+                |> __to_struct__()
+            invalid_shape ->
+                {:error, "Expected a tensor or a mat with shape `{n, 4}`, got `#{inspect(invalid_shape)}`"}
+        end
+    end
+""", """
+    def dnn_NMSBoxes(_opts \\\\ []), do: :erlang.nif_error("dnn::NMSBoxes not loaded")
+""")
+    ]}
+
+def evision_erlang_module_fixes():
+    return {"DNN": [
+        ("""
+-spec nmsBoxes(list({number(), number(), number(), number()}), list(number()), number(), number(), [{atom(), term()},...] | nil) -> list(integer()) | {error, binary()}.
+nmsBoxes(Bboxes, Scores, Score_threshold, Nms_threshold, Options) when is_list(Bboxes), is_list(Scores), is_float(Score_threshold), is_float(Nms_threshold), is_list(Options), is_tuple(hd(Options)), tuple_size(hd(Options)) == 2->
+  Positional = [
+    {bboxes, Bboxes},
+    {scores, Scores},
+    {score_threshold, Score_threshold},
+    {nms_threshold, Nms_threshold}
+  ],
+  Ret = evision_nif:dnn_NMSBoxes(Positional ++ evision_internal_structurise:from_struct(Options)),
+  '__to_struct__'(Ret).
+
+-spec nmsBoxes(list({number(), number(), number(), number()}), list(number()), number(), number()) -> list(integer()) | {error, binary()}.
+nmsBoxes(Bboxes, Scores, Score_threshold, Nms_threshold) when is_list(Bboxes), is_list(Scores), is_float(Score_threshold), is_float(Nms_threshold)->
+  Positional = [
+    {bboxes, Bboxes},
+    {scores, Scores},
+    {score_threshold, Score_threshold},
+    {nms_threshold, Nms_threshold}
+  ],
+  Ret = evision_nif:dnn_NMSBoxes(Positional),
+  '__to_struct__'(Ret).
+""", """
+dnn_NMSBoxes(_self, _opts) ->
+    not_loaded(?LINE).
+""")
+    ]}

--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -18,7 +18,7 @@ from namespace import Namespace
 from func_info import FuncInfo
 from class_info import ClassInfo
 from module_generator import ModuleGenerator
-from fixes import evision_elixir_fixes, evision_erlang_fixes
+from fixes import evision_elixir_fixes, evision_erlang_fixes, evision_elixir_module_fixes, evision_erlang_module_fixes
 from pathlib import Path
 import os
 from os import makedirs
@@ -712,11 +712,21 @@ class BeamWrapperGenerator(object):
             module_file_generator = self.evision_modules[name]
 
             if 'elixir' in self.langs:
+                if name in evision_elixir_module_fixes():
+                    fixes = evision_elixir_module_fixes()[name]
+                    for f,d in fixes:
+                        module_file_generator.write_elixir(f)
+                        self.evision_nif.write(d)
                 module_file_generator.end('elixir')
                 self.evision_nif.write(module_file_generator.get_nif_declaration('elixir'))
                 self.save(erl_output_path, f"evision_{name.lower()}.ex", module_file_generator.get_generated_code('elixir'))
 
             if 'erlang' in self.langs:
+                if name in evision_erlang_module_fixes():
+                    fixes = evision_erlang_module_fixes()[name]
+                    for f,d in fixes:
+                        module_file_generator.write_erlang(f)
+                        self.evision_nif_erlang.write(d)
                 module_file_generator.end('erlang')
                 self.evision_nif_erlang.write(module_file_generator.get_nif_declaration('erlang'))
                 self.save(erlang_output_path, f"evision_{name.lower()}.erl", module_file_generator.get_generated_code('erlang'))

--- a/py_src/helper.py
+++ b/py_src/helper.py
@@ -114,6 +114,8 @@ def special_handling_funcs():
             'videoCapture_waitAny']
         ]
 
+def special_handling_funcs_only_in_beam():
+    return ["{}{}".format(evision_nif_prefix(), name) for name in ['dnn_NMSBoxes']]
 
 def handle_inline_math_escaping(text, start_pos=0):
     inline_docs_inline_math_re = re.compile(r'(?:.*?)\\\\f[$\[](.*?)\\\\f[$\]]', re.MULTILINE|re.DOTALL)

--- a/py_src/module_generator.py
+++ b/py_src/module_generator.py
@@ -256,7 +256,7 @@ class ModuleGenerator(object):
     def _process_function(self, full_qualified_name: str, name: str, func: FuncInfo, is_ns: bool, is_constructor: bool, namespace_list: list):
         # ======== step 1. get wrapper name and ensure function name starts with a lowercase letter ========
         nif_name, func_name = func.get_wrapper_name(True)
-        if func_name in special_handling_funcs():
+        if func_name in special_handling_funcs() or func_name in special_handling_funcs_only_in_beam():
             return
         if len(func_name) > 0 and not ('a' <= func_name[0] <= 'z'):
             func_name = func_name.lower()

--- a/src/evision.app.src
+++ b/src/evision.app.src
@@ -1,6 +1,6 @@
 {application, evision,
  [{description, "OpenCV-Erlang/Elixir binding."},
-  {vsn, "0.1.29"},
+  {vsn, "0.1.31"},
   {registered, []},
   {applications,
    [kernel,


### PR DESCRIPTION
### Changed
- [Evision.DNN] Added support for passing `Nx.Tensor` or `Evision.Mat` as the input argument of `bboxes` in `Evision.DNN.nmsBoxes/{4,5}`.

  ```elixir
  iex> Evision.DNN.nmsBoxes([{0,1,2,3}], [1], 0.4, 0.3)
  [0]
  iex> Evision.DNN.nmsBoxes(Nx.tensor([[0,1,2,3]]), [1], 0.4, 0.3)
  [0]
  iex> Evision.DNN.nmsBoxes(Evision.Mat.literal([[0,1,2,3]], :f64), [1], 0.4, 0.3)
  [0]
  ```