### PR TITLE
feat: use Nx.tensor without converting the last dim as channels

### DIFF
--- a/c_src/evision_consts.h
+++ b/c_src/evision_consts.h
@@ -1,0 +1,84 @@
+#ifndef EVISION_CONSTS_H
+#pragma once
+
+#include <erl_nif.h>
+
+// nil
+static ERL_NIF_TERM kAtomNil;
+// true
+static ERL_NIF_TERM kAtomTrue;
+// false
+static ERL_NIF_TERM kAtomFalse;
+// out_of_memory
+static ERL_NIF_TERM kAtomOutOfMemory;
+// ref
+static ERL_NIF_TERM kAtomRef;
+// class
+static ERL_NIF_TERM kAtomClass;
+// dims
+static ERL_NIF_TERM kAtomDims;
+// channels
+static ERL_NIF_TERM kAtomChannels;
+// type
+static ERL_NIF_TERM kAtomType;
+// data
+static ERL_NIF_TERM kAtomData;
+// raw_type
+static ERL_NIF_TERM kAtomRawType;
+// elemSize
+static ERL_NIF_TERM kAtomElemSize;
+// shape
+static ERL_NIF_TERM kAtomShape;
+// __struct__
+static ERL_NIF_TERM kAtomStructKey;
+// Elixir.Nx.Tensor
+static ERL_NIF_TERM kAtomNxTensorModule;
+// nx_tensor (only for internal use)
+static ERL_NIF_TERM kAtomNxTensor;
+// Elixir.Nx.Tensor
+static ERL_NIF_TERM kAtomEvisionMatModule;
+
+// atoms for types
+static ERL_NIF_TERM kAtomU;
+static ERL_NIF_TERM kAtomS;
+static ERL_NIF_TERM kAtomF;
+static ERL_NIF_TERM kAtomU8;
+static ERL_NIF_TERM kAtomS8;
+static ERL_NIF_TERM kAtomU16;
+static ERL_NIF_TERM kAtomS16;
+static ERL_NIF_TERM kAtomU32;
+static ERL_NIF_TERM kAtomS32;
+static ERL_NIF_TERM kAtomU64;
+static ERL_NIF_TERM kAtomS64;
+static ERL_NIF_TERM kAtomF16;
+static ERL_NIF_TERM kAtomF32;
+static ERL_NIF_TERM kAtomF64;
+static ERL_NIF_TERM kAtomUser;
+
+// atoms for cv::Moments
+static ERL_NIF_TERM kAtomM00;
+static ERL_NIF_TERM kAtomM10;
+static ERL_NIF_TERM kAtomM01;
+static ERL_NIF_TERM kAtomM20;
+static ERL_NIF_TERM kAtomM11;
+static ERL_NIF_TERM kAtomM02;
+static ERL_NIF_TERM kAtomM30;
+static ERL_NIF_TERM kAtomM21;
+static ERL_NIF_TERM kAtomM12;
+static ERL_NIF_TERM kAtomM03;
+static ERL_NIF_TERM kAtomMu20;
+static ERL_NIF_TERM kAtomMu11;
+static ERL_NIF_TERM kAtomMu02;
+static ERL_NIF_TERM kAtomMu30;
+static ERL_NIF_TERM kAtomMu21;
+static ERL_NIF_TERM kAtomMu12;
+static ERL_NIF_TERM kAtomMu03;
+static ERL_NIF_TERM kAtomNu20;
+static ERL_NIF_TERM kAtomNu11;
+static ERL_NIF_TERM kAtomNu02;
+static ERL_NIF_TERM kAtomNu30;
+static ERL_NIF_TERM kAtomNu21;
+static ERL_NIF_TERM kAtomNu12;
+static ERL_NIF_TERM kAtomNu03;
+
+#endif  // EVISION_CONSTS_H

--- a/c_src/modules/evision_mat_api.h
+++ b/c_src/modules/evision_mat_api.h
@@ -2,20 +2,21 @@
 #define EVISION_MAT_API_H
 
 #include <erl_nif.h>
