### PR TITLE
Fix aarch64-linux-musl precompile by disabling KleidiCV HAL

### DIFF
--- a/cc_toolchain/aarch64-linux-musl.cmake
+++ b/cc_toolchain/aarch64-linux-musl.cmake
@@ -7,6 +7,11 @@ set(TARGET_SYS aarch64-linux-musl)
 include(${CMAKE_CURRENT_LIST_DIR}/zig.toolchain.cmake)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
+# OpenCV's KleidiCV HAL passes `-march=armv8-a`, which `zig cc` rejects
+# (it parses the value as the unknown CPU `armv8`). NEON is baseline on
+# aarch64 anyway, so disable the HAL for this cross-compile target.
+set(WITH_KLEIDICV OFF CACHE BOOL "" FORCE)
+
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 


### PR DESCRIPTION
## Problem

The `linux-precompile-musl` workflow fails for the `aarch64-linux-musl` target ([failing run](https://github.com/cocoa-xu/evision/actions/runs/25848956472/job/75950606374)):

```
error: Unknown CPU: 'armv8'
make[3]: *** [hal/kleidicv/CMakeFiles/kleidicv_neon.dir/.../canny_neon.cpp.o] Error 1
```

OpenCV 4.13.0 added the **KleidiCV HAL**, whose CMake compiles its NEON sources with `-march=armv8-a`. The musl cross-builds use `zig cc`, which parses `armv8-a` as `-mcpu` syntax (CPU `armv8` minus feature `a`) and aborts on the unknown CPU name.

This only affects the musl (zig) builds — `aarch64-linux-gnu` uses real `gcc-aarch64-linux-gnu`, which accepts the flag, and riscv64-musl never enables KleidiCV.

## Fix

Disable `WITH_KLEIDICV` in the `aarch64-linux-musl` toolchain file. NEON is baseline on aarch64 and the carotene HAL still provides ARM acceleration (`Custom HAL: YES (carotene)`). Scoping it to the toolchain file keeps local cross-builds working too and invalidates the workflow's OpenCV build cache.

## Verification

Reproduced the exact `Unknown CPU: 'armv8'` failure in Docker (native arm64 host, zig 0.8.0 cross-compiling to aarch64-linux-musl), then ran all four CI build steps with the fix:

| Step | Result |
|---|---|
| Compile OpenCV (no contrib) | ✅ 100%, zero KleidiCV references |
| Mix compile (no contrib) | ✅ `evision.so` linked |
| Compile OpenCV (contrib) | ✅ 100% |
| Mix compile (contrib) | ✅ `evision.so` linked |