### PR TITLE
override env `EVISION_PREFER_PRECOMPILED` when building from source

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -755,7 +755,8 @@ defmodule Evision.MixProject do
             "CMAKE_OPTIONS" => cmake_options,
             "ENABLED_CV_MODULES" => enabled_modules,
             "TARGET_ABI" => System.get_env("TARGET_ABI", target_abi),
-            "EVISION_GENERATE_LANG" => System.get_env("EVISION_GENERATE_LANG", "elixir")
+            "EVISION_GENERATE_LANG" => System.get_env("EVISION_GENERATE_LANG", "elixir"),
+            "EVISION_PREFER_PRECOMPILED" => "false"
           }
 
           {[:elixir_make] ++ Mix.compilers(), make_env}


### PR DESCRIPTION
This PR should fix #195 