### PR TITLE
ci: bust compiled-opencv cache when patches/** changes

### DIFF
--- a/.github/workflows/linux-cuda-gnu.yml
+++ b/.github/workflows/linux-cuda-gnu.yml
@@ -133,7 +133,7 @@ jobs:
         id: cache-mix-compile_opencv
         uses: actions/cache@v5
         with:
-          key: compiled-opencv-${{ env.OPENCV_VER }}-cuda${{ matrix.cuda_ver }}-x86_64-linux-gnu-${{ hashFiles('Makefile') }}
+          key: compiled-opencv-${{ env.OPENCV_VER }}-cuda${{ matrix.cuda_ver }}-x86_64-linux-gnu-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}-${{ hashFiles('patches/**') }}
           path: |
             ./_build/${{ env.MIX_ENV }}/lib/evision
             ./c_src/headers.txt

--- a/.github/workflows/linux-precompile-musl.yml
+++ b/.github/workflows/linux-precompile-musl.yml
@@ -80,7 +80,7 @@ jobs:
         id: cache-mix-compile_opencv
         uses: actions/cache@v5
         with:
-          key: precompiled-opencv-${{ env.OPENCV_VER }}-${{ runner.os }}-x86_64-linux-musl-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}
+          key: precompiled-opencv-${{ env.OPENCV_VER }}-${{ runner.os }}-x86_64-linux-musl-${{ hashFiles('cc_toolchain/**') }}-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}-${{ hashFiles('patches/**') }}
           path: |
             ./_build/${{ env.MIX_ENV }}/lib/evision
             ./c_src/headers.txt
@@ -240,7 +240,7 @@ jobs:
         id: cache-mix-compile_opencv
         uses: actions/cache@v5
         with:
-          key: precompiled-opencv-${{ env.OPENCV_VER }}-${{ matrix.pair.arch }}-${{ hashFiles('cc_toolchain/*linux-musl.cmake') }}-${{ hashFiles('cc_toolchain/zig.toolchain.cmake') }}-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}
+          key: precompiled-opencv-${{ env.OPENCV_VER }}-${{ matrix.pair.arch }}-${{ hashFiles('cc_toolchain/*linux-musl.cmake') }}-${{ hashFiles('cc_toolchain/zig.toolchain.cmake') }}-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}-${{ hashFiles('patches/**') }}
           path: |
             ./_build/${{ env.MIX_ENV }}/lib/evision
             ./c_src/headers.txt

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -130,7 +130,7 @@ jobs:
         id: cache-mix-compile_opencv
         uses: actions/cache@v5
         with:
-          key: compile-opencv-v${{ env.OPENCV_VER }}-x86_64-linux-musl-${{ hashFiles('Makefile') }}
+          key: compile-opencv-v${{ env.OPENCV_VER }}-x86_64-linux-musl-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}-${{ hashFiles('patches/**') }}
           path: |
             ./_build/${{ env.MIX_ENV }}/lib/evision
             ./c_src/headers.txt
@@ -224,7 +224,7 @@ jobs:
         id: cache-mix-compile_opencv
         uses: actions/cache@v5
         with:
-          key: compiled-opencv-${{ env.OPENCV_VER }}-x86_64-linux-gnu-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}
+          key: compiled-opencv-${{ env.OPENCV_VER }}-x86_64-linux-gnu-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}-${{ hashFiles('patches/**') }}
           path: |
             ./_build/${{ env.MIX_ENV }}/lib/evision
             ./c_src/headers.txt

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -119,7 +119,7 @@ jobs:
         id: cache-mix-compile_opencv
         uses: actions/cache@v5
         with:
-          key: compiled-with-ffmpeg${{ env.FFMPEG_VER }}-opencv-${{ env.OPENCV_VER }}-x86_64-apple-darwin-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}
+          key: compiled-with-ffmpeg${{ env.FFMPEG_VER }}-opencv-${{ env.OPENCV_VER }}-x86_64-apple-darwin-${{ hashFiles('Makefile') }}-${{ hashFiles('py_src/*.py') }}-${{ hashFiles('patches/**') }}
           path: |
             ./_build/${{ env.MIX_ENV }}/lib/evision
             ./c_src/headers.txt

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -108,7 +108,7 @@ jobs:
         id: cache-mix-compile
         uses: actions/cache@v5
         with:
-          key: compiled-opencv-${{ env.OPENCV_VER }}-x86_64-windows-msvc-${{ hashFiles('Makefile.win') }}-${{ hashFiles('py_src/*.py') }}
+          key: compiled-opencv-${{ env.OPENCV_VER }}-x86_64-windows-msvc-${{ hashFiles('Makefile.win') }}-${{ hashFiles('py_src/*.py') }}-${{ hashFiles('patches/**') }}
           path: |
             ./_build/${{ env.MIX_ENV }}/lib/evision
             ./c_src/gen_python_config.json


### PR DESCRIPTION
## Summary
The Windows (and several Linux) CI workflows cache the compiled OpenCV between runs to avoid the ~30-minute rebuild. The cache key hashes \`Makefile\` and \`py_src/*.py\` but **not** \`patches/**\`.

So when #296 added \`patch_ocr_tesseract_run_with_components\` (which injects \`runWithComponents\` into \`ocr.hpp\`), the cache continued to hit on the pre-patch OpenCV build, and the evision compile bombed with:

\`\`\`
error: 'runWithComponents' is not a member of 'cv::text::OCRTesseract'
\`\`\`

Add \`hashFiles('patches/**')\` to all six \`compiled-opencv\` / \`compile-opencv\` / \`precompiled-opencv\` keys:

- \`windows-x86_64.yml\`
- \`linux-precompile-musl.yml\` (×2 — musl + cross-arch)
- \`linux-x86_64.yml\` (×2 — musl + gnu; also added missing \`py_src/*.py\` to the musl one)
- \`linux-cuda-gnu.yml\`

Future patch changes (new patches, version-allowlist tweaks, etc.) will now correctly invalidate the cached OpenCV build.

## Test plan
- [ ] Windows CI green this time
- [ ] Other CI workflows still green (first run rebuilds OpenCV from scratch — slower; subsequent runs cache as expected)