### PR TITLE
use nif version 2.16 for all builds

### DIFF
--- a/.github/workflows/linux-cuda-gnu.yml
+++ b/.github/workflows/linux-cuda-gnu.yml
@@ -76,13 +76,14 @@ jobs:
       # evision related env vars
       MIX_ENV: test
       OPENCV_VER: "4.9.0"
-      OTP_VERSION: "25.2"
-      ELIXIR_VERSION: "1.14.3"
+      OTP_VERSION: "25.3"
+      ELIXIR_VERSION: "1.16.1"
       EVISION_PREFER_PRECOMPILED: "false"
       EVISION_ENABLE_CUDA: "true"
       PKG_CONFIG_PATH: "/usr/lib/x86_64-linux-gnu/pkgconfig"
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/linux-precompile-cuda-gnu.yml
+++ b/.github/workflows/linux-precompile-cuda-gnu.yml
@@ -21,21 +21,11 @@ jobs:
             cuda_id: "118"
             OTP_VERSION: "25"
             NIF_VERSION: "2.16"
-          - container: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
-            cuda_ver: "11.8.0"
-            cuda_id: "118"
-            OTP_VERSION: "26"
-            NIF_VERSION: "2.17"
           - container: nvidia/cuda:12.1.0-cudnn8-devel-ubuntu20.04
             cuda_ver: "12.1.0"
             cuda_id: "121"
             OTP_VERSION: "25"
             NIF_VERSION: "2.16"
-          - container: nvidia/cuda:12.1.0-cudnn8-devel-ubuntu20.04
-            cuda_ver: "12.1.0"
-            cuda_id: "121"
-            OTP_VERSION: "26"
-            NIF_VERSION: "2.17"
 
     container: ${{ matrix.container }}
     env:

--- a/.github/workflows/linux-precompile-gnu.yml
+++ b/.github/workflows/linux-precompile-gnu.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       OPENCV_VER: "4.9.0"
       MIX_ENV: prod
-      ELIXIR_VERSION: "1.15.2"
+      ELIXIR_VERSION: "1.16.1"
       EVISION_PREFER_PRECOMPILED: "false"
       EVISION_GENERATE_LANG: "erlang,elixir"
     strategy:
@@ -71,55 +71,6 @@ jobs:
               cpp_compiler: g++-riscv64-linux-gnu
               OTP_VERSION: "25"
               NIF_VERSION: "2.16"
-          - pair:
-              arch: i686-linux-gnu
-              cmake_toolchain_file: cc_toolchain/i686-linux-gnu.cmake
-              c_compiler: gcc-i686-linux-gnu
-              cpp_compiler: g++-i686-linux-gnu
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
-          - pair:
-              arch: aarch64-linux-gnu
-              cmake_toolchain_file: cc_toolchain/aarch64-linux-gnu.cmake
-              c_compiler: gcc-aarch64-linux-gnu
-              cpp_compiler: g++-aarch64-linux-gnu
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
-          - pair:
-              arch: armv7l-linux-gnueabihf
-              cmake_toolchain_file: cc_toolchain/armv7l-linux-gnueabihf.cmake
-              c_compiler: gcc-arm-linux-gnueabihf
-              cpp_compiler: g++-arm-linux-gnueabihf
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
-          - pair:
-              arch: armv6-linux-gnueabihf
-              cmake_toolchain_file: cc_toolchain/armv6-nerves-linux-gnueabihf.cmake
-              c_compiler: armv6-nerves-linux-gnueabihf-gcc
-              cpp_compiler: armv6-nerves-linux-gnueabihf-g++
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
-          - pair:
-              arch: ppc64le-linux-gnu
-              cmake_toolchain_file: cc_toolchain/ppc64le-linux-gnu.cmake
-              c_compiler: gcc-powerpc64le-linux-gnu
-              cpp_compiler: g++-powerpc64le-linux-gnu
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
-          - pair:
-              arch: s390x-linux-gnu
-              cmake_toolchain_file: cc_toolchain/s390x-linux-gnu.cmake
-              c_compiler: gcc-s390x-linux-gnu
-              cpp_compiler: g++-s390x-linux-gnu
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
-          - pair:
-              arch: riscv64-linux-gnu
-              cmake_toolchain_file: cc_toolchain/riscv64-linux-gnu.cmake
-              c_compiler: gcc-riscv64-linux-gnu
-              cpp_compiler: g++-riscv64-linux-gnu
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
 
     steps:
       - name: Checkout

--- a/.github/workflows/linux-precompile-manylinux2014-gnu.yml
+++ b/.github/workflows/linux-precompile-manylinux2014-gnu.yml
@@ -30,16 +30,10 @@ jobs:
               OTP_VERSION: "25.3.2.8"
               NIF_VERSION: "2.16"
               ELIXIR_VERSION: "1.16.0"
