### PR TITLE
Update model zoo URL for OpenCV 4.8.0

### DIFF
--- a/lib/zoo/face_detection/yunet.ex
+++ b/lib/zoo/face_detection/yunet.ex
@@ -243,15 +243,15 @@ defmodule Evision.Zoo.FaceDetection.YuNet do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:default_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/7e062e54cf5410c09b795ff71b4a255e58498c79/models/face_detection_yunet/face_detection_yunet_2022mar.onnx?raw=true",
-      "face_detection_yunet_2022mar.onnx"
+      "https://github.com/opencv/opencv_zoo/blob/main/models/face_detection_yunet/face_detection_yunet_2023mar.onnx?raw=true",
+      "face_detection_yunet_2023mar.onnx"
     }
   end
 
   def model_info(:quant_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/7e062e54cf5410c09b795ff71b4a255e58498c79/models/face_detection_yunet/face_detection_yunet_2022mar_int8.onnx?raw=true",
-      "face_detection_yunet_2022mar_int8.onnx"
+      "https://github.com/opencv/opencv_zoo/blob/main/models/face_detection_yunet/face_detection_yunet_2023mar_int8.onnx?raw=true",
+      "face_detection_yunet_2023mar_int8.onnx"
     }
   end
 

--- a/lib/zoo/face_detection/yunet.ex
+++ b/lib/zoo/face_detection/yunet.ex
@@ -243,7 +243,7 @@ defmodule Evision.Zoo.FaceDetection.YuNet do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:default_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/main/models/face_detection_yunet/face_detection_yunet_2023mar.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/0d619617a8e9a389150d8c76e417451a19468150/models/face_detection_yunet/face_detection_yunet_2023mar.onnx?raw=true",
       "face_detection_yunet_2023mar.onnx"
     }
   end

--- a/lib/zoo/image_segmentation/pp_humanseg.ex
+++ b/lib/zoo/image_segmentation/pp_humanseg.ex
@@ -183,14 +183,14 @@ defmodule Evision.Zoo.ImageSegmentation.PPHumanSeg do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:default_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/main/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar.onnx?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/0d619617a8e9a389150d8c76e417451a19468150/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar.onnx?raw=true",
       "human_segmentation_pphumanseg_2023mar.onnx"
     }
   end
 
   def model_info(:quant_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/main/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar_int8?raw=true",
+      "https://github.com/opencv/opencv_zoo/blob/0d619617a8e9a389150d8c76e417451a19468150/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar_int8?raw=true",
       "human_segmentation_pphumanseg_2023mar_int8.onnx"
     }
   end

--- a/lib/zoo/image_segmentation/pp_humanseg.ex
+++ b/lib/zoo/image_segmentation/pp_humanseg.ex
@@ -183,15 +183,15 @@ defmodule Evision.Zoo.ImageSegmentation.PPHumanSeg do
   @spec model_info(:default_model | :quant_model) :: {String.t(), String.t()}
   def model_info(:default_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/25e096fd2e16c39a39b982205abccff2ecc8fbb4/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct.onnx?raw=true",
-      "human_segmentation_pphumanseg_2021oct.onnx"
+      "https://github.com/opencv/opencv_zoo/blob/main/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar.onnx?raw=true",
+      "human_segmentation_pphumanseg_2023mar.onnx"
     }
   end
 
   def model_info(:quant_model) do
     {
-      "https://github.com/opencv/opencv_zoo/blob/25e096fd2e16c39a39b982205abccff2ecc8fbb4/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2021oct-act_int8-wt_int8-quantized.onnx?raw=true",
-      "human_segmentation_pphumanseg_2021oct-act_int8-wt_int8-quantized.onnx"
+      "https://github.com/opencv/opencv_zoo/blob/main/models/human_segmentation_pphumanseg/human_segmentation_pphumanseg_2023mar_int8?raw=true",
+      "human_segmentation_pphumanseg_2023mar_int8.onnx"
     }
   end
 


### PR DESCRIPTION
Update model zoo URL for OpenCV 4.8.0

Some current URLs are for OpenCV 4.7

https://github.com/opencv/opencv_zoo