### PR TITLE
docs(readme): macOS precompiled needs brew install tesseract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,19 @@ $(C_SRC_HEADERS_TXT): $(HEADERS_TXT)
 
 $(OPENCV_CONFIG_CMAKE):
 	@cd "$(CMAKE_OPENCV_BUILD_DIR)" && make install
+	@ if [ "$$(uname -s)" = "Darwin" ]; then \
+		echo "[+] post-install: relocating Homebrew-hardcoded dylib deps" ; \
+		for dylib in "$(PRIV_DIR)/lib/"libopencv_*.dylib; do \
+			[ -f "$$dylib" ] || continue ; \
+			otool -L "$$dylib" 2>/dev/null | awk '/\/opt\/homebrew\/opt\/(tesseract|leptonica)\// {print $$1}' \
+				| while read -r dep; do \
+					install_name_tool -change "$$dep" "@rpath/$$(basename "$$dep")" "$$dylib" 2>/dev/null || true ; \
+				done ; \
+			for rpath in /opt/homebrew/lib /usr/local/lib /opt/local/lib; do \
+				install_name_tool -add_rpath "$$rpath" "$$dylib" 2>/dev/null || true ; \
+			done ; \
+		done ; \
+	fi
 
 opencv: $(C_SRC_HEADERS_TXT)
 	@echo > /dev/null

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ The following environment variables can be set based on your needs.
 
 (Note that precompiled binaries do not use FFmpeg. If you'd like to use FFmpeg, please compile from source (please see instructions in the next section) and set corresponding environment variables. We're considering this option at the moment.)
 
+#### macOS: install Tesseract
+
+The precompiled macOS binaries link against [Tesseract](https://github.com/tesseract-ocr/tesseract) (and its dependency Leptonica) for OpenCV's `text`/OCR module. Tesseract is **not bundled** with the precompiled tarball, so it must be present on your system or `evision.so` will fail to load with a `Library not loaded: ...libtesseract.5.dylib` error — even if you never call any OCR functions, because dyld resolves the dependency graph eagerly at load time.
+
+Install with Homebrew:
+
+```sh
+brew install tesseract
+```
+
+evision searches `/opt/homebrew/lib`, `/usr/local/lib`, and `/opt/local/lib` for the Tesseract dylib at load time, so Homebrew (both Apple Silicon and Intel) and MacPorts work out of the box. For Nix or other custom prefixes, set `DYLD_LIBRARY_PATH` to the directory containing `libtesseract.5.dylib` before starting your application. See [#287](https://github.com/cocoa-xu/evision/issues/287) for details.
+
 <details>
 
 <summary>Advanced Options</summary>


### PR DESCRIPTION
## Summary
Adds a short note under \"Use Precompiled Library (Default)\" calling out that the macOS precompiled tarball doesn't bundle Tesseract/Leptonica, so users must \`brew install tesseract\` (or have it via MacPorts/Nix). Even non-OCR users hit this because dyld resolves the full dep graph at \`evision.so\` load time.

Also documents the LC_RPATH locations added by #300 (Homebrew Apple Silicon + Intel + MacPorts work out of the box; Nix/custom prefixes need \`DYLD_LIBRARY_PATH\`).

Refs #287.

## Test plan
- [x] Render preview in GitHub UI