### PR TITLE
Failing camera calibration test

### DIFF
--- a/test/evision_camera.exs
+++ b/test/evision_camera.exs
@@ -1,0 +1,39 @@
+defmodule Evision.Camera.Test do
+  use ExUnit.Case
+
+  describe "camera" do
+    test "calibration" do
+      img = Evision.imread(Path.join([__DIR__, "testdata", "test-circle-grid.jpg"]))
+      gray = Evision.cvtColor(img, Evision.Constant.cv_COLOR_BGR2GRAY())
+      pattern_size = {12, 8}
+      square_size = 0.012
+      corners = Evision.findCirclesGrid(gray, pattern_size)
+      assert is_struct(corners, Evision.Mat)
+
+      obj_points = generate_object_points(pattern_size, square_size)
+      img_points = [corners]
+
+      {height, width, _} = Evision.Mat.shape(img)
+      image_size = {width, height}
+
+      {ret, camera_matrix, dist_coeffs, _rvecs, _tvecs} =
+        Evision.calibrateCamera(
+          objectPoints: [obj_points],
+          imagePoints: img_points,
+          imageSize: image_size
+        )
+    end
+
+    defp generate_object_points({rows, cols}, square_size) do
+      points =
+        for i <- 0..(rows - 1), j <- 0..(cols - 1) do
+          x = j * square_size
+          y = i * square_size
+          z = 0.0
+          [x, y, z]
+        end
+
+      List.flatten(points) |> Enum.chunk_every(3)
+    end
+  end
+end


### PR DESCRIPTION
Hi!

I made a test for camera calibration that fails.
Hoped you maybe knew what I was sending in that might be incorrect?

Stacktrace is currently:

```elixir
** (ArgumentError) argument error
     code: Evision.calibrateCamera(
     stacktrace:
       (evision 0.2.13) :evision_nif.calibrateCamera([imageSize: {816, 612}, imagePoints: [#Reference<0.2028425594.2489450544.188643>], objectPoints: [[[0.0, 0.0, 0.0], [0.012, 0.0, 0.0], [0.024, 0.0, 0.0], [0.036000000000000004, 0.0, 0.0], [0.048, 0.0, 0.0], [0.06, 0.0, 0.0], [0.07200000000000001, 0.0, 0.0], [0.084, 0.0, 0.0], [0.0, 0.012, 0.0], [0.012, 0.012, 0.0], [0.024, 0.012, 0.0], [0.036000000000000004, 0.012, 0.0], [0.048, 0.012, 0.0], [0.06, 0.012, 0.0], [0.07200000000000001, 0.012, 0.0], [0.084, 0.012, 0.0], [0.0, 0.024, 0.0], [0.012, 0.024, 0.0], [0.024, 0.024, 0.0], [0.036000000000000004, 0.024, 0.0], [0.048, 0.024, 0.0], [0.06, 0.024, 0.0], [0.07200000000000001, 0.024, 0.0], [0.084, 0.024, 0.0], [0.0, 0.036000000000000004, 0.0], [0.012, 0.036000000000000004, 0.0], [0.024, 0.036000000000000004, 0.0], [0.036000000000000004, 0.036000000000000004, 0.0], [0.048, 0.036000000000000004, 0.0], [0.06, 0.036000000000000004, 0.0], [0.07200000000000001, 0.036000000000000004, 0.0], [0.084, 0.036000000000000004, 0.0], [0.0, 0.048, 0.0], [0.012, 0.048, 0.0], [0.024, 0.048, 0.0], [0.036000000000000004, 0.048, 0.0], [0.048, 0.048, 0.0], [0.06, 0.048, 0.0], [0.07200000000000001, 0.048, 0.0], [0.084, 0.048, 0.0], [0.0, 0.06, 0.0], [0.012, 0.06, 0.0], [0.024, 0.06, 0.0], [0.036000000000000004, 0.06, ...], [0.048, ...], [...], ...]]])
       (evision 0.2.13) lib/generated/evision.ex:6584: Evision.calibrateCamera/1
```