### PR TITLE
Remove spec in Kino.Render implementation

### DIFF
--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -652,7 +652,6 @@ defmodule Evision.Mat do
         end
       end
 
-      @spec to_livebook(Evision.Mat.t()) :: Kino.Output.t()
       def to_livebook(mat) when is_struct(mat, Evision.Mat) do
         render_types = Evision.Mat.kino_render_tab_order()
 


### PR DESCRIPTION
`Kino.Output.t/0` will no longer be available in the future. We could say `map()`, but I'm not sure specs have much additional value for protocol implementation, where it's already known :)