### PR TITLE
fix: c_src correctness bugs and share read-only input matrices

### DIFF
--- a/c_src/ArgInfo.hpp
+++ b/c_src/ArgInfo.hpp
@@ -9,6 +9,7 @@ private:
     static const uint32_t arg_pathlike_flag      = 0x4;
     static const uint32_t arg_nd_mat_flag        = 0x8;
     static const uint32_t arg_has_default_flag   = 0x10;
+    static const uint32_t arg_input_only_flag    = 0x20;
 
 public:
     const char* name;
@@ -17,6 +18,11 @@ public:
     bool pathlike;
     bool nd_mat;
     bool has_default; // <- added in evision
+    // Pure read-only input. Set only by generated bindings, where the source
+    // matrix is guaranteed to be handed to OpenCV as a const InputArray. It
+    // lets converters share the source buffer instead of deep-copying it.
+    // Hand-written modules leave this unset and keep the safe copying default.
+    bool input_only;  // <- added in evision
     // more fields may be added if necessary
 
     ArgInfo(const char* name_, uint32_t arg_) :
@@ -25,7 +31,8 @@ public:
         arithm_op_src((arg_ & arg_arithm_op_src_flag) != 0),
         pathlike((arg_ & arg_pathlike_flag) != 0),
         nd_mat((arg_ & arg_nd_mat_flag) != 0),
-        has_default((arg_ & arg_has_default_flag) != 0) {}
+        has_default((arg_ & arg_has_default_flag) != 0),
+        input_only((arg_ & arg_input_only_flag) != 0) {}
 
 private:
     ArgInfo(const ArgInfo&) = delete;