-          - pair:
-              arch: x86_64-linux-gnu
-              cmake_toolchain_file: ""
-              c_compiler: gcc
-              cpp_compiler: g++
-              OTP_VERSION: "26.2.1"
-              NIF_VERSION: "2.17"
-              ELIXIR_VERSION: "1.16.0"
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Pull Docker Image
         run: |

--- a/.github/workflows/linux-precompile-musl.yml
+++ b/.github/workflows/linux-precompile-musl.yml
@@ -22,15 +22,14 @@ jobs:
       matrix:
         include:
           - pair: 
-              OTP_VERSION: "25.3.2.5"
+              OTP_VERSION: "25.3"
               NIF_VERSION: "2.16"
-              ELIXIR_VERSION: "1.15.4"
-          - pair: 
-              OTP_VERSION: "26.0.2"
-              NIF_VERSION: "2.17"
-              ELIXIR_VERSION: "1.15.4"
+              ELIXIR_VERSION: "1.16.1"
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Install system dependencies
         run: |
           apk add cmake make python3 bash curl unzip gcc g++ ncurses-dev openssl-dev linux-headers perl git dpkg patch
@@ -175,22 +174,12 @@ jobs:
               arch: aarch64-linux-musl
               OTP_VERSION: "25.3"
               NIF_VERSION: "2.16"
-              ELIXIR_VERSION: "1.14.3"
-          - pair:
-              arch: aarch64-linux-musl
-              OTP_VERSION: "26.0.2"
-              NIF_VERSION: "2.17"
-              ELIXIR_VERSION: "1.15.4"
+              ELIXIR_VERSION: "1.16.1"
           - pair:
               arch: riscv64-linux-musl
               OTP_VERSION: "25.3"
               NIF_VERSION: "2.16"
-              ELIXIR_VERSION: "1.14.3"
-          - pair:
-              arch: riscv64-linux-musl
-              OTP_VERSION: "26.0.2"
-              NIF_VERSION: "2.17"
-              ELIXIR_VERSION: "1.15.4"
+              ELIXIR_VERSION: "1.16.1"
 
     steps:
       - name: Checkout

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -66,7 +66,7 @@ jobs:
     env:
       MIX_ENV: test
       OPENCV_VER: "4.9.0"
-      OTP_VERSION: "26.2"
+      OTP_VERSION: "26.2.2"
       ELIXIR_VERSION: "1.16.1"
       EVISION_PREFER_PRECOMPILED: "false"
     steps:
@@ -76,8 +76,8 @@ jobs:
       - name: Install system dependencies
         run: |
           apk add cmake make python3 bash curl unzip gcc g++ ncurses-dev openssl-dev linux-headers perl git dpkg ca-certificates
-          curl -fSL "https://repo.uwucocoa.moe/pool/main/erlang_${OTP_VERSION}_musl-linux-amd64.deb" -o "erlang_${OTP_VERSION}_musl-linux-amd64.deb"
-          dpkg -i "erlang_${OTP_VERSION}_musl-linux-amd64.deb"
+          curl -fSL https://github.com/cocoa-xu/otp-build/releases/download/v${{ env.OTP_VERSION }}/otp-x86_64-linux-musl.tar.gz -o /tmp/otp-v${{ env.OTP_VERSION }}-x86_64-linux-musl.tar.gz
+          tar -xzf /tmp/otp-v${{ env.OTP_VERSION }}-x86_64-linux-musl.tar.gz -C /usr/local --strip-components=3
 
       - name: Install elixir
         run: |

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -66,11 +66,13 @@ jobs:
     env:
       MIX_ENV: test
       OPENCV_VER: "4.9.0"
-      OTP_VERSION: "25.2"
-      ELIXIR_VERSION: "1.14.3"
+      OTP_VERSION: "26.2"
+      ELIXIR_VERSION: "1.16.1"
       EVISION_PREFER_PRECOMPILED: "false"
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Install system dependencies
         run: |
           apk add cmake make python3 bash curl unzip gcc g++ ncurses-dev openssl-dev linux-headers perl git dpkg ca-certificates

--- a/.github/workflows/macos-apple-device-precompile.yml
+++ b/.github/workflows/macos-apple-device-precompile.yml
@@ -31,23 +31,11 @@ jobs:
               NIF_VERSION: "2.16"
               OTP_VERSION: "25.3.2.2"
               ELIXIR_VERSION: "1.16.0"
-          - pair:
-              mix_target: ios
-              arch_name: aarch64
-              NIF_VERSION: "2.17"
-              OTP_VERSION: "26.2.2"
-              ELIXIR_VERSION: "1.16.0"
           # - pair:
           #     mix_target: xros
           #     arch_name: aarch64
           #     NIF_VERSION: "2.16"
           #     OTP_VERSION: "25.3.2.2"
