### PR TITLE
fix(macOS): rewrite Homebrew-hardcoded tesseract/leptonica paths in OpenCV dylibs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,19 @@ $(C_SRC_HEADERS_TXT): $(HEADERS_TXT)
 
 $(OPENCV_CONFIG_CMAKE):
 	@cd "$(CMAKE_OPENCV_BUILD_DIR)" && make install
+	@ if [ "$$(uname -s)" = "Darwin" ]; then \
+		echo "[+] post-install: relocating Homebrew-hardcoded dylib deps" ; \
+		for dylib in "$(PRIV_DIR)/lib/"libopencv_*.dylib; do \
+			[ -f "$$dylib" ] || continue ; \
+			otool -L "$$dylib" 2>/dev/null | awk '/\/opt\/homebrew\/opt\/(tesseract|leptonica)\// {print $$1}' \
+				| while read -r dep; do \
+					install_name_tool -change "$$dep" "@rpath/$$(basename "$$dep")" "$$dylib" 2>/dev/null || true ; \
+				done ; \
+			for rpath in /opt/homebrew/lib /usr/local/lib /opt/local/lib; do \
+				install_name_tool -add_rpath "$$rpath" "$$dylib" 2>/dev/null || true ; \
+			done ; \
+		done ; \
+	fi
 
 opencv: $(C_SRC_HEADERS_TXT)
 	@echo > /dev/null


### PR DESCRIPTION
## Summary
Fixes #287.

OpenCV builds \`libopencv_text.dylib\` (and similar) against Homebrew tesseract+leptonica, embedding \`/opt/homebrew/opt/{tesseract,leptonica}/lib/...\` as absolute LC_LOAD_DYLIB entries. \`evision.so\` then fails to load on any macOS that doesn't have Homebrew tesseract at that exact path — Intel brew at \`/usr/local\`, MacPorts at \`/opt/local\`, Nix store, etc.

After \`make install\`, walk \`priv/lib/libopencv_*.dylib\` and:
1. Rewrite any \`/opt/homebrew/opt/(tesseract|leptonica)/\` LOAD_DYLIB to \`@rpath/<basename>\`.
2. Add LC_RPATH entries for \`/opt/homebrew/lib\`, \`/usr/local/lib\`, \`/opt/local/lib\` so dyld finds the user's actual tesseract regardless of which install method they used.

Nix users (whose tesseract lives in \`/nix/store/...\`) can still resolve via \`DYLD_LIBRARY_PATH\` because the dep is now \`@rpath\`-relative, not absolute.

Linux/Windows skipped via \`uname -s\` guard; \`install_name_tool\`'s duplicate-rpath error swallowed via \`|| true\` (some libs already have one of these rpaths from OpenCV's own build).

## Verification
Tested on a local 4.13.0 build:

\`\`\`
before:  /opt/homebrew/opt/tesseract/lib/libtesseract.5.dylib
after:   @rpath/libtesseract.5.dylib
LC_RPATH: /opt/homebrew/lib, /usr/local/lib, /opt/local/lib (+ existing)
\`\`\`

## Test plan
- [ ] macOS CI green
- [ ] precompiled tarball produced from this commit loads on a machine without \`/opt/homebrew/opt/tesseract\`