### PR TITLE
Fix face detection bbox

### DIFF
--- a/lib/zoo/face_recognition/sface.ex
+++ b/lib/zoo/face_recognition/sface.ex
@@ -436,8 +436,8 @@ defmodule Evision.Zoo.FaceRecognition.SFace do
 
           case {original_results, comparison_results} do
             {%Evision.Mat{}, %Evision.Mat{}} ->
-              original_bbox = Nx.reverse(Evision.Mat.to_nx(original_results, Nx.BinaryBackend)[0])
-              comparison_bbox = Nx.reverse(Evision.Mat.to_nx(comparison_results, Nx.BinaryBackend)[0])
+              original_bbox = Evision.Mat.to_nx(original_results, Nx.BinaryBackend)[0][0..-2//1]
+              comparison_bbox = Evision.Mat.to_nx(comparison_results, Nx.BinaryBackend)[0][0..-2//1]
 
               original_feature = Evision.Zoo.FaceRecognition.SFace.infer(recognizer, original_image, original_bbox)
               comparison_feature = Evision.Zoo.FaceRecognition.SFace.infer(recognizer, comparison_image, comparison_bbox)


### PR DESCRIPTION
bbox is not a reversal of result, but uses all but the last one

https://github.com/opencv/opencv_zoo/blob/main/models/face_recognition_sface/demo.py#L80

```python
result = recognizer.match(img1, face1[0][:-1], img2, face2[0][:-1])
```

This `[:-1]` is not "reversed" but "other than last"