### PR TITLE
fix: emit Evision.Flann.Algorithm and friends on OpenCV 4.13+

### DIFF
--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -47,18 +47,26 @@ if __name__ == "__main__":
             # etc.
             with open(args.headers, 'r') as f:
                 cfg = json.load(f)
-            srcfiles = cfg['headers']
+            srcfiles = list(cfg['headers'])
             preprocessor_definitions = cfg.get('preprocessor_definitions', {})
         else:
             srcfiles = []
             with open(args.headers, 'r') as f:
                 for l in f.readlines():
-                    l = l.strip()
-                    srcfiles.append(l)
-                    if l.endswith("modules/flann/include/opencv2/flann.hpp"):
-                        flann_defines = l.replace("modules/flann/include/opencv2/flann.hpp", "modules/flann/include/opencv2/flann/defines.h")
-                        if os.path.exists(flann_defines):
-                            srcfiles.append(flann_defines)
+                    srcfiles.append(l.strip())
+
+        # OpenCV's header list omits modules/flann/include/opencv2/flann/defines.h,
+        # but the cvflann enums (flann_algorithm_t, flann_distance_t,
+        # flann_centers_init_t) live there. pipeline.add_const() relies on
+        # them to emit Evision.Flann.Algorithm, Evision.Flann.CentersInit,
+        # and friends, so inject the file explicitly when flann.hpp is in
+        # the list.
+        for l in list(srcfiles):
+            if l.endswith("modules/flann/include/opencv2/flann.hpp"):
+                flann_defines = l.replace("modules/flann/include/opencv2/flann.hpp", "modules/flann/include/opencv2/flann/defines.h")
+                if os.path.exists(flann_defines) and flann_defines not in srcfiles:
+                    srcfiles.append(flann_defines)
+                break
     lang = []
     if len(args.lang) >= 5:
         lang = list(set([l.lower().strip() for l in args.lang.split(",")]))

--- a/test/evision_flann_test.exs
+++ b/test/evision_flann_test.exs
@@ -1,0 +1,71 @@
+defmodule Evision.Flann.Test do
+  use ExUnit.Case
+
+  # Regression coverage for the cvflann enums (PR #311). These constants
+  # live in modules/flann/include/opencv2/flann/defines.h, which OpenCV
+  # does not feed to the Python binding generator; gen2.py injects that
+  # header itself. A bug in the 4.13 upgrade dropped that injection on
+  # the new gen_python_config.json path and the modules below silently
+  # disappeared — so an explicit value check on each enum is what catches
+  # that regression.
+
+  describe "Evision.Flann.Algorithm (flann_algorithm_t)" do
+    test "FLANN_INDEX_* values match OpenCV's cvflann::flann_algorithm_t" do
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_LINEAR() == 0
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_KDTREE() == 1
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_KMEANS() == 2
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_COMPOSITE() == 3
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_KDTREE_SINGLE() == 4
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_HIERARCHICAL() == 5
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_LSH() == 6
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_SAVED() == 254
+      assert Evision.Flann.Algorithm.cv_FLANN_INDEX_AUTOTUNED() == 255
+    end
+  end
+
+  describe "Evision.Flann.CentersInit (flann_centers_init_t)" do
+    test "FLANN_CENTERS_* values match OpenCV's cvflann::flann_centers_init_t" do
+      assert Evision.Flann.CentersInit.cv_FLANN_CENTERS_RANDOM() == 0
+      assert Evision.Flann.CentersInit.cv_FLANN_CENTERS_GONZALES() == 1
+      assert Evision.Flann.CentersInit.cv_FLANN_CENTERS_KMEANSPP() == 2
+      assert Evision.Flann.CentersInit.cv_FLANN_CENTERS_GROUPWISE() == 3
+    end
+  end
+
+  describe "Evision.Flann.Distance (flann_distance_t)" do
+    test "FLANN_DIST_* values match OpenCV's cvflann::flann_distance_t" do
+      assert Evision.Flann.Distance.cv_FLANN_DIST_EUCLIDEAN() == 1
+      assert Evision.Flann.Distance.cv_FLANN_DIST_L2() == 1
+      assert Evision.Flann.Distance.cv_FLANN_DIST_MANHATTAN() == 2
+      assert Evision.Flann.Distance.cv_FLANN_DIST_L1() == 2
+      assert Evision.Flann.Distance.cv_FLANN_DIST_MINKOWSKI() == 3
+      assert Evision.Flann.Distance.cv_FLANN_DIST_MAX() == 4
+      assert Evision.Flann.Distance.cv_FLANN_DIST_HIST_INTERSECT() == 5
+    end
+  end
+
+  describe "Evision.Flann.LogLevel (flann_log_level_t)" do
+    test "FLANN_LOG_* values match OpenCV's cvflann::flann_log_level_t" do
+      assert Evision.Flann.LogLevel.cv_FLANN_LOG_NONE() == 0
+      assert Evision.Flann.LogLevel.cv_FLANN_LOG_FATAL() == 1
+      assert Evision.Flann.LogLevel.cv_FLANN_LOG_ERROR() == 2
+      assert Evision.Flann.LogLevel.cv_FLANN_LOG_WARN() == 3
+      assert Evision.Flann.LogLevel.cv_FLANN_LOG_INFO() == 4
+    end
+  end
+
+  describe "FlannBasedMatcher accepts the restored constants" do
+    test "create/1 with KDTREE index_params (the user-reported reproducer)" do
+      matcher =
+        Evision.FlannBasedMatcher.create(
+          indexParams: %{
+            "algorithm" => Evision.Flann.Algorithm.cv_FLANN_INDEX_KDTREE(),
+            "trees" => 5
+          },
+          searchParams: %{"checks" => 50}
+        )
+
+      assert %Evision.FlannBasedMatcher{} = matcher
+    end
+  end
+end


