### PR TITLE
fix(Makefile): don't cp gen_python_config.json over itself when contrib=false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,9 @@ ifdef TARGET_GCC_FLAGS
 endif
 
 # evision
-OPENCV_HEADERS_TXT = $(CMAKE_OPENCV_BUILD_DIR)/modules/python_bindings_generator/headers.txt
+# OpenCV 4.13.0 produces one JSON config from CMake regardless of whether
+# contrib is enabled; the contrib variant just adds more entries.
+OPENCV_HEADERS_TXT = $(CMAKE_OPENCV_BUILD_DIR)/modules/python_bindings_generator/gen_python_config.json
 CONFIGURATION_PRIVATE_HPP = $(C_SRC)/configuration.private.hpp
 GENERATED_ELIXIR_SRC_DIR = $(LIB_SRC)/generated
 GENERATED_ERLANG_SRC_DIR = $(SRC)/generated
@@ -216,7 +218,9 @@ $(HEADERS_TXT): $(CONFIGURATION_PRIVATE_HPP)
 		else \
 			make -j$(DEFAULT_JOBS) ; \
 		fi && \
-		cp -f "$(CMAKE_OPENCV_BUILD_DIR)/modules/python_bindings_generator/gen_python_config.json" "$(HEADERS_TXT)" ; \
+		if [ "$(OPENCV_HEADERS_TXT)" != "$(HEADERS_TXT)" ]; then \
+			cp -f "$(OPENCV_HEADERS_TXT)" "$(HEADERS_TXT)" ; \
+		fi \
 	fi
 
 $(C_SRC_HEADERS_TXT): $(HEADERS_TXT)


### PR DESCRIPTION
## Summary
- When \`EVISION_ENABLE_CONTRIB=false\` the contrib-gated branch sets \`HEADERS_TXT\` to the same path as the unconditional \`OPENCV_HEADERS_TXT\` (\`gen_python_config.json\`), so the cp at the end of the OpenCV-build target was copying the file over itself and erroring out:

  \`\`\`
  cp: '.../gen_python_config.json' and '.../gen_python_config.json' are the same file
  make: *** [.../gen_python_config.json] Error 1
  \`\`\`
- Restore the original guard (\`if \$(OPENCV_HEADERS_TXT) != \$(HEADERS_TXT); then cp; fi\`) and update \`OPENCV_HEADERS_TXT\` from the stale \`headers.txt\` name to \`gen_python_config.json\`.

## Test plan
- [ ] CI green on the linux-cuda-gnu / non-contrib path that surfaced this
- [ ] Contrib-enabled path still copies and runs (no regression)