### PR TITLE
ci: support skip-ci label; default-skip nerves-build on PRs

### DIFF
--- a/.github/workflows/linux-cuda-gnu.yml
+++ b/.github/workflows/linux-cuda-gnu.yml
@@ -3,7 +3,7 @@ name: linux-cuda
 on:
   workflow_dispatch:
   pull_request:
-    types: [ labeled, synchronize, opened, reopened ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'assets/**'
       - '*.md'
@@ -58,7 +58,7 @@ concurrency:
 
 jobs:
   x86_64-gnu-cuda:
-    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'cuda') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') && (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'cuda')) }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -2,6 +2,7 @@ name: linux-x86_64
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'assets/**'
       - '*.md'
@@ -66,6 +67,7 @@ concurrency:
 
 jobs:
   musl:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-latest
     container: alpine:3.18.12
     env:
@@ -163,6 +165,7 @@ jobs:
           mix test --include require_downloading
 
   gnu:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-latest
     container: ubuntu:20.04
     env:

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -2,6 +2,7 @@ name: macos-x86_64
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'assets/**'
       - '*.md'
@@ -55,6 +56,7 @@ concurrency:
 
 jobs:
   mix_test:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: macos-15-intel
     env:
       OPENCV_VER: "4.13.0"

--- a/.github/workflows/nerves-build.yml
+++ b/.github/workflows/nerves-build.yml
@@ -2,6 +2,7 @@ name: nerves-build
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'assets/**'
       - '*.md'
@@ -54,6 +55,14 @@ concurrency:
 
 jobs:
   mix_compile:
+    # nerves-build is heavy and rarely affected by most PRs, so it is
+    # skipped on PRs by default. Add the `nerves-build` label to a PR to
+    # run it. push/tag/workflow_dispatch events always run it.
+    # The `skip-ci` label skips it everywhere, like the other workflows.
+    if: >-
+      ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci')
+          && (github.event_name != 'pull_request'
+              || contains(github.event.pull_request.labels.*.name, 'nerves-build')) }}
     runs-on: ubuntu-22.04
     env:
       MIX_ENV: prod

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -3,6 +3,7 @@ name: windows-x86_64
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'assets/**'
       - '*.md'
@@ -54,6 +55,7 @@ concurrency:
 
 jobs:
   mix_test:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: windows-2022
     env:
       MIX_ENV: test


### PR DESCRIPTION
## Summary
Two label-driven CI controls:

### `skip-ci` label
Adding the `skip-ci` label to a PR skips all PR-triggered CI jobs — `linux-x86_64` (musl + gnu), `macos-x86_64`, `windows-x86_64`, `linux-cuda-gnu`, `nerves-build` — via a job-level `if:` guard:

```yaml
if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
```

`push` / tag / `workflow_dispatch` events are unaffected — `github.event.pull_request` is null there, so the `contains()` is `false` and the job runs as normal.

### `nerves-build` becomes opt-in on PRs
`nerves-build` is heavy (13-target matrix) and rarely affected by most PRs, so it now **skips on PRs by default** and only runs when the PR carries the `nerves-build` label. `push` to `main`/`nerves-*`, tag pushes, and `workflow_dispatch` still always run it. `skip-ci` overrides everywhere.

### Trigger types
Each affected workflow's `pull_request` trigger gains `types: [opened, synchronize, reopened, labeled, unlabeled]` so adding/removing a label re-evaluates the job conditions without needing a new commit push.

`linux-cuda-gnu` already had a `cuda`-label gate; the `skip-ci` check is ANDed in front of it.

## Test plan
- [ ] Open a throwaway PR with `skip-ci` → all listed jobs show as skipped
- [ ] PR without `nerves-build` label → nerves-build skipped; add the label → it runs
- [ ] Normal PR (no labels) → everything except nerves-build runs as before
- [ ] Push to main → all workflows run as before