--- a/c_src/erlcompat.hpp
+++ b/c_src/erlcompat.hpp
@@ -99,7 +99,7 @@ template<>                                                                      
 bool evision_to(ErlNifEnv *env, ERL_NIF_TERM dst, TYPE& src, const ArgInfo& info)                     \
 {                                                                                                     \
     int i32;                                                                                          \
-    if (!evision::nif::get(env, dst, &i32)) {                                                         \
+    if (evision::nif::get(env, dst, &i32)) {                                                          \
         src = static_cast<TYPE>(i32);                                                                 \
         return true;                                                                                  \
     } else {                                                                                          \

--- a/c_src/evision.cpp
+++ b/c_src/evision.cpp
@@ -519,10 +519,21 @@ static bool evision_to(ErlNifEnv *env, ERL_NIF_TERM o, Mat& m, const ArgInfo& in
     if (enif_get_resource(env, o, evision_res<cv::Mat *>::type, (void **)&in_res))
     {
         if (in_res->val) {
-            // should we copy the matrix?
-            // probably yes so that the original matrix is not modified
-            // because erlang/elixir users would expect that the original matrix to be unchanged
-            in_res->val->copyTo(m);
+            // By default the source matrix is deep-copied, so the caller's
+            // (immutable) matrix is never modified -- even if this NIF writes
+            // to the argument in place.
+            //
+            // `input_only` is set only by generated bindings, where the matrix
+            // is passed to OpenCV as a const InputArray and never written. For
+            // those we can share the data through a refcounted shallow copy and
+            // skip the deep copy. The `in_buf` check keeps zero-copy
+            // (binary-backed) matrices on the deep-copy path: their data is
+            // owned by an Erlang binary, so a shared view could outlive it.
+            if (info.input_only && in_res->in_buf == nullptr) {
+                m = *in_res->val;
+            } else {
+                in_res->val->copyTo(m);
+            }
             return true;
         }
         return false;

--- a/c_src/evision.cpp
+++ b/c_src/evision.cpp
@@ -1701,7 +1701,7 @@ ERL_NIF_TERM evision_from(ErlNifEnv *env, const std::vector<char>& value)
     unsigned char * ptr;
     size_t len = value.size();
     if ((ptr = enif_make_new_binary(env, len, &erl_string)) != nullptr) {
-        strncpy((char *)ptr, value.data(), len);
+        memcpy(ptr, value.data(), len);
         return erl_string;
     } else {
         return kAtomOutOfMemory;
@@ -1713,9 +1713,9 @@ ERL_NIF_TERM evision_from(ErlNifEnv *env, const String& value)
 {
     ERL_NIF_TERM erl_string;
     unsigned char * ptr;
-    size_t len = strlen(value.c_str());
+    size_t len = value.size();
     if ((ptr = enif_make_new_binary(env, len, &erl_string)) != nullptr) {
-        strncpy((char *)ptr, value.c_str(), len);
+        memcpy(ptr, value.data(), len);
         return erl_string;
     } else {
         return kAtomOutOfMemory;
@@ -1728,9 +1728,9 @@ ERL_NIF_TERM evision_from(ErlNifEnv *env, const std::string& value)
 {
     ERL_NIF_TERM erl_string;
     unsigned char * ptr;
-    size_t len = strlen(value.c_str());
+    size_t len = value.size();
     if ((ptr = enif_make_new_binary(env, len, &erl_string)) != nullptr) {
-        strncpy((char *)ptr, value.c_str(), len);
+        memcpy(ptr, value.data(), len);
         return erl_string;
     } else {
         return kAtomOutOfMemory;
@@ -1942,7 +1942,7 @@ ERL_NIF_TERM evision_from(ErlNifEnv *env, const Point3f& p)
     return enif_make_tuple3(env,
         evision_from(env, p.x),
         evision_from(env, p.y),
-        evision_from(env, p.x)
+        evision_from(env, p.z)
     );
 }
 
@@ -2756,9 +2756,9 @@ template<std::size_t I = 0, typename... Tp>
 inline typename std::enable_if<I < sizeof...(Tp), void>::type
 convert_to_erlang_tuple(ErlNifEnv *env, const std::tuple<Tp...>& cpp_tuple, std::vector<ERL_NIF_TERM>& erl_tuple)
 {
-    ERL_NIF_TERM item = evision_from(std::get<I>(cpp_tuple));
+    ERL_NIF_TERM item = evision_from(env, std::get<I>(cpp_tuple));
     erl_tuple.push_back(item);
-    convert_to_erlang_tuple<I + 1, Tp...>(cpp_tuple, erl_tuple);
+    convert_to_erlang_tuple<I + 1, Tp...>(env, cpp_tuple, erl_tuple);
 }
 
 

--- a/c_src/modules/evision_backend/from_binary.h
+++ b/c_src/modules/evision_backend/from_binary.h
@@ -36,7 +36,7 @@ static ERL_NIF_TERM evision_cv_mat_from_binary(ErlNifEnv *env, int argc, const E
                 // validate binary data
                 int type = 0;
                 if (!get_binary_type(t, l, img_channels, type)) return evision::nif::error(env, "not implemented for the given type");
-                size_t declared_size = img_rows * img_cols * img_channels * (l/8);
+                size_t declared_size = (size_t)img_rows * img_cols * img_channels * (l / 8);
                 if (declared_size != data.size) return evision::nif::error(env, "size mismatch");
 
                 evision_res<cv::Mat *> * res;

--- a/c_src/nif_utils.hpp
+++ b/c_src/nif_utils.hpp
@@ -32,7 +32,7 @@ namespace evision
       unsigned char * ptr;
       size_t len = strlen(msg);
       if ((ptr = enif_make_new_binary(env, len, &reason)) != nullptr) {
-          strcpy((char *)ptr, msg);
+          memcpy(ptr, msg, len);
           return enif_make_tuple2(env, atom_error, reason);
       } else {
           ERL_NIF_TERM msg_term = enif_make_string(env, msg, ERL_NIF_LATIN1);

--- a/c_src/windows_fix/windows_fix.cpp
+++ b/c_src/windows_fix/windows_fix.cpp
@@ -22,7 +22,7 @@ ERL_NIF_TERM atom(ErlNifEnv *env, const char *msg) {
 ERL_NIF_TERM error(ErlNifEnv *env, const char *msg) {
     ERL_NIF_TERM error_atom = atom(env, "error");
     ERL_NIF_TERM msg_term = enif_make_string(env, msg, ERL_NIF_LATIN1);
-    return enif_make_tuple2(env, atom, msg_term);
+    return enif_make_tuple2(env, error_atom, msg_term);
 }
 
 ERL_NIF_TERM ok(ErlNifEnv *env) {

--- a/py_src/ir/args.py
+++ b/py_src/ir/args.py
@@ -97,4 +97,7 @@ class ArgInfo(object):
         arg += 0x04 if self.pathlike else 0x0
         arg += 0x08 if self.nd_mat else 0x0
         arg += 0x10 if has_default else 0x0
+        # Pure read-only input: handed to OpenCV as a const InputArray, so the
+        # converter may share the source buffer instead of deep-copying it.
+        arg += 0x20 if not self.outputarg else 0x0
         return "ArgInfo(\"%s\", %d)" % (self.name, arg)

--- a/py_src/pipeline.py
+++ b/py_src/pipeline.py
@@ -41,6 +41,15 @@ from fixes import (
 from config.modules import NAMESPACE_TO_ELIXIR_MODULE
 
 
+# Enum types whose evision_to/evision_from converters are hand-written in
+# evision_custom_headers/. The generator must not emit CV_ERL_*_ENUM for these,
+# or the translation unit gets two definitions of the same converter.
+HAND_WRITTEN_ENUM_CONVERTERS = (
+    "cvflann_flann_algorithm_t",
+    "cvflann_flann_distance_t",
+)
+
+
 if sys.version_info[0] >= 3:
     from io import StringIO
 else:
@@ -410,6 +419,13 @@ class Pipeline(object):
 
         wname = normalize_class_name(enum_name)
         cname = enum_name.replace(".", "::")
+
+        # These enum types already have hand-written evision_to/evision_from
+        # specialisations in evision_custom_headers/evision_flann.hpp. OpenCV
+        # 4.13 started exposing them to the header parser, so emitting
+        # CV_ERL_*_ENUM for them here too would be a redefinition.
+        if wname in HAND_WRITTEN_ENUM_CONVERTERS:
+            return
 
         code = ""
         if re.sub(r"^cv\.", "", enum_name) != wname:

--- a/test/evision_input_immutability_test.exs
+++ b/test/evision_input_immutability_test.exs
@@ -1,0 +1,82 @@
+defmodule Evision.InputImmutabilityTest do
+  use ExUnit.Case
+
+  # Guards the input-sharing optimisation in `evision_to(Mat&)`.
+  #
+  # Generated bindings hand read-only matrices to OpenCV as const InputArrays,
+  # so the converter shares the source buffer instead of deep-copying it. These
+  # tests make sure that optimisation never lets an OpenCV call mutate the
+  # caller's matrix, for both OpenCV-owned and binary-backed matrices.
+
+  alias Evision.Mat
+
+  # 3x4 u8 matrix with distinct values, so an accidental write is visible.
+  @data <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>
+
+  # A binary-backed (zero-copy) matrix: its data is owned by an Erlang binary,
+  # so it stays on the deep-copy path.
+  defp zero_copy_mat, do: Mat.from_binary(@data, {:u, 8}, 3, 4, 1)
+
+  # `clone/1` deep-copies, so the result is an OpenCV-owned matrix -- the case
+  # eligible for the shared-input fast path.
+  defp owned_mat, do: Mat.clone(zero_copy_mat())
+
+  describe "a generated binding never mutates its input matrix" do
+    test "OpenCV-owned input (shared fast path)" do
+      a = owned_mat()
+      before = Mat.to_binary(a)
+
+      _ = Evision.add(a, a)
+      _ = Evision.subtract(a, a)
+      _ = Evision.add(a, a)
+
+      assert Mat.to_binary(a) == before
+    end
+
+    test "binary-backed input (deep-copy path)" do
+      a = zero_copy_mat()
+
+      _ = Evision.add(a, a)
+      _ = Evision.subtract(a, a)
+
+      assert Mat.to_binary(a) == @data
+    end
+
+    test "the same matrix passed twice to one call is left intact" do
+      # add(a, a) would corrupt `a` if the input were aliased onto the output.
+      a = owned_mat()
+      sum = Evision.add(a, a)
+
+      assert Mat.to_binary(a) == @data
+
+      doubled =
+        @data |> :binary.bin_to_list() |> Enum.map(&(&1 * 2)) |> :erlang.list_to_binary()
+
+      assert Mat.to_binary(sum) == doubled
+    end
+  end
+
+  describe "results stay correct across reuse" do
+    test "one matrix reused through a chain of ops" do
+      a = owned_mat()
+
+      b = Evision.add(a, a)
+      c = Evision.subtract(b, a)
+      d = Evision.add(c, c)
+
+      assert Mat.to_binary(a) == @data
+      assert Mat.to_binary(c) == @data
+      assert Mat.to_binary(d) == Mat.to_binary(b)
+    end
+
+    test "clone is independent of its source" do
+      a = owned_mat()
+      copy = Mat.clone(a)
+
+      _ = Evision.add(a, a)
+
+      assert Mat.to_binary(copy) == @data
+      assert Mat.to_binary(a) == @data
+    end
+  end
+end


### PR DESCRIPTION
Came out of a review of the hand-written C++ under `c_src/`.

## Correctness fixes

| Bug | Impact |
| --- | --- |
| `nif_utils.hpp` — `error()` used `strcpy` into an `enif_make_new_binary` buffer sized for `strlen(msg)` | 1-byte heap overflow on every NIF error path |
| `evision.cpp` — `evision_from(Point3f)` emitted `x` twice, dropped `z` | any `Point3f` returned to Elixir lost its z coordinate |
| `evision.cpp` — `convert_to_erlang_tuple` dropped the `env` argument | `evision_from(std::tuple<...>)` would not compile if instantiated |
| `evision.cpp` — `evision_from` for `std::vector<char>`/`String`/`std::string` used `strncpy` | binary data truncated at embedded NUL bytes |
| `erlcompat.hpp` — `CV_ERL_TO_ENUM` inverted its success check | enum conversion returned `false` for valid input, `true` (uninitialised) otherwise |
| `from_binary.h` — `declared_size` computed in 32-bit `int` before widening | overflow could let the size guard pass and hand OpenCV an undersized buffer |
| `windows_fix.cpp` — `error()` built the tuple with the `atom` function instead of `error_atom` | `error()` returned a malformed tuple on Windows |

## Performance: share read-only input matrices

`evision_to(Mat&)` always deep-copied a source matrix so OpenCV could never mutate the caller's (immutable) matrix. Most arguments are plain `InputArray`s that OpenCV only reads, so that copy is pure overhead.

A new `input_only` `ArgInfo` flag — emitted by the code generator for every non-output argument (provably a const `InputArray`) — lets `evision_to(Mat&)` share the source buffer via a refcounted shallow copy instead.

Two guards keep it safe:
- the flag is set **only** by generated bindings; hand-written modules pass flag `0` and keep the deep-copy default, so any NIF that writes to its argument in place is unaffected;
- binary-backed (zero-copy) matrices stay on the deep-copy path, since a shared view must not outlive the Erlang binary it borrows.

## Build fix: flann enum redefinition under OpenCV 4.13

OpenCV 4.13 exposes `cvflann::flann_algorithm_t` / `flann_distance_t` to the header parser, so the generator emitted `CV_ERL_*_ENUM` for them — colliding with the hand-written `evision_to`/`evision_from` specializations in `evision_custom_headers/evision_flann.hpp`. This currently breaks `main` itself; the generator now skips `CV_ERL_*_ENUM` for enum types that have hand-written converters.

## Tests

`test/evision_input_immutability_test.exs` checks that generated bindings never mutate their input matrix and still produce correct results, for both OpenCV-owned and binary-backed matrices.

Verified locally with a from-source OpenCV 4.13 build: `evision.so` compiles cleanly and `mix test` passes (52 tests across the new file plus the mat/backend/core suites).

## Not included (follow-up)

Robustness items noted during review but intentionally left out: `mat_from_binary_by_shape` size validation, `start_native_gui` thread-spawn guard, `to_batched` `batch_size == 0` division, and applying the same input-sharing optimisation to `UMat` and the hand-written backend ops.
