### PR TITLE
Fix model zoo url

### DIFF
--- a/lib/zoo/face_recognition/sface.ex
+++ b/lib/zoo/face_recognition/sface.ex
@@ -322,14 +322,14 @@ defmodule Evision.Zoo.FaceRecognition.SFace do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:default_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/face_recognition_sface/face_recognition_sface_2021dec.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/face_recognition_sface/face_recognition_sface_2021dec.onnx?raw=true",
       "face_recognition_sface_2021dec.onnx"
     }
   end
 
   def model_info(:quant_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/face_recognition_sface/face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/face_recognition_sface/face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx?raw=true",
       "face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx"
     }
   end

--- a/lib/zoo/image_classification/mobilenet_v1.ex
+++ b/lib/zoo/image_classification/mobilenet_v1.ex
@@ -208,14 +208,14 @@ defmodule Evision.Zoo.ImageClassification.MobileNetV1 do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:default_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/image_classification_mobilenet/image_classification_mobilenetv1_2022apr.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/image_classification_mobilenet/image_classification_mobilenetv1_2022apr.onnx?raw=true",
       "image_classification_mobilenetv1_2022apr.onnx"
     }
   end
 
   def model_info(:quant_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/image_classification_mobilenet/image_classification_mobilenetv1_2022apr-int8-quantized.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/image_classification_mobilenet/image_classification_mobilenetv1_2022apr-int8-quantized.onnx?raw=true",
       "image_classification_mobilenetv1_2022apr-int8-quantized.onnx"
     }
   end

--- a/lib/zoo/image_classification/pp_resnet.ex
+++ b/lib/zoo/image_classification/pp_resnet.ex
@@ -209,14 +209,14 @@ defmodule Evision.Zoo.ImageClassification.PPResNet do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:default_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/image_classification_ppresnet/image_classification_ppresnet50_2022jan.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/image_classification_ppresnet/image_classification_ppresnet50_2022jan.onnx?raw=true",
       "image_classification_ppresnet50_2022jan.onnx"
     }
   end
 
   def model_info(:quant_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/image_classification_ppresnet/image_classification_ppresnet50_2022jan-act_int8-wt_int8-quantized.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/image_classification_ppresnet/image_classification_ppresnet50_2022jan-act_int8-wt_int8-quantized.onnx?raw=true",
       "image_classification_ppresnet50_2022jan-act_int8-wt_int8-quantized.onnx"
     }
   end

--- a/lib/zoo/image_segmentation/pp_humanseg.ex
+++ b/lib/zoo/image_segmentation/pp_humanseg.ex
@@ -183,14 +183,14 @@ defmodule Evision.Zoo.ImageSegmentation.PPHumanSeg do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:default_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct.onnx?raw=true",
       "human_segmentation_pphumanseg_2021oct.onnx"
     }
   end
 
   def model_info(:quant_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct-act_int8-wt_int8-quantized.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct-act_int8-wt_int8-quantized.onnx?raw=true",
       "human_segmentation_pphumanseg_2021oct-act_int8-wt_int8-quantized.onnx"
     }
   end

--- a/lib/zoo/text_detection/db.ex
+++ b/lib/zoo/text_detection/db.ex
@@ -187,7 +187,7 @@ defmodule Evision.Zoo.TextDetection.DB do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:ic15_resnet18) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/text_detection_db/text_detection_DB_IC15_resnet18_2021sep.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/text_detection_db/text_detection_DB_IC15_resnet18_2021sep.onnx?raw=true",
       "text_detection_DB_IC15_resnet18_2021sep.onnx"
     }
   end
@@ -202,7 +202,7 @@ defmodule Evision.Zoo.TextDetection.DB do
 
   def model_info(:td500_resnet18) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/master/models/text_detection_db/text_detection_DB_TD500_resnet18_2021sep.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/main/models/text_detection_db/text_detection_DB_TD500_resnet18_2021sep.onnx?raw=true",
       "text_detection_DB_TD500_resnet18_2021sep.onnx"
     }
   end


### PR DESCRIPTION
Modifying the URL of the model file.
Because the branch name of opencv_zoo changed from master to main.

https://github.com/opencv/opencv_zoo

Closes #203