### PR TITLE
manually adds `flann/defines.h` to the header list

### DIFF
--- a/c_src/evision_custom_headers/evision_flann.hpp
+++ b/c_src/evision_custom_headers/evision_flann.hpp
@@ -2,17 +2,17 @@
 typedef cvflann::flann_distance_t cvflann_flann_distance_t;
 typedef cvflann::flann_algorithm_t cvflann_flann_algorithm_t;
 
-template<>
-ERL_NIF_TERM evision_from(ErlNifEnv *env, const cvflann_flann_algorithm_t& value)
-{
-    return enif_make_int(env, int(value));
-}
+// template<>
+// ERL_NIF_TERM evision_from(ErlNifEnv *env, const cvflann_flann_algorithm_t& value)
+// {
+//     return enif_make_int(env, int(value));
+// }
 
-template<>
-ERL_NIF_TERM evision_from(ErlNifEnv *env, const cvflann_flann_distance_t& value)
-{
-    return enif_make_int(env, int(value));
-}
+// template<>
+// ERL_NIF_TERM evision_from(ErlNifEnv *env, const cvflann_flann_distance_t& value)
+// {
+//     return enif_make_int(env, int(value));
+// }
 
 template<>
 bool evision_to(ErlNifEnv *env, ERL_NIF_TERM o, cv::flann::IndexParams& p, const ArgInfo& info)
@@ -77,12 +77,12 @@ bool evision_to(ErlNifEnv *env, ERL_NIF_TERM obj, cv::flann::SearchParams & valu
     return evision_to<cv::flann::IndexParams>(env, obj, value, info);
 }
 
-template<>
-bool evision_to(ErlNifEnv *env, ERL_NIF_TERM o, cvflann::flann_distance_t& dist, const ArgInfo& info)
-{
-    int d = (int)dist;
-    bool ok = evision_to(env, o, d, info);
-    dist = (cvflann::flann_distance_t)d;
-    return ok;
-}
+// template<>
+// bool evision_to(ErlNifEnv *env, ERL_NIF_TERM o, cvflann::flann_distance_t& dist, const ArgInfo& info)
+// {
+//     int d = (int)dist;
+//     bool ok = evision_to(env, o, d, info);
+//     dist = (cvflann::flann_distance_t)d;
+//     return ok;
+// }
 #endif

--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -179,10 +179,22 @@ class BeamWrapperGenerator(object):
 
     def add_const(self, name, decl, original_name=None):
         (module_name, erl_const_name) = name.split('.')[-2:]
+        
+        if original_name.startswith('cvflann.'):
+            original_name = original_name.replace('cvflann.', 'cv.flann.')
+            name = name.replace('cvflann.', 'cv.flann.')
+            
+            if original_name == 'cv.flann.flann_algorithm_t':
+                if not name.startswith('cv.flann.FLANN_INDEX_'):
+                    return
+            if original_name == 'cv.flann.flann_centers_init_t':
+                if not name.startswith('cv.flann.FLANN_CENTERS_'):
+                    return
+            if original_name == 'cv.flann.flann_distance_t':
+                if not name.startswith('cv.flann.FLANN_DIST_'):
+                    return
+
         if original_name is not None:
-            if original_name.startswith('cvflann.'):
-                original_name = original_name.replace('cvflann.', 'cv.flann.')
-                name = name.replace('cvflann.', 'cv.flann.')
             if not original_name.startswith('cv.'):
                 print(f'warning: enum name {original_name} does not start with `cv.`')
                 sys.exit(-1)
@@ -236,11 +248,11 @@ class BeamWrapperGenerator(object):
                         'fisheye': 'Evision.FishEye',
                         'ft': 'Evision.Ft',
                         'flann': 'Evision.Flann',
-                        'flann.flann_algorithm_t': 'Evision.Flann.FlannAlgorithm',
-                        'flann.flann_centers_init_t': 'Evision.Flann.FlannCentersInit',
-                        'flann.flann_log_level_t': 'Evision.Flann.FlannLogLevel',
-                        'flann.flann_distance_t': 'Evision.Flann.FlannDistance',
-                        'flann.flann_datatype_t': 'Evision.Flann.FlannDatatype',
+                        'flann.flann_algorithm_t': 'Evision.Flann.Algorithm',
+                        'flann.flann_centers_init_t': 'Evision.Flann.CentersInit',
+                        'flann.flann_log_level_t': 'Evision.Flann.LogLevel',
+                        'flann.flann_distance_t': 'Evision.Flann.Distance',
+                        'flann.flann_datatype_t': 'Evision.Flann.Datatype',
                         'kinfu.VolumeType': 'Evision.KinFu.VolumeType',
                         'mcc.TYPECHART': 'Evision.MCC.TYPECHART',
                         'ml.LogisticRegression.Methods': 'Evision.ML.LogisticRegression.Methods',
@@ -396,8 +408,6 @@ class BeamWrapperGenerator(object):
         const_decls = decl[3]
         for decl in const_decls:
             enum_name = decl[0].replace("const ", "").strip()
-            if 'kdtree' in enum_name.lower():
-                print(enum_name, decl)
             self.add_const(enum_name, decl, original_name=original_name)
 
     def add_func(self, decl):
@@ -796,8 +806,6 @@ class BeamWrapperGenerator(object):
         # step 1: scan the headers and build more descriptive maps of classes, consts, functions
         for hdr in srcfiles:
             decls = self.parser.parse(hdr)
-            if 'flann' in hdr:
-                print(hdr)
             if len(decls) == 0:
                 continue
 


### PR DESCRIPTION
This PR should allow the binding code generator to parse and generate flann-related enums.

It checks if `modules/flann/include/opencv2/flann.hpp` is in the header list, if so (which indicates the user compiles OpenCV with the flann module), it will add `modules/flann/include/opencv2/flann/defines.h` to the list (if exists, just in case the file is removed or renamed in the future versions of OpenCV).

This should include the following enums and place them in the corresponding modules.

- `flann_algorithm_t`
- `flann_centers_init_t`
- `flann_log_level_t`
- `flann_distance_t`
- `flann_datatype_t`

~For example, `flann_algorithm_t` will be put in `Evision.Flann.FlannAlgorithm`:~

Actually `Evision.Flann.FlannAlgorithm` sounds too wordy lets just remove the prefixed `Flann` in the module name, so it becomes `Evision.Flann.Algorithm`.

Also, let's not add deprecated ones for each of these enums. (See https://github.com/opencv/opencv/blob/39a7b3d1869d31df92029503b9a8670071eac596/modules/flann/include/opencv2/flann/defines.h#L82)

```elixir
defmodule Evision.Flann.Algorithm do
  @type enum :: integer()
  @doc enum: true
  def cv_FLANN_INDEX_LINEAR, do: 0
  @doc enum: true
  def cv_FLANN_INDEX_KDTREE, do: 1
  @doc enum: true
  def cv_FLANN_INDEX_KMEANS, do: 2
  @doc enum: true
  def cv_FLANN_INDEX_COMPOSITE, do: 3
  @doc enum: true
  def cv_FLANN_INDEX_KDTREE_SINGLE, do: 4
  @doc enum: true
  def cv_FLANN_INDEX_HIERARCHICAL, do: 5
  @doc enum: true
  def cv_FLANN_INDEX_LSH, do: 6
  @doc enum: true
  def cv_FLANN_INDEX_SAVED, do: 254
  @doc enum: true
  def cv_FLANN_INDEX_AUTOTUNED, do: 255
end
```