+#include "../evision_consts.h"
 
 static ERL_NIF_TERM __evision_get_mat_type(ErlNifEnv *env, int type) {
     uint8_t depth = type & CV_MAT_DEPTH_MASK;
 
     switch ( depth ) {
-        case CV_8U:  return enif_make_tuple2(env, evision::nif::atom(env, "u"), enif_make_uint64(env, 8));
-        case CV_8S:  return enif_make_tuple2(env, evision::nif::atom(env, "s"), enif_make_uint64(env, 8));
-        case CV_16U: return enif_make_tuple2(env, evision::nif::atom(env, "u"), enif_make_uint64(env, 16));
-        case CV_16S: return enif_make_tuple2(env, evision::nif::atom(env, "s"), enif_make_uint64(env, 16));
-        case CV_32S: return enif_make_tuple2(env, evision::nif::atom(env, "s"), enif_make_uint64(env, 32));
-        case CV_32F: return enif_make_tuple2(env, evision::nif::atom(env, "f"), enif_make_uint64(env, 32));
-        case CV_64F: return enif_make_tuple2(env, evision::nif::atom(env, "f"), enif_make_uint64(env, 64));
-        case CV_16F: return enif_make_tuple2(env, evision::nif::atom(env, "f"), enif_make_uint64(env, 16));
-        default:     return enif_make_tuple2(env, evision::nif::atom(env, "user"), enif_make_uint64(env, depth));
+        case CV_8U:  return enif_make_tuple2(env, kAtomU, enif_make_uint64(env, 8));
+        case CV_8S:  return enif_make_tuple2(env, kAtomS, enif_make_uint64(env, 8));
+        case CV_16U: return enif_make_tuple2(env, kAtomU, enif_make_uint64(env, 16));
+        case CV_16S: return enif_make_tuple2(env, kAtomS, enif_make_uint64(env, 16));
+        case CV_32S: return enif_make_tuple2(env, kAtomS, enif_make_uint64(env, 32));
+        case CV_32F: return enif_make_tuple2(env, kAtomF, enif_make_uint64(env, 32));
+        case CV_64F: return enif_make_tuple2(env, kAtomF, enif_make_uint64(env, 64));
+        case CV_16F: return enif_make_tuple2(env, kAtomF, enif_make_uint64(env, 16));
+        default:     return enif_make_tuple2(env, kAtomUser, enif_make_uint64(env, depth));
     }
 }
 
@@ -59,39 +60,39 @@ static ERL_NIF_TERM _evision_make_mat_resource_into_map(ErlNifEnv *env, const cv
     ERL_NIF_TERM keys[num_items];
     ERL_NIF_TERM values[num_items];
 
-    keys[item_index] = evision::nif::atom(env, "channels");
+    keys[item_index] = kAtomChannels;
     values[item_index] = enif_make_int(env, m.channels());
     item_index++;
 
-    keys[item_index] = evision::nif::atom(env, "dims");
+    keys[item_index] = kAtomDims;
     values[item_index] = enif_make_int(env, m.dims);
     item_index++;
 
-    keys[item_index] = evision::nif::atom(env, "type");
+    keys[item_index] = kAtomType;
     values[item_index] = _evision_get_mat_type(env, m);
     item_index++;
 
-    keys[item_index] = evision::nif::atom(env, "raw_type");
+    keys[item_index] = kAtomRawType;
     values[item_index] = enif_make_int(env, m.type());
     item_index++;
 
-    keys[item_index] = evision::nif::atom(env, "shape");
+    keys[item_index] = kAtomShape;
     values[item_index] = _evision_get_mat_shape(env, m);
     item_index++;
 
-    keys[item_index] = evision::nif::atom(env, "ref");
+    keys[item_index] = kAtomRef;
     values[item_index] = res_term;
     item_index++;
 
-    keys[item_index] = evision::nif::atom(env, "class");
-    values[item_index] = evision::nif::atom(env, "Elixir.Evision.Mat");
+    keys[item_index] = kAtomClass;
+    values[item_index] = kAtomEvisionMatModule;
     item_index++;
 
     ERL_NIF_TERM map;
     if (enif_make_map_from_arrays(env, keys, values, item_index, &map)) {
         return map;
     } else {
-        return evision::nif::atom(env, "error when making map from arrays");
+        return evision::nif::error(env, "error when making map from arrays");
     }
 }
 

