### PR TITLE
Fix features2d inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## main
+[Browse the Repository](https://github.com/cocoa-xu/evision/)
+
+### Fix
+- Allow implicitly cast to `Evision.Feature2D` from the following types:
+  - `Evision.AKAZE`
+  - `Evision.AffineFeature`
+  - `Evision.AgastFeatureDetector`
+  - `Evision.BRISK`
+  - `Evision.FastFeatureDetector`
+  - `Evision.GFTTDetector`
+  - `Evision.KAZE`
+  - `Evision.MSER`
+  - `Evision.ORB`
+  - `Evision.SimpleBlobDetector`
+  - `Evision.XFeatures2D.BEBLID`
+  - `Evision.XFeatures2D.BoostDesc`
+  - `Evision.XFeatures2D.BriefDescriptorExtractor`
+  - `Evision.XFeatures2D.DAISY`
+  - `Evision.XFeatures2D.FREAK`
+  - `Evision.XFeatures2D.LATCH`
+  - `Evision.XFeatures2D.LUCID`
+  - `Evision.XFeatures2D.MSDDetector`
+  - `Evision.XFeatures2D.StarDetector`
+  - `Evision.XFeatures2D.TBMR`
+  - `Evision.XFeatures2D.TEBLID`
+  - `Evision.XFeatures2D.VGG`
+
 ## v0.1.35 (2024-02-14)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.1.35) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.1.35)
 

--- a/c_src/evision.cpp
+++ b/c_src/evision.cpp
@@ -533,6 +533,255 @@ bool evision_to(ErlNifEnv *env, ERL_NIF_TERM o, Vec<_Tp, cn>& vec, const ArgInfo
     return evision_to(env, o, (Matx<_Tp, cn, 1>&)vec, info);
 }
 
+#ifdef HAVE_OPENCV_FEATURES2D
+template<>
+bool evision_to(ErlNifEnv *env, ERL_NIF_TERM obj, cv::Ptr<cv::Feature2D> &feature, const ArgInfo& info)
+{
+    if (evision::nif::check_nil(env, obj)) {
+        return false;
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::AKAZE>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::AffineFeature>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::AgastFeatureDetector>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::BRISK>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::FastFeatureDetector>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::GFTTDetector>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::KAZE>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::MSER>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::ORB>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::SIFT>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::SimpleBlobDetector>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+#ifdef HAVE_OPENCV_XFEATURES2D
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::AffineFeature2D>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::BEBLID>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::BoostDesc>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::BriefDescriptorExtractor>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::DAISY>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::FREAK>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::HarrisLaplaceFeatureDetector>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::LATCH>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::LUCID>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::MSDDetector>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::SURF>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::StarDetector>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::TBMR>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::TEBLID>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+    {
+        using source_type = evision_res<cv::Ptr<cv::xfeatures2d::VGG>>;
+        source_type * in_res;
+        if (enif_get_resource(env, obj, source_type::type, (void **)&in_res) ) {
+            feature = in_res->val;
+            return true;
+        }
+    }
+
+#endif
+
+    return false;
+}
+#endif
+
 template<>
 ERL_NIF_TERM evision_from(ErlNifEnv *env, const Mat& m)
 {

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Evision.MixProject.Metadata do
   @moduledoc false
 
   def app, do: :evision
-  def version, do: "0.1.35"
+  def version, do: "0.1.36-dev"
   def github_url, do: "https://github.com/cocoa-xu/evision"
   def opencv_version, do: "4.9.0"
   # only means compatible. need to write more tests

--- a/py_src/helper.py
+++ b/py_src/helper.py
@@ -1352,6 +1352,8 @@ def map_argtype_to_guard_elixir(argname, argtype, classname: Optional[str] = Non
         return f'is_tuple({argname})'
     elif is_struct(argtype, classname=classname):
         _, struct_name = is_struct(argtype, also_get='struct_name', classname=classname)
+        if struct_name == 'Evision.Feature2D':
+            return f''
         if struct_name == 'Evision.Mat':
             return f'(is_struct({argname}, Evision.Mat) or is_struct({argname}, Nx.Tensor))'
         else:

--- a/test/evision_features2d_test.exs
+++ b/test/evision_features2d_test.exs
@@ -1,0 +1,74 @@
+defmodule Evision.Features2D.Test do
+  use ExUnit.Case
+
+  setup do
+    %Evision.Mat{} = image = Evision.imread(Path.join([__DIR__, "testdata", "back.jpg"]))
+    opts = [nfeatures: 500]
+    %{image: image, opts: opts}
+  end
+
+  describe "implicit cast to Evision.Features2D" do
+    test "cast from Evision.AKAZE.t()", %{image: image, opts: opts} do
+      detector = Evision.AKAZE.create(opts)
+      features = Evision.Detail.computeImageFeatures2(detector, image)
+      assert Evision.Detail.ImageFeatures == features.__struct__
+    end
+
+    test "cast from Evision.AffineFeature.t()", %{image: image, opts: opts} do
+      detector = Evision.AKAZE.create(opts)
+      affine_detector = Evision.AffineFeature.create(detector)
+      features = Evision.Detail.computeImageFeatures2(affine_detector, image)
+      assert Evision.Detail.ImageFeatures == features.__struct__
+    end
+
+    test "cast from Evision.BRISK.t()", %{image: image, opts: opts} do
+      detector = Evision.BRISK.create(opts)
+      features = Evision.Detail.computeImageFeatures2(detector, image)
+      assert Evision.Detail.ImageFeatures == features.__struct__
+    end
+
+    test "cast from Evision.KAZE.t()", %{image: image, opts: opts} do
+      detector = Evision.KAZE.create(opts)
+      features = Evision.Detail.computeImageFeatures2(detector, image)
+      assert Evision.Detail.ImageFeatures == features.__struct__
+    end
+
+    test "cast from Evision.ORB.t()", %{image: image, opts: opts} do
+      detector = Evision.ORB.create(opts)
+      features = Evision.Detail.computeImageFeatures2(detector, image)
+      assert Evision.Detail.ImageFeatures == features.__struct__
+    end
+  end
+
+  describe "implicit cast to Evision.Features2D okay but not implemented detectAndCompute" do
+    test "cast from Evision.AgastFeatureDetector.t()", %{image: image, opts: opts} do
+      detector = Evision.AgastFeatureDetector.create(opts)
+      {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+      assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "cast from Evision.FastFeatureDetector.t()", %{image: image, opts: opts} do
+      detector = Evision.FastFeatureDetector.create(opts)
+      {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+      assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "cast from Evision.GFTTDetector.t()", %{image: image, opts: opts} do
+      detector = Evision.GFTTDetector.create(opts)
+      {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+      assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "cast from Evision.MSER.t()", %{image: image, opts: opts} do
+      detector = Evision.MSER.create(opts)
+      {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+      assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "cast from Evision.SimpleBlobDetector.t()", %{image: image, opts: opts} do
+      detector = Evision.SimpleBlobDetector.create(opts)
+      {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+      assert msg =~ "The function/feature is not implemented"
+    end
+  end
+end

--- a/test/evision_xfeatures2d_test.exs
+++ b/test/evision_xfeatures2d_test.exs
@@ -1,0 +1,82 @@
+defmodule Evision.Features2D.Test do
+  use ExUnit.Case
+
+  setup do
+    %Evision.Mat{} = image = Evision.imread(Path.join([__DIR__, "testdata", "back.jpg"]))
+    %{image: image}
+  end
+
+  describe "implicit cast to Evision.Features2D okay" do
+    test "from Evision.XFeatures2D.BEBLID.t()", %{image: image} do
+        detector = Evision.XFeatures2D.BEBLID.create(0.5)
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.BoostDesc.t()", %{image: image} do
+        detector = Evision.XFeatures2D.BoostDesc.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.BriefDescriptorExtractor.t()", %{image: image} do
+        detector = Evision.XFeatures2D.BriefDescriptorExtractor.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.DAISY.t()", %{image: image} do
+        detector = Evision.XFeatures2D.DAISY.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.FREAK.t()", %{image: image} do
+        detector = Evision.XFeatures2D.FREAK.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.LATCH.t()", %{image: image} do
+        detector = Evision.XFeatures2D.LATCH.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.LUCID.t()", %{image: image} do
+        detector = Evision.XFeatures2D.LUCID.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.MSDDetector.t()", %{image: image} do
+        detector = Evision.XFeatures2D.MSDDetector.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.StarDetector.t()", %{image: image} do
+        detector = Evision.XFeatures2D.StarDetector.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.TBMR.t()", %{image: image} do
+        detector = Evision.XFeatures2D.TBMR.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.TEBLID.t()", %{image: image} do
+        detector = Evision.XFeatures2D.TEBLID.create(1.0)
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+
+    test "from Evision.XFeatures2D.VGG.t()", %{image: image} do
+        detector = Evision.XFeatures2D.VGG.create()
+        {:error, msg} = Evision.Detail.computeImageFeatures2(detector, image)
+        assert msg =~ "The function/feature is not implemented"
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses the issue reported in #223. Now the following types can be implicitly cast to `Evision.Feature2D`:

- `Evision.AKAZE`
- `Evision.AffineFeature`
- `Evision.AgastFeatureDetector`
- `Evision.BRISK`
- `Evision.FastFeatureDetector`
- `Evision.GFTTDetector`
- `Evision.KAZE`
- `Evision.MSER`
- `Evision.ORB`
- `Evision.SimpleBlobDetector`
- `Evision.XFeatures2D.BEBLID`
- `Evision.XFeatures2D.BoostDesc`
- `Evision.XFeatures2D.BriefDescriptorExtractor`
- `Evision.XFeatures2D.DAISY`
- `Evision.XFeatures2D.FREAK`
- `Evision.XFeatures2D.LATCH`
- `Evision.XFeatures2D.LUCID`
- `Evision.XFeatures2D.MSDDetector`
- `Evision.XFeatures2D.StarDetector`
- `Evision.XFeatures2D.TBMR`
- `Evision.XFeatures2D.TEBLID`
- `Evision.XFeatures2D.VGG`