-          #     ELIXIR_VERSION: "1.16.0"
-          # - pair:
-          #     mix_target: xros
-          #     arch_name: aarch64
-          #     NIF_VERSION: "2.17"
-          #     OTP_VERSION: "26.2.2"
           #     ELIXIR_VERSION: "1.16.0"
 
     steps:

--- a/.github/workflows/macos-precompile.yml
+++ b/.github/workflows/macos-precompile.yml
@@ -26,29 +26,15 @@ jobs:
               arch: x86_64
               arch_name: x86_64
               NIF_VERSION: "2.16"
-              OTP_VERSION: "25.3.2.2"
-              ELIXIR_VERSION: "1.16.0"
+              OTP_VERSION: "25.3"
+              ELIXIR_VERSION: "1.16.1"
           - pair:
               os: macos-14
               arch: arm64
               arch_name: aarch64
               NIF_VERSION: "2.16"
-              OTP_VERSION: "25.3.2.2"
-              ELIXIR_VERSION: "1.16.0"
-          - pair:
-              os: macos-12
-              arch: x86_64
-              arch_name: x86_64
-              NIF_VERSION: "2.17"
-              OTP_VERSION: "26.2.2"
-              ELIXIR_VERSION: "1.16.0"
-          - pair:
-              os: macos-14
-              arch: arm64
-              arch_name: aarch64
-              NIF_VERSION: "2.17"
-              OTP_VERSION: "26.2.2"
-              ELIXIR_VERSION: "1.16.0"
+              OTP_VERSION: "25.3"
+              ELIXIR_VERSION: "1.16.1"
 
     steps:
       - name: Checkout

--- a/.github/workflows/windows-precompile-cuda.yml
+++ b/.github/workflows/windows-precompile-cuda.yml
@@ -35,12 +35,6 @@ jobs:
               cudnn: "8.7.0"
               OTP_VERSION: "25"
               NIF_VERSION: "2.16"
-          - pair:
-              cuda_ver: "11.8.0"
-              cuda_id: "118"
-              cudnn: "8.7.0"
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
 
     steps:
       - name: Checkout
@@ -133,12 +127,6 @@ jobs:
               cudnn: "8.9.0"
               OTP_VERSION: "25"
               NIF_VERSION: "2.16"
-          - pair:
-              cuda_ver: "12.1.0"
-              cuda_id: "121"
-              cudnn: "8.9.0"
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
 
     steps:
       - name: Checkout

--- a/.github/workflows/windows-precompile.yml
+++ b/.github/workflows/windows-precompile.yml
@@ -28,6 +28,8 @@ jobs:
               arch_name: aarch64
               msbuild_platform: ARM64
               vcvarsall: amd64_arm64
+              OTP_VERSION: "25"
+              NIF_VERSION: "2.16"
               CMAKE_GENERATOR_TYPE: "Visual Studio 17 2022"
               CMAKE_TOOLCHAIN_FILE: "cc_toolchain/aarch64-windows-msvc.cmake"
           - pair:
@@ -37,13 +39,6 @@ jobs:
               vcvarsall: x64
               OTP_VERSION: "25"
               NIF_VERSION: "2.16"
-          - pair:
-              arch: x64
-              arch_name: x86_64
-              msbuild_platform: x64
-              vcvarsall: x64
-              OTP_VERSION: "26"
-              NIF_VERSION: "2.17"
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changes
 - [nerves-build] use fwup v1.10.1
 - [precompiled] support `armv6-linux-gnueabihf` target
+- [precompiled] precompiled binaries are now built with Erlang/OTP NIF version 2.16, and they are compatible with NIF version 2.16 and later.
 
 ### Added
 - [experimental] support `aarch64-windows-msvc` target

--- a/do_release.sh
+++ b/do_release.sh
@@ -8,7 +8,7 @@ export MIX_ENV=docs
 export EVISION_PREFER_PRECOMPILED=true
 export EVISION_ENABLE_CUDA=true
 export EVISION_CUDA_VERSION=121
-export NIF_VERSION=2.17
+export NIF_VERSION=2.16
 export EVISION_VERSION="$(grep 'def version, do: "' mix.exs | grep -E -oh '(\d+).(\d+).(\d+)')"
 
 export TARBALL_FILENAME="evision-nif_${NIF_VERSION}-x86_64-linux-gnu-contrib-cuda${EVISION_CUDA_VERSION}-${EVISION_VERSION}.tar.gz"

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,10 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
 
   @compile_nif_version "2.16"
 
+  def get_available_nif_versions do
+    ["2.16", "2.17"]
+  end
+
   def available_nif_urls(_host_nif_version, version \\ Metadata.version()) do
     nif_version = get_compile_nif_version()
 


### PR DESCRIPTION
This PR should close #230. Precompiled binaries are now built with Erlang/OTP NIF version 2.16, and they are compatible with NIF version 2.16 and later.