### PR TITLE
Fix Nerves rpi3/rpi3a/rpi0_2 build by gating carotene vcvtn* on AArch64

### DIFF
--- a/patches/apply_patch.py
+++ b/patches/apply_patch.py
@@ -165,6 +165,42 @@ typedef double float64_t;
             dst.truncate(0)
             dst.write(fixed.getvalue())
 
+
+def patch_carotene_vround(opencv_version: str, opencv_src_root: str):
+    """Gate carotene's ARMv8 round-to-nearest intrinsics on __aarch64__.
+
+    OpenCV's carotene HAL (hal/carotene/src/vround_helper.hpp) guards the
+    vcvtn* intrinsics with `__ARM_ARCH >= 8`. On 32-bit ARMv8 targets such as
+    Nerves rpi3/rpi3a/rpi0_2 (Cortex-A53 built for armv7hf) `__ARM_ARCH` is 8,
+    but GCC's AArch32 arm_neon.h does not provide vcvtn* at all, so the HAL
+    fails to compile. Restrict the fast path to AArch64; AArch32 keeps the
+    portable rounding fallback already present in the file.
+    """
+    vround_hpp = (
+        Path(opencv_src_root) / 'hal' / 'carotene' / 'src' / 'vround_helper.hpp'
+    )
+    if not vround_hpp.exists():
+        print(f"warning: {vround_hpp} not found, skipping patch_carotene_vround")
+        return
+
+    original = '#if defined(__ARM_ARCH) && (__ARM_ARCH >= 8)'
+    fixed = StringIO()
+    patched = 0
+    with open(vround_hpp, 'r') as source:
+        for line in source:
+            if line.strip() == original:
+                fixed.write('#if defined(__aarch64__) // patched\n')
+                patched += 1
+            else:
+                fixed.write(line)
+
+    if patched:
+        with open(vround_hpp, 'w') as dst:
+            dst.truncate(0)
+            dst.write(fixed.getvalue())
+        print(f"[+] patched carotene vround_helper.hpp ({patched} guards)")
+
+
 def patch_ocr_tesseract_run_with_components(opencv_version: str, opencv_src_root: str):
     """Add CV_WRAP runWithComponents() to OCRTesseract.
 
@@ -259,6 +295,7 @@ patches = [
     patch_rpath_linux,
     patch_python_bindings_generator,
     patch_intrin_rvv,
+    patch_carotene_vround,
     patch_imread,
     patch_cmake_minimum_version,
     patch_ocr_tesseract_run_with_components


### PR DESCRIPTION
## Problem

The `nerves-build` workflow fails on **rpi3 / rpi3a / rpi0_2** while compiling OpenCV 4.13.0's carotene HAL:

```
hal/carotene/src/vround_helper.hpp:61:12: error: 'vcvtnq_u32_f32' was not declared in this scope
```

## Root cause

`hal/carotene/src/vround_helper.hpp` gates the `vcvtn*` round-to-nearest NEON intrinsics with `#if defined(__ARM_ARCH) && (__ARM_ARCH >= 8)`.

The Nerves rpi3/rpi3a/rpi0_2 systems are Cortex-A53 built for **32-bit armv7hf**. `-mcpu=cortex-a53` makes GCC define `__ARM_ARCH = 8`, so the fast path is selected — but GCC's **AArch32** `arm_neon.h` does not provide `vcvtn*` at all. Verified with a GCC 13.3 cross-compiler that no `-march`/`-mfpu` combination exposes those intrinsics in 32-bit mode; they are AArch64-only in GCC. `__ARM_ARCH >= 8` is therefore the wrong test — ARMv8 does not imply the AArch64 intrinsic set.

Other matrix targets only showed as failed because `fail-fast` cancelled the matrix once rpi3 failed first:

| Targets | Arch | Status |
|---|---|---|
| rpi3, rpi3a, rpi0_2 | 32-bit ARMv8 (Cortex-A53), `__ARM_ARCH=8` | genuinely failed |
| rpi4, rpi5 | aarch64 | fine — `vcvtn*` is baseline |
| rpi2, bbb, osd32mp1, npi_imx6ull, grisp2 | ARMv7, `__ARM_ARCH=7` | fine — fallback path |
| rpi0, rpi, mangopi_mq_pro | ARMv6 / RISC-V | fine — no carotene NEON |

## Fix

New `patch_carotene_vround` step in `patches/apply_patch.py` rewrites the four guards to `#if defined(__aarch64__)`. AArch32 then uses the portable rounding fallback already present in the file; aarch64 targets (rpi4, rpi5) keep the fast path — no behavior change for any currently-passing target.

## Verification

With the Nerves rpi3 flags (`-mcpu=cortex-a53 -mfpu=neon -marm -mfloat-abi=hard`, GCC 13.3 cross-compiler):

- Reproduced the exact CI error on the unpatched source.
- All 6 carotene files that include `vround_helper.hpp` (`add_weighted`, `blur`, `colorconvert`, `convert_scale`, `div`, `phase`) compile cleanly after the patch.
- Patch function is idempotent (matters because CI caches `3rd_party/`); editing `patches/**` also invalidates the `opencv-` cache key, so the next run patches a freshly downloaded source.

This is an upstream OpenCV bug (`__ARM_ARCH >= 8` ≠ "AArch64 intrinsics available") and is worth reporting upstream as well.