### PR DESCRIPTION
## Problem
In v0.2.16-pre, callers like \`Evision.Flann.Algorithm.cv_FLANN_INDEX_KDTREE()\` warn with \"module Evision.Flann.Algorithm is not available or is yet to be defined\" and fail at runtime. The whole \`Evision.Flann.Algorithm / CentersInit / LogLevel\` family is missing from the generated tree.

## Root cause
The cvflann enums (\`flann_algorithm_t\`, \`flann_distance_t\`, \`flann_centers_init_t\`) live in \`modules/flann/include/opencv2/flann/defines.h\`. OpenCV does **not** include that file in the header list it feeds to the Python binding generator, so \`py_src/gen2.py\` has long had a workaround that injects \`defines.h\` alongside any \`flann.hpp\` it sees in the header list.

The 4.13 upgrade switched the binding generator's input from a plain \`headers.txt\` to a \`gen_python_config.json\`, and the new JSON branch in \`gen2.py\` didn't carry the workaround. So 4.13 builds parse \`flann.hpp\` (no enums) and skip \`defines.h\` (where the enums are) — \`pipeline.add_const()\`'s \`cvflann.\` handling never sees the values, and \`Evision.Flann.Algorithm\` & friends are silently dropped.

## Fix
Hoist the \`defines.h\` injection out of the legacy branch so it runs for both the \`gen_python_config.json\` and \`headers.txt\` inputs.

## Verification
Ran \`gen2.py\` locally against the 4.13.0 config:

\`\`\`
$ ls /tmp/.../lib/ | grep flann
evision_flann.ex
evision_flann_algorithm.ex          # ← restored
evision_flann_centersinit.ex        # ← restored
evision_flann_datatype.ex
evision_flann_distance.ex           # ← restored
evision_flann_flannindextype.ex
evision_flann_index.ex
evision_flann_loglevel.ex           # ← restored
evision_flannbasedmatcher.ex

$ grep cv_FLANN_INDEX_KDTREE /tmp/.../lib/evision_flann_algorithm.ex
  def cv_FLANN_INDEX_KDTREE, do: 1
\`\`\`

## Test plan
- [ ] Reproducer project that calls \`Evision.Flann.Algorithm.cv_FLANN_INDEX_KDTREE()\` builds and runs against this branch
- [ ] CI green