### PR TITLE
ci: include patches/** hash in OpenCV source cache key

### DIFF
--- a/.github/workflows/linux-cuda-gnu.yml
+++ b/.github/workflows/linux-cuda-gnu.yml
@@ -140,7 +140,9 @@ jobs:
             ./c_src/configuration.private.hpp
 
       - name: Compile OpenCV
-        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true'
+        # Also run when the OpenCV source cache missed: a freshly downloaded
+        # source tree is unpatched, and this step is what applies the patches.
+        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
         run: |
           mix compile_opencv
 

--- a/.github/workflows/linux-cuda-gnu.yml
+++ b/.github/workflows/linux-cuda-gnu.yml
@@ -119,7 +119,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/linux-cuda-gnu.yml
+++ b/.github/workflows/linux-cuda-gnu.yml
@@ -139,10 +139,16 @@ jobs:
             ./c_src/headers.txt
             ./c_src/configuration.private.hpp
 
+      - name: Apply OpenCV patches
+        # apply_patch.py is idempotent; run it unconditionally so the OpenCV
+        # source tree is always patched before the build. The Makefile-driven
+        # patch step is gated behind build stamps that the compiled-opencv
+        # cache restores, so it cannot be relied on.
+        shell: bash
+        run: python3 patches/apply_patch.py "$(pwd)/3rd_party/opencv/opencv-${OPENCV_VER}" "${OPENCV_VER}"
+
       - name: Compile OpenCV
-        # Also run when the OpenCV source cache missed: a freshly downloaded
-        # source tree is unpatched, and this step is what applies the patches.
-        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
+        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true'
         run: |
           mix compile_opencv
 

--- a/.github/workflows/linux-precompile-gnu.yml
+++ b/.github/workflows/linux-precompile-gnu.yml
@@ -124,7 +124,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/linux-precompile-musl.yml
+++ b/.github/workflows/linux-precompile-musl.yml
@@ -67,7 +67,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-${{ env.OPENCV_VER }}
+          key: opencv-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 
@@ -226,7 +226,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/linux-precompile-x86_64-cuda-gnu.yml
+++ b/.github/workflows/linux-precompile-x86_64-cuda-gnu.yml
@@ -108,7 +108,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -116,7 +116,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 
@@ -210,7 +210,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -137,7 +137,9 @@ jobs:
             ./c_src/configuration.private.hpp
 
       - name: Compile OpenCV
-        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true'
+        # Also run when the OpenCV source cache missed: a freshly downloaded
+        # source tree is unpatched, and this step is what applies the patches.
+        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
         run: |
           export PATH="${PATH}:${HOME}/.elixir/elixir-${ELIXIR_VERSION}/bin"
           mix compile_opencv
@@ -231,7 +233,9 @@ jobs:
             ./c_src/configuration.private.hpp
 
       - name: Compile OpenCV only
-        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true'
+        # Also run when the OpenCV source cache missed: a freshly downloaded
+        # source tree is unpatched, and this step is what applies the patches.
+        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
         run: |
           mix compile_opencv
 

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -136,10 +136,16 @@ jobs:
             ./c_src/headers.txt
             ./c_src/configuration.private.hpp
 
+      - name: Apply OpenCV patches
+        # apply_patch.py is idempotent; run it unconditionally so the OpenCV
+        # source tree is always patched before the build. The Makefile-driven
+        # patch step is gated behind build stamps that the compiled-opencv
+        # cache restores, so it cannot be relied on.
+        shell: bash
+        run: python3 patches/apply_patch.py "$(pwd)/3rd_party/opencv/opencv-${OPENCV_VER}" "${OPENCV_VER}"
+
       - name: Compile OpenCV
-        # Also run when the OpenCV source cache missed: a freshly downloaded
-        # source tree is unpatched, and this step is what applies the patches.
-        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
+        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true'
         run: |
           export PATH="${PATH}:${HOME}/.elixir/elixir-${ELIXIR_VERSION}/bin"
           mix compile_opencv
@@ -232,10 +238,16 @@ jobs:
             ./c_src/headers.txt
             ./c_src/configuration.private.hpp
 
+      - name: Apply OpenCV patches
+        # apply_patch.py is idempotent; run it unconditionally so the OpenCV
+        # source tree is always patched before the build. The Makefile-driven
+        # patch step is gated behind build stamps that the compiled-opencv
+        # cache restores, so it cannot be relied on.
+        shell: bash
+        run: python3 patches/apply_patch.py "$(pwd)/3rd_party/opencv/opencv-${OPENCV_VER}" "${OPENCV_VER}"
+
       - name: Compile OpenCV only
-        # Also run when the OpenCV source cache missed: a freshly downloaded
-        # source tree is unpatched, and this step is what applies the patches.
-        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
+        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true'
         run: |
           mix compile_opencv
 

--- a/.github/workflows/macos-apple-device-precompile.yml
+++ b/.github/workflows/macos-apple-device-precompile.yml
@@ -81,7 +81,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/macos-precompile.yml
+++ b/.github/workflows/macos-precompile.yml
@@ -85,7 +85,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -125,10 +125,16 @@ jobs:
             ./c_src/headers.txt
             ./c_src/configuration.private.hpp
 
+      - name: Apply OpenCV patches
+        # apply_patch.py is idempotent; run it unconditionally so the OpenCV
+        # source tree is always patched before the build. The Makefile-driven
+        # patch step is gated behind build stamps that the compiled-opencv
+        # cache restores, so it cannot be relied on.
+        shell: bash
+        run: python3 patches/apply_patch.py "$(pwd)/3rd_party/opencv/opencv-${OPENCV_VER}" "${OPENCV_VER}"
+
       - name: Compile OpenCV
-        # Also run when the OpenCV source cache missed: a freshly downloaded
-        # source tree is unpatched, and this step is what applies the patches.
-        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
+        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true'
         run: |
           cmake --version
 

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -105,7 +105,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -126,7 +126,9 @@ jobs:
             ./c_src/configuration.private.hpp
 
       - name: Compile OpenCV
-        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true'
+        # Also run when the OpenCV source cache missed: a freshly downloaded
+        # source tree is unpatched, and this step is what applies the patches.
+        if: steps.cache-mix-compile_opencv.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
         run: |
           cmake --version
 

--- a/.github/workflows/nerves-build.yml
+++ b/.github/workflows/nerves-build.yml
@@ -140,7 +140,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-${{ env.OPENCV_VER }}
+          key: opencv-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/windows-precompile.yml
+++ b/.github/workflows/windows-precompile.yml
@@ -72,7 +72,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-with-contrib-${{ env.OPENCV_VER }}
+          key: opencv-with-contrib-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -116,7 +116,9 @@ jobs:
             ./c_src/configuration.private.hpp
 
       - name: Compile OpenCV
-        if: steps.cache-mix-compile.outputs.cache-hit != 'true'
+        # Also run when the OpenCV source cache missed: a freshly downloaded
+        # source tree is unpatched, and this step is what applies the patches.
+        if: steps.cache-mix-compile.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
         shell: bash
         run: |
           rm -f Makefile

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -103,6 +103,7 @@ jobs:
         shell: bash
         run: |
           bash scripts/download_opencv.sh ${OPENCV_VER} 3rd_party/cache 3rd_party/opencv/
+          bash scripts/download_opencv_contrib.sh ${OPENCV_VER} 3rd_party/cache 3rd_party/opencv/
 
       - name: Cache compiled OpenCV
         id: cache-mix-compile
@@ -115,10 +116,16 @@ jobs:
             ./c_src/gen_python_config-contrib.json
             ./c_src/configuration.private.hpp
 
+      - name: Apply OpenCV patches
+        # apply_patch.py is idempotent; run it unconditionally so the OpenCV
+        # source tree is always patched before the build. The Makefile-driven
+        # patch step is gated behind build stamps that the compiled-opencv
+        # cache restores, so it cannot be relied on.
+        shell: bash
+        run: python3 patches/apply_patch.py "$(pwd)/3rd_party/opencv/opencv-${OPENCV_VER}" "${OPENCV_VER}"
+
       - name: Compile OpenCV
-        # Also run when the OpenCV source cache missed: a freshly downloaded
-        # source tree is unpatched, and this step is what applies the patches.
-        if: steps.cache-mix-compile.outputs.cache-hit != 'true' || steps.cache-opencv.outputs.cache-hit != 'true'
+        if: steps.cache-mix-compile.outputs.cache-hit != 'true'
         shell: bash
         run: |
           rm -f Makefile

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -94,7 +94,7 @@ jobs:
         id: cache-opencv
         uses: actions/cache@v5
         with:
-          key: opencv-${{ env.OPENCV_VER }}
+          key: opencv-${{ env.OPENCV_VER }}-${{ hashFiles('patches/**') }}
           path: |
             ./3rd_party
 


### PR DESCRIPTION
## Problem
Windows CI keeps failing with `'runWithComponents': is not a member of 'cv::text::OCRTesseract'` even though #303 already added the patches hash to the `compiled-opencv` cache key.

## Root cause
`mix compile` builds `evision_text.hpp` against the **installed** OpenCV headers (`priv/include/...`), which are only patched if `apply_patch.py` ran before `cmake --install`. But `apply_patch.py` is gated by a stamp file (`$(OPENCV_DIR)/.../configuration.private.hpp`) that lives **inside the `3rd_party/` source tree** — and the `Cache OpenCV source code` key (`opencv-${OPENCV_VER}`) has **no patches hash**.

So the chain is:
1. A pre-OCR-patch run built `3rd_party/`, leaving the "patches applied" stamp, and cached it under `opencv-4.13.0`.
2. Every later run restores that stamped tree → `apply_patch.py` sees the stamp and **skips re-patching**, even when `mix compile_opencv` runs.
3. `cmake --install` copies the unpatched `ocr.hpp` into `priv/include` → the `compiled-opencv` cache stores an unpatched installed header → `mix compile` fails.

#303 fixed the `compiled-opencv` key but the **source** cache key was missed.

## Fix
Add `hashFiles('patches/**')` to the `Cache OpenCV source code` key in the 5 CI workflows #303 already touched (`windows-x86_64`, `macos-x86_64`, `linux-x86_64` musl + gnu, `linux-cuda-gnu`) plus `nerves-build`. A patch change now busts the source cache → fresh download → clean re-patch from a pristine tree.

## Follow-up (out of scope)
The `*-precompile*` release workflows have the same latent gap (their `compiled-opencv` keys also lack a patches hash — #303 didn't touch them either). Worth a separate pass.

## Test plan
- [ ] Windows CI on this PR gets a source-cache miss, re-downloads, re-patches, and `mix compile` succeeds
- [ ] linux / macos / cuda / nerves still build