### PR TITLE
fix: restore char-as-int args + properly exclude OCRTesseract tests

### DIFF
--- a/c_src/evision.cpp
+++ b/c_src/evision.cpp
@@ -3057,6 +3057,17 @@ static int convert_to_char(ErlNifEnv *env, ERL_NIF_TERM o, std::unique_ptr<std::
         buf.reset();
         return info.has_default || info.outputarg;
     }
+    // This converter backs both `char` and `c_string` argument types:
+    //   - `char` args (e.g. VideoWriter.fourcc's c1..c4) arrive as an
+    //     integer char code; store it as a one-character std::string so
+    //     the `char` call site can do buf->at(0).
+    //   - `c_string` args arrive as a string/binary; store it verbatim.
+    int i32;
+    if (evision::nif::get(env, o, &i32))
+    {
+        buf.reset(new std::string(1, static_cast<char>(i32)));
+        return 1;
+    }
     std::string str;
     if (evision::nif::get(env, o, str))
     {
@@ -3064,7 +3075,7 @@ static int convert_to_char(ErlNifEnv *env, ERL_NIF_TERM o, std::unique_ptr<std::
         return 1;
     }
     buf.reset();
-    return failmsg(env, "Expected single character string for argument '%s'", info.name);
+    return failmsg(env, "Expected an integer char code or a string for argument '%s'", info.name);
 }
 
 

--- a/test/ocr_tesseract_test.exs
+++ b/test/ocr_tesseract_test.exs
@@ -2,7 +2,7 @@ defmodule Evision.OCRTesseractTest do
   use ExUnit.Case
 
   @moduletag timeout: 120_000
-  @tag :require_tesseract
+  @moduletag :require_tesseract
 
   @test_image Path.join(__DIR__, "testdata/ocr_test.png")
 


### PR DESCRIPTION
## Summary
Two regressions on `main` surfaced by linux-x86_64 CI:

### 1. `convert_to_char` rejected integer char codes
PR #296 unified the `char` and `c_string` argument handlers into one `convert_to_char` that only accepts a string. But `char`-typed args (e.g. `VideoWriter.fourcc`'s `c1..c4`) arrive from the Elixir side as **integer char codes** — the generated guard is `-128 <= c1 <= 127`. The unified converter then failed:

```
(ArgumentError) :evision_nif.videoWriter_fourcc_static([c1: 109, c2: 112, c3: 52, c4: 118])
```

Fix: `convert_to_char` tries an integer first (stores as a 1-char `std::string` so the `char` call site's `buf->at(0)` works), then falls back to the string path for `c_string` args. Verified locally: `Evision.VideoWriter.fourcc(?m, ?p, ?4, ?v)` → `1983148141`.

### 2. `OCRTesseract.runWithComponents` test ran without tesseract
The test module used `@tag :require_tesseract`, which only applies to the **next** test. The second test (`runWithComponents`) was untagged and ran even when `require_tesseract` was excluded, failing on CI machines without tesseract. Changed to `@moduletag :require_tesseract` so it applies to every test in the module.

## Test plan
- [x] `Evision.VideoWriter.fourcc(?m, ?p, ?4, ?v)` returns correct fourcc int locally
- [x] `mix test test/ocr_tesseract_test.exs` — both tests now excluded when `require_tesseract` is excluded
- [ ] linux-x86_64 CI green (both `gnu` and `musl` jobs)