--- a/c_src/nif_utils.hpp
+++ b/c_src/nif_utils.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include "evision_consts.h"
 
 namespace evision
 {
@@ -109,10 +110,7 @@ namespace evision
 
     ERL_NIF_TERM make(ErlNifEnv *env, bool var)
     {
-      if (var)
-        return atom(env, "true");
-
-      return atom(env, "false");
+        return var ? kAtomTrue : kAtomFalse;
     }
 
     ERL_NIF_TERM make(ErlNifEnv *env, long var)
@@ -262,21 +260,16 @@ namespace evision
 
     // Check if :nil
     int check_nil(ErlNifEnv *env, ERL_NIF_TERM term) {
-        std::string atom_str;
-        if (get_atom(env, term, atom_str) && atom_str == "nil") {
-            return true;
-        }
-        return false;
+      return enif_is_identical(term, kAtomNil);
     }
 
     // Boolean
 
     int get(ErlNifEnv *env, ERL_NIF_TERM term, bool *var)
     {
-      std::string bool_atom;
-      if (!get_atom(env, term, bool_atom))
+      if (!enif_is_atom(env, term))
         return 0;
-      *var = (bool_atom == "true");
+      *var = enif_is_identical(term, kAtomTrue);
       return 1;
     }
 

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -113,11 +113,11 @@ defmodule Evision.Mat do
 
   @type enum :: integer()
   @doc enum: true
-  def cv_MAGIC_VAL, do: 1124007936
+  def cv_MAGIC_VAL, do: 1_124_007_936
   @doc enum: true
   def cv_AUTO_STEP, do: 0
   @doc enum: true
-  def cv_MAGIC_MASK, do: 4294901760
+  def cv_MAGIC_MASK, do: 4_294_901_760
   @doc enum: true
   def cv_TYPE_MASK, do: 4095
   @doc enum: true
@@ -859,7 +859,7 @@ defmodule Evision.Mat do
   end
 
   def to_pointer(img, opts) when is_list(opts) do
-    opts = Keyword.validate!(opts || [], [mode: :local])
+    opts = Keyword.validate!(opts || [], mode: :local)
     img = from_struct(img)
     :evision_nif.mat_to_pointer([img: img] ++ opts)
   end
@@ -1960,6 +1960,7 @@ defmodule Evision.Mat do
   @spec to_binary(maybe_mat_in(), non_neg_integer()) :: binary() | {:error, String.t()}
   def to_binary(mat, limit \\ 0) when is_integer(limit) and limit >= 0 do
     mat = from_struct(mat)
+
     case mat do
       %{__struct__: :nx_tensor, data: data} when is_binary(data) ->
         if limit == 0 do
@@ -1967,6 +1968,7 @@ defmodule Evision.Mat do
         else
           :binary.part(data, 0, limit)
         end
+
       _ ->
         :evision_nif.mat_to_binary(img: mat, limit: limit)
     end

--- a/lib/evision_structurise.ex
+++ b/lib/evision_structurise.ex
@@ -65,7 +65,7 @@ defmodule Evision.Internal.Structurise do
 
   # specialised for Evision.Backend
   @spec from_struct(Nx.Tensor.t()) :: reference()
-  def from_struct(%Nx.Tensor{data: %Evision.Backend{ref: mat=%Evision.Mat{ref: ref}}}) do
+  def from_struct(%Nx.Tensor{data: %Evision.Backend{ref: %Evision.Mat{ref: ref}}}) do
     ref
   end
 

--- a/lib/evision_structurise.ex
+++ b/lib/evision_structurise.ex
@@ -63,26 +63,21 @@ defmodule Evision.Internal.Structurise do
     atom
   end
 
-  # specialised for Nx.BinaryBackend
+  # specialised for Evision.Backend
   @spec from_struct(Nx.Tensor.t()) :: reference()
-  def from_struct(%Nx.Tensor{data: %Nx.BinaryBackend{}} = tensor) do
+  def from_struct(%Nx.Tensor{data: %Evision.Backend{ref: mat=%Evision.Mat{ref: ref}}}) do
+    ref
+  end
+
+  # for generic Nx.Tensor
+  @spec from_struct(Nx.Tensor.t()) :: reference()
+  def from_struct(%Nx.Tensor{} = tensor) do
     %{
       tensor
       | data: Nx.to_binary(tensor),
         type: to_compact_type(tensor.type),
         __struct__: :nx_tensor
     }
-  end
-
-  @spec from_struct(Nx.Tensor.t()) :: reference()
-  def from_struct(%Nx.Tensor{} = tensor) do
-    case Evision.Mat.from_nx(tensor) do
-      {:error, msg} ->
-        raise RuntimeError, msg
-
-      %Evision.Mat{ref: ref} ->
-        ref
-    end
   end
 
   @spec from_struct(%{ref: reference()}) :: reference()

--- a/lib/evision_structurise.ex
+++ b/lib/evision_structurise.ex
@@ -46,6 +46,28 @@ defmodule Evision.Internal.Structurise do
 
   def to_struct_ok(pass_through), do: {:ok, pass_through}
 
+  def to_compact_type({:u, 8}), do: :u8
+  def to_compact_type({:u, 16}), do: :u16
+  def to_compact_type({:u, 32}), do: :u32
+  def to_compact_type({:u, 64}), do: :u64
+  def to_compact_type({:s, 8}), do: :s8
+  def to_compact_type({:s, 16}), do: :s16
+  def to_compact_type({:s, 32}), do: :s32
+  def to_compact_type({:s, 64}), do: :s64
+  def to_compact_type({:f, 32}), do: :f32
+  def to_compact_type({:f, 64}), do: :f64
+  def to_compact_type({:c, 32}), do: :c32
+  def to_compact_type({:c, 64}), do: :c64
+  def to_compact_type(atom) when is_atom(atom) do
+    atom
+  end
+
+  # specialised for Nx.BinaryBackend
+  @spec from_struct(Nx.Tensor.t()) :: reference()
+  def from_struct(%Nx.Tensor{data: %Nx.BinaryBackend{}} = tensor) do
+    %{tensor | data: Nx.to_binary(tensor), type: to_compact_type(tensor.type), __struct__: :nx_tensor}
+  end
+
   @spec from_struct(Nx.Tensor.t()) :: reference()
   def from_struct(%Nx.Tensor{} = tensor) do
     case Evision.Mat.from_nx(tensor) do

--- a/lib/evision_structurise.ex
+++ b/lib/evision_structurise.ex
@@ -58,6 +58,7 @@ defmodule Evision.Internal.Structurise do
   def to_compact_type({:f, 64}), do: :f64
   def to_compact_type({:c, 32}), do: :c32
   def to_compact_type({:c, 64}), do: :c64
+
   def to_compact_type(atom) when is_atom(atom) do
     atom
   end
@@ -65,7 +66,12 @@ defmodule Evision.Internal.Structurise do
   # specialised for Nx.BinaryBackend
   @spec from_struct(Nx.Tensor.t()) :: reference()
   def from_struct(%Nx.Tensor{data: %Nx.BinaryBackend{}} = tensor) do
-    %{tensor | data: Nx.to_binary(tensor), type: to_compact_type(tensor.type), __struct__: :nx_tensor}
+    %{
+      tensor
+      | data: Nx.to_binary(tensor),
+        type: to_compact_type(tensor.type),
+        __struct__: :nx_tensor
+    }
   end
 
   @spec from_struct(Nx.Tensor.t()) :: reference()

--- a/py_src/fixes.py
+++ b/py_src/fixes.py
@@ -180,7 +180,7 @@ def evision_elixir_module_fixes():
     case bboxes.shape do
       {_, 4} ->
         positional = [
-          bboxes: Evision.Mat.to_binary(Evision.Internal.Structurise.from_struct(bboxes)),
+          bboxes: Evision.Mat.to_binary(bboxes),
           scores: Evision.Internal.Structurise.from_struct(scores),
           score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
           nms_threshold: Evision.Internal.Structurise.from_struct(nms_threshold)
@@ -257,7 +257,7 @@ def evision_elixir_module_fixes():
             raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
-          bboxes: Evision.Mat.to_binary(Evision.Internal.Structurise.from_struct(bboxes)),
+          bboxes: Evision.Mat.to_binary(bboxes),
           scores: Evision.Internal.Structurise.from_struct(scores),
           score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
           nms_threshold: Evision.Internal.Structurise.from_struct(nms_threshold)
@@ -341,7 +341,7 @@ def evision_elixir_module_fixes():
               raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
-          bboxes: Evision.Mat.to_binary(Evision.Internal.Structurise.from_struct(bboxes)),
+          bboxes: Evision.Mat.to_binary(bboxes),
           scores: Evision.Internal.Structurise.from_struct(scores),
           class_ids: Evision.Internal.Structurise.from_struct(class_ids),
           score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
@@ -424,7 +424,7 @@ def evision_elixir_module_fixes():
               raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
-          bboxes: Evision.Mat.to_binary(Evision.Internal.Structurise.from_struct(bboxes)),
+          bboxes: Evision.Mat.to_binary(bboxes),
           scores: Evision.Internal.Structurise.from_struct(scores),
           class_ids: Evision.Internal.Structurise.from_struct(class_ids),
           score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
@@ -515,7 +515,7 @@ def evision_elixir_module_fixes():
               raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
-          bboxes: Evision.Mat.to_binary(Evision.Internal.Structurise.from_struct(bboxes)),
+          bboxes: Evision.Mat.to_binary(bboxes),
           scores: Evision.Internal.Structurise.from_struct(scores),
           score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
           nms_threshold: Evision.Internal.Structurise.from_struct(nms_threshold)
@@ -603,7 +603,7 @@ def evision_elixir_module_fixes():
               raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
-          bboxes: Evision.Mat.to_binary(Evision.Internal.Structurise.from_struct(bboxes)),
+          bboxes: Evision.Mat.to_binary(bboxes),
           scores: Evision.Internal.Structurise.from_struct(scores),
           score_threshold: Evision.Internal.Structurise.from_struct(score_threshold),
           nms_threshold: Evision.Internal.Structurise.from_struct(nms_threshold)

--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -725,6 +725,7 @@ class BeamWrapperGenerator(object):
         }
 
         num_total_modules = sum([len(components) for s, components in all_modules.items()])
+        self.code_funcs.write('#include "evision_consts.h"\n')
         self.code_funcs.write("static ERL_NIF_TERM evision_cv_enabled_modules(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]){\n")
         self.code_funcs.write(f"""    const size_t num_total_modules = {num_total_modules};
     size_t index = 0;
@@ -737,9 +738,9 @@ class BeamWrapperGenerator(object):
             for component in components:
                 self.code_funcs.write(f"""    keys[index] = evision::nif::atom(env, "{component}");
 #ifdef HAVE_OPENCV_{component.upper()}
-    values[index] = evision::nif::atom(env, "true");
+    values[index] = kAtomTrue;
 #else
-    values[index] = evision::nif::atom(env, "false");
+    values[index] = kAtomFalse;
 #endif
     index++;
 """)

--- a/test/evision_mat_test.exs
+++ b/test/evision_mat_test.exs
@@ -4,6 +4,19 @@ defmodule Evision.Mat.Test do
   alias Evision.Mat
 
   @tag :nx
+  test "use Nx.tensor without calling last_dim_as_channel" do
+    v = Nx.broadcast(Nx.tensor(1.0, type: :f64), {120, 120, 3})
+
+    assert %Evision.Mat{
+             channels: 3,
+             dims: 2,
+             type: {:f, 64},
+             raw_type: 22,
+             shape: {120, 120, 3}
+           } = Evision.gaussianBlur(v, {31, 31}, 0)
+  end
+
+  @tag :nx
   test "load an image from file and convert to Nx.tensor" do
     %Mat{} = mat = Evision.imread(Path.join([__DIR__, "testdata", "test.png"]))
 

--- a/test/pca_test.exs
+++ b/test/pca_test.exs
@@ -13,25 +13,19 @@ defmodule Evision.PCA.Test do
 
     %Mat{} =
       src =
-      Evision.line(src, {px, py}, {qx, qy}, colour,
-        thickness: 1
-      )
+      Evision.line(src, {px, py}, {qx, qy}, colour, thickness: 1)
 
     px = trunc(qx + 9 * :math.cos(angle + :math.pi() / 4))
     py = trunc(qy + 9 * :math.sin(angle + :math.pi() / 4))
 
     %Mat{} =
       src =
-      Evision.line(src, {px, py}, {qx, qy}, colour,
-        thickness: 1
-      )
+      Evision.line(src, {px, py}, {qx, qy}, colour, thickness: 1)
 
     px = trunc(qx + 9 * :math.cos(angle - :math.pi() / 4))
     py = trunc(qy + 9 * :math.sin(angle - :math.pi() / 4))
 
-    Evision.line(src, {px, py}, {qx, qy}, colour,
-      thickness: 1
-    )
+    Evision.line(src, {px, py}, {qx, qy}, colour, thickness: 1)
   end
 
   @tag :nx


### PR DESCRIPTION
This PR should address #250 and #248.

### Before
```elixir
iex> v = Nx.broadcast(Nx.tensor(1.0, type: :f64), {120, 120, 3})
iex> Evision.gaussianBlur(v, {31, 31}, 0)
{:error,
 "OpenCV(4.10.0) /Users/runner/work/evision/evision/3rd_party/opencv/opencv-4.10.0/modules/core/src/matrix.cpp:1099: error: (-215:Assertion failed) dims <= 2 && step[0] > 0 in function 'locateROI'\n"}
```

### After

```elixir
iex> v = Nx.broadcast(Nx.tensor(1.0, type: :f64), {120, 120, 3})
iex> Evision.gaussianBlur(v, {31, 31}, 0)
%Evision.Mat{
  channels: 3,
  dims: 2,
  type: {:f, 64},
  raw_type: 22,
  shape: {120, 120, 3},
  ref: #Reference<0.542551177.3596484632.178098>
}
```