### PR TITLE
docs: address issue #192 (module + function grouping, MathJax, extras)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1367,30 +1367,11 @@ defmodule Evision.MixProject do
       main: "Evision",
       source_ref: "v#{Metadata.version()}",
       source_url: @source_url,
-      extras: [
-        "CHANGELOG.md",
-        "Cheatsheet.cheatmd",
-        "README.md",
-        # Evision
-        "examples/getting_started.livemd",
-        "examples/qrcode.livemd",
-        "examples/warp_perspective.livemd",
-        "examples/warp_polar.livemd",
-        "examples/find_and_draw_contours.livemd",
-        "examples/stitching.livemd",
-        "examples/pca.livemd",
-        "examples/photo-hdr.livemd",
-        "examples/sudoku.livemd",
-        "examples/cifar10.livemd",
-        # Evision.DNN
-        "examples/dnn-googlenet.livemd",
-        "examples/dnn-detection-model.livemd",
-        "examples/densenet121_benchmark.livemd",
-        # Evision.ML
-        "examples/ml-svm.livemd",
-        "examples/ml-decision_tree_and_random_forest.livemd"
-      ],
+      extras: extras(),
       before_closing_body_tag: &before_closing_body_tag/1,
+      groups_for_extras: groups_for_extras(),
+      groups_for_modules: groups_for_modules(),
+      nest_modules_by_prefix: nest_modules_by_prefix(),
       groups_for_docs: [
         external: &(&1[:namespace] == :external),
         Enumerator: &(&1[:enum] == true)
@@ -1398,44 +1379,336 @@ defmodule Evision.MixProject do
     ]
   end
 
+  defp extras do
+    [
+      "README.md",
+      "CHANGELOG.md",
+      "Cheatsheet.cheatmd",
+      "examples/getting_started.livemd",
+      "examples/qrcode.livemd",
+      "examples/warp_perspective.livemd",
+      "examples/warp_polar.livemd",
+      "examples/find_and_draw_contours.livemd",
+      "examples/stitching.livemd",
+      "examples/pca.livemd",
+      "examples/photo-hdr.livemd",
+      "examples/sudoku.livemd",
+      "examples/cifar10.livemd",
+      "examples/dnn-googlenet.livemd",
+      "examples/dnn-detection-model.livemd",
+      "examples/densenet121_benchmark.livemd",
+      "examples/ml-svm.livemd",
+      "examples/ml-decision_tree_and_random_forest.livemd"
+    ]
+  end
+
+  defp groups_for_extras do
+    [
+      Introduction: ["Cheatsheet.cheatmd", "CHANGELOG.md"],
+      "Examples: Getting Started": ["examples/getting_started.livemd"],
+      "Examples: Image Processing": [
+        "examples/qrcode.livemd",
+        "examples/warp_perspective.livemd",
+        "examples/warp_polar.livemd",
+        "examples/find_and_draw_contours.livemd",
+        "examples/stitching.livemd",
+        "examples/pca.livemd",
+        "examples/photo-hdr.livemd",
+        "examples/sudoku.livemd"
+      ],
+      "Examples: Deep Neural Networks": [
+        "examples/cifar10.livemd",
+        "examples/dnn-googlenet.livemd",
+        "examples/dnn-detection-model.livemd",
+        "examples/densenet121_benchmark.livemd"
+      ],
+      "Examples: Machine Learning": [
+        "examples/ml-svm.livemd",
+        "examples/ml-decision_tree_and_random_forest.livemd"
+      ]
+    ]
+  end
+
+  # OpenCV's high-level module taxonomy mapped onto the Elixir module names
+  # emitted by py_src. Order matters: ExDoc walks the list top-down and a
+  # module ends up in the first group whose pattern it matches, so put more
+  # specific patterns above broader ones.
+  defp groups_for_modules do
+    [
+      "Core Functionality": [
+        Evision.Constant,
+        Evision.Backend,
+        ~r/^Evision\.(Mat|SparseMat|UMat|UMatData|UMatUsageFlags)(\..*)?$/,
+        ~r/^Evision\.(AsyncArray|Algorithm|AlgorithmHint|RotatedRect|KeyPoint|DMatch|RNG|TickMeter|Subdiv2D|IStreamReader)$/,
+        ~r/^Evision\.(TermCriteria|PCA|SVD|FileNode|FileStorage|Param|Parallel|Samples|Animation)(\..*)?$/,
+        ~r/^Evision\.(Error|Instr|QuatAssumeType|QuatEnum)(\..*)?$/,
+        ~r/^Evision\.(Utils|UtilsFS|Utilslogging|Ipp|Signal|AccessFlag)(\..*)?$/,
+        ~r/^Evision\.Formatter\..+$/
+      ],
+      "Image Processing": [
+        ~r/^Evision\.(CLAHE|GeneralizedHough|GeneralizedHoughBallard|GeneralizedHoughGuil|LineSegmentDetector|IntelligentScissorsMB)$/
+      ],
+      "Image File I/O": [
+        ~r/^Evision\.(Imread|Imwrite)[A-Z].*$/,
+        Evision.ImageMetadataType
+      ],
+      "Video I/O": [
+        ~r/^Evision\.Video(Capture|Writer|IORegistry|Acceleration)[A-Z]*.*$/
+      ],
+      "High-level GUI": [
+        Evision.HighGui,
+        Evision.Wx,
+        ~r/^Evision\.(Window|MouseEvent|Qt)[A-Z].*$/,
+        ~r/^Evision\.(MarkerTypes|HersheyFonts|LineTypes|DrawMatchesFlags)$/
+      ],
+      "Video Analysis": [
+        ~r/^Evision\.(KalmanFilter|BackgroundSubtractor.*|VariationalRefinement)$/,
+        ~r/^Evision\.(DenseOpticalFlow|DISOpticalFlow|FarnebackOpticalFlow|SparseOpticalFlow|SparsePyrLKOpticalFlow)$/
+      ],
+      "Camera Calibration & 3D Reconstruction": [
+        ~r/^Evision\.(FishEye|Omnidir|StereoBM|StereoSGBM|StereoMatcher)$/,
+        ~r/^Evision\.(CirclesGridFinderParameters|UsacParams|SolveLPResult|SolvePnPMethod|HandEyeCalibrationMethod|RobotWorldHandEyeCalibrationMethod|LocalOptimMethod|SamplingMethod|NeighborSearchMethod|ScoreMethod|PolishingMethod)(\..*)?$/
+      ],
+      "Stereo Correspondence": [
+        ~r/^Evision\.Stereo(\..*)?$/
+      ],
+      "2D Features Framework": [
+        ~r/^Evision\.(AKAZE|AffineFeature|AgastFeatureDetector|AffineTransformer|BRISK|BFMatcher|FastFeatureDetector|Feature2D|FlannBasedMatcher|GFTTDetector|KAZE|MSER|ORB|SIFT|SimpleBlobDetector)(\..*)?$/,
+        ~r/^Evision\.BOW[A-Z].*$/,
+        ~r/^Evision\.DescriptorMatcher(\..*)?$/
+      ],
+      "Object Detection": [
+        ~r/^Evision\.(CascadeClassifier|BaseCascadeClassifier|HOGDescriptor|FaceDetectorYN|GraphicalCodeDetector)(\..*)?$/,
+        ~r/^Evision\.(QRCodeDetector|QRCodeDetectorAruco|QRCodeEncoder|Barcode)(\..*)?$/
+      ],
+      "Computational Photography (HDR)": [
+        ~r/^Evision\.(Tonemap|TonemapDrago|TonemapMantiuk|TonemapReinhard)$/,
+        ~r/^Evision\.(CalibrateCRF|CalibrateDebevec|CalibrateRobertson)$/,
+        ~r/^Evision\.(MergeDebevec|MergeExposures|MergeMertens|MergeRobertson)$/,
+        ~r/^Evision\.(AlignExposures|AlignMTB|SeamlessCloneFlags|Alphamat)$/
+      ],
+      "Shape Matching": [
+        ~r/^Evision\.(ShapeContextDistanceExtractor|ShapeDistanceExtractor|ShapeTransformer|ShapeMatchModes|ThinPlateSplineShapeTransformer|HausdorffDistanceExtractor)$/,
+        ~r/^Evision\.(ChiHistogramCostExtractor|NormHistogramCostExtractor|EMDHistogramCostExtractor|EMDL1HistogramCostExtractor|HistogramCostExtractor)$/
+      ],
+      "Image Stitching": [
+        ~r/^Evision\.(Stitcher|PyRotationWarper|WarperCreator)(\..*)?$/,
+        ~r/^Evision\.Detail(\..*)?$/
+      ],
+      "Machine Learning (ML)": [
+        ~r/^Evision\.ML(\..*)?$/
+      ],
+      "Deep Neural Networks (DNN)": [
+        ~r/^Evision\.DNN(\..*)?$/
+      ],
+      "DNN Super-Resolution": [
+        ~r/^Evision\.DNNSuperRes(\..*)?$/
+      ],
+      "Clustering & Search (FLANN)": [
+        ~r/^Evision\.Flann(\..*)?$/
+      ],
+      "CUDA Acceleration": [
+        ~r/^Evision\.CUDA(\..*)?$/
+      ],
+      "OpenCL Acceleration": [
+        ~r/^Evision\.OCL(\..*)?$/
+      ],
+      "OpenGL Interop": [
+        ~r/^Evision\.OGL(\..*)?$/
+      ],
+      "Object Tracking": [
+        ~r/^Evision\.(Tracker|TrackerCSRT|TrackerDaSiamRPN|TrackerGOTURN|TrackerKCF|TrackerMIL|TrackerNano|TrackerVit)(\..*)?$/,
+        ~r/^Evision\.Legacy(\..*)?$/
+      ],
+      "3D Volumetric Reconstruction (KinFu)": [
+        ~r/^Evision\.(KinFu|LargeKinfu|ColoredKinFu|DynaFu)(\..*)?$/
+      ],
+      "ArUco Markers": [
+        ~r/^Evision\.ArUco(\..*)?$/
+      ],
+      "Background Segmentation (bgsegm)": [
+        ~r/^Evision\.BgSegm(\..*)?$/
+      ],
+      "Bio-Inspired Vision": [
+        ~r/^Evision\.Bioinspired(\..*)?$/
+      ],
+      "Color Correction Model (CCM)": [
+        ~r/^Evision\.CCM(\..*)?$/
+      ],
+      "Face Analysis": [
+        ~r/^Evision\.(Face|FaceRecognizerSF)(\..*)?$/
+      ],
+      "Fuzzy Image Processing": [
+        ~r/^Evision\.Ft(\..*)?$/
+      ],
+      "Hierarchical Feature Selection (HFS)": [
+        ~r/^Evision\.HFS(\..*)?$/
+      ],
+      "Image Hashing": [
+        ~r/^Evision\.ImgHash(\..*)?$/
+      ],
+      "Intensity Transformations": [
+        ~r/^Evision\.Intensitytransform(\..*)?$/
+      ],
+      "Line Descriptors": [
+        ~r/^Evision\.LineDescriptor(\..*)?$/
+      ],
+      LineMod: [
+        ~r/^Evision\.LineMod(\..*)?$/
+      ],
+      "Macbeth Chart (MCC)": [
+        ~r/^Evision\.MCC(\..*)?$/
+      ],
+      "Multi-Camera Calibration": [
+        ~r/^Evision\.MultiCalib(\..*)?$/
+      ],
+      "Phase Unwrapping": [
+        ~r/^Evision\.PhaseUnwrapping(\..*)?$/
+      ],
+      "2D Plotting": [
+        ~r/^Evision\.Plot(\..*)?$/
+      ],
+      "Surface Matching (PPF Match 3D)": [
+        ~r/^Evision\.PPFMatch3D(\..*)?$/
+      ],
+      "Image Quality Analysis": [
+        ~r/^Evision\.Quality(\..*)?$/
+      ],
+      "RAPID 3D Tracking": [
+        ~r/^Evision\.Rapid(\..*)?$/
+      ],
+      "Image Registration": [
+        ~r/^Evision\.Reg(\..*)?$/
+      ],
+      "RGB-Depth Processing": [
+        ~r/^Evision\.RGBD(\..*)?$/
+      ],
+      Saliency: [
+        ~r/^Evision\.Saliency(\..*)?$/
+      ],
+      "Image Segmentation": [
+        ~r/^Evision\.Segmentation(\..*)?$/
+      ],
+      "Structured Light": [
+        ~r/^Evision\.StructuredLight(\..*)?$/
+      ],
+      "Text Detection & Recognition": [
+        ~r/^Evision\.Text(\..*)?$/
+      ],
+      "WeChat QR Code": [
+        ~r/^Evision\.WeChatQRCode(\..*)?$/
+      ],
+      "Extra 2D Features (xfeatures2d)": [
+        ~r/^Evision\.XFeatures2D(\..*)?$/
+      ],
+      "Extended Image Processing (ximgproc)": [
+        ~r/^Evision\.XImgProc(\..*)?$/
+      ],
+      "Extra Photo (xphoto)": [
+        ~r/^Evision\.XPhoto(\..*)?$/
+      ],
+      "Model Zoo": [
+        ~r/^Evision\.Zoo(\..*)?$/
+      ],
+      "Livebook Smart Cells": [
+        ~r/^Evision\.SmartCell(\..*)?$/
+      ],
+      "IPC Handles": [
+        ~r/^Evision\.IPCHandle(\..*)?$/
+      ],
+      "Enums & Flags": [
+        ~r/^Evision\..*(Flags|Types|Modes|Codes|Masks|Methods|Classes|Shapes|Mode|Filter)$/
+      ]
+    ]
+  end
+
+  # Fold deeply-nested generated namespaces under a single prefix in the
+  # sidebar. `Evision.DNN.Net` shows as `Net` under the `Evision.DNN` heading,
+  # etc.
+  defp nest_modules_by_prefix do
+    [
+      Evision.ArUco,
+      Evision.BgSegm,
+      Evision.Bioinspired,
+      Evision.CCM,
+      Evision.ColoredKinFu,
+      Evision.CUDA,
+      Evision.Detail,
+      Evision.DNN,
+      Evision.DNNSuperRes,
+      Evision.DynaFu,
+      Evision.Face,
+      Evision.Flann,
+      Evision.HFS,
+      Evision.ImgHash,
+      Evision.IPCHandle,
+      Evision.KinFu,
+      Evision.LargeKinfu,
+      Evision.Legacy,
+      Evision.LineDescriptor,
+      Evision.LineMod,
+      Evision.MCC,
+      Evision.ML,
+      Evision.MultiCalib,
+      Evision.OCL,
+      Evision.OGL,
+      Evision.PhaseUnwrapping,
+      Evision.Plot,
+      Evision.PPFMatch3D,
+      Evision.Quality,
+      Evision.Rapid,
+      Evision.Reg,
+      Evision.RGBD,
+      Evision.Saliency,
+      Evision.Segmentation,
+      Evision.SmartCell,
+      Evision.Stereo,
+      Evision.Stitcher,
+      Evision.StructuredLight,
+      Evision.Text,
+      Evision.Utils,
+      Evision.WeChatQRCode,
+      Evision.XFeatures2D,
+      Evision.XImgProc,
+      Evision.XPhoto,
+      Evision.Zoo
+    ]
+  end
+
   defp before_closing_body_tag(:html) do
-    ~S'
-    <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-        tex2jax: {
-            inlineMath: [["\\f$", "\\f$"]],
-            displayMath: [["\\f[", "\\f]"]],
-            skipTags: ["script", "noscript", "style", "textarea"],
-            processEnvironments: false
+    """
+    <script>
+      window.MathJax = {
+        tex: {
+          inlineMath: [["\\\\f$", "\\\\f$"]],
+          displayMath: [["\\\\f[", "\\\\f]"]],
+          processEnvironments: false,
+          macros: {
+            matTT: ["\\\\[ \\\\left|\\\\begin{array}{ccc} #1 & #2 & #3\\\\\\\\ #4 & #5 & #6\\\\\\\\ #7 & #8 & #9 \\\\end{array}\\\\right| \\\\]", 9],
+            fork: ["\\\\left\\\\{ \\\\begin{array}{l l} #1 & \\\\mbox{#2}\\\\\\\\ #3 & \\\\mbox{#4}\\\\\\\\ \\\\end{array} \\\\right.", 4],
+            forkthree: ["\\\\left\\\\{ \\\\begin{array}{l l} #1 & \\\\mbox{#2}\\\\\\\\ #3 & \\\\mbox{#4}\\\\\\\\ #5 & \\\\mbox{#6}\\\\\\\\ \\\\end{array} \\\\right.", 6],
+            forkfour: ["\\\\left\\\\{ \\\\begin{array}{l l} #1 & \\\\mbox{#2}\\\\\\\\ #3 & \\\\mbox{#4}\\\\\\\\ #5 & \\\\mbox{#6}\\\\\\\\ #7 & \\\\mbox{#8}\\\\\\\\ \\\\end{array} \\\\right.", 8],
+            vecthree: ["\\\\begin{bmatrix} #1\\\\\\\\ #2\\\\\\\\ #3 \\\\end{bmatrix}", 3],
+            vecthreethree: ["\\\\begin{bmatrix} #1 & #2 & #3\\\\\\\\ #4 & #5 & #6\\\\\\\\ #7 & #8 & #9 \\\\end{bmatrix}", 9],
+            cameramatrix: ["#1 = \\\\begin{bmatrix} f_x & 0 & c_x\\\\\\\\ 0 & f_y & c_y\\\\\\\\ 0 & 0 & 1 \\\\end{bmatrix}", 1],
+            distcoeffs: ["(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \\\\tau_x, \\\\tau_y]]]]) \\\\text{ of 4, 5, 8, 12 or 14 elements}"],
+            distcoeffsfisheye: ["(k_1, k_2, k_3, k_4)"],
+            hdotsfor: ["\\\\dots", 1],
+            mathbbm: ["\\\\mathbb{#1}", 1],
+            bordermatrix: ["\\\\matrix{#1}", 1]
+          }
         },
-        extensions: ["tex2jax.js", "TeX/AMSmath.js", "TeX/AMSsymbols.js"],
-        jax: ["input/TeX", "output/HTML-CSS"],
-    });
-    //<![CDATA[
-    MathJax.Hub.Config(
-    {
-        TeX: {
-            Macros: {
-                matTT: ["\\[ \\left|\\begin{array}{ccc} #1 & #2 & #3\\\\ #4 & #5 & #6\\\\ #7 & #8 & #9 \\end{array}\\right| \\]", 9],
-                fork: ["\\left\\{ \\begin{array}{l l} #1 & \\mbox{#2}\\\\ #3 & \\mbox{#4}\\\\ \\end{array} \\right.", 4],
-                forkthree: ["\\left\\{ \\begin{array}{l l} #1 & \\mbox{#2}\\\\ #3 & \\mbox{#4}\\\\ #5 & \\mbox{#6}\\\\ \\end{array} \\right.", 6],
-                forkfour: ["\\left\\{ \\begin{array}{l l} #1 & \\mbox{#2}\\\\ #3 & \\mbox{#4}\\\\ #5 & \\mbox{#6}\\\\ #7 & \\mbox{#8}\\\\ \\end{array} \\right.", 8],
-                vecthree: ["\\begin{bmatrix} #1\\\\ #2\\\\ #3 \\end{bmatrix}", 3],
-                vecthreethree: ["\\begin{bmatrix} #1 & #2 & #3\\\\ #4 & #5 & #6\\\\ #7 & #8 & #9 \\end{bmatrix}", 9],
-                cameramatrix: ["#1 = \\begin{bmatrix} f_x & 0 & c_x\\\\ 0 & f_y & c_y\\\\ 0 & 0 & 1 \\end{bmatrix}", 1],
-                distcoeffs: ["(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \\tau_x, \\tau_y]]]]) \\text{ of 4, 5, 8, 12 or 14 elements}"],
-                distcoeffsfisheye: ["(k_1, k_2, k_3, k_4)"],
-                hdotsfor: ["\\dots", 1],
-                mathbbm: ["\\mathbb{#1}", 1],
-                bordermatrix: ["\\matrix{#1}", 1]
-            }
-        }
-    }
-    );
-    //]]>
+        options: {
+          skipHtmlTags: ["script", "noscript", "style", "textarea", "pre", "code"],
+          ignoreHtmlClass: "tex2jax_ignore",
+          processHtmlClass: "tex2jax_process"
+        },
+        svg: { fontCache: "global" },
+        startup: { typeset: true }
+      };
     </script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"></script>
-    '
+    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+    """
   end
 
   defp before_closing_body_tag(_), do: ""

--- a/mix.exs
+++ b/mix.exs
@@ -1372,10 +1372,110 @@ defmodule Evision.MixProject do
       groups_for_extras: groups_for_extras(),
       groups_for_modules: groups_for_modules(),
       nest_modules_by_prefix: nest_modules_by_prefix(),
-      groups_for_docs: [
-        external: &(&1[:namespace] == :external),
-        Enumerator: &(&1[:enum] == true)
-      ]
+      groups_for_docs: groups_for_docs()
+    ]
+  end
+
+  # Categories that ExDoc applies to functions inside a module. The generator
+  # emits `@doc group: "<OpenCV @defgroup title>"` for cv:: namespace
+  # functions (the ~1400 that land in the root `Evision` module) so that the
+  # function list mirrors OpenCV's docs taxonomy rather than appearing as one
+  # flat brick. Entries here pull in everything OpenCV's headers tag plus the
+  # binding-only `external`/`Enumerator` buckets.
+  defp groups_for_docs do
+    [
+      external: &(&1[:namespace] == :external),
+      Enumerator: &(&1[:enum] == true)
+    ] ++ for title <- opencv_doc_group_titles(), do: {String.to_atom(title), &doc_in_group?(&1, title)}
+  end
+
+  defp doc_in_group?(metadata, title), do: metadata[:group] == title
+
+  defp opencv_doc_group_titles do
+    [
+      "Operations on arrays",
+      "Basic structures",
+      "Asynchronous API",
+      "XML/YAML/JSON Persistence",
+      "Clustering",
+      "Utility and system functions and macros",
+      "Logging facilities",
+      "OpenGL interoperability",
+      "Optimization Algorithms",
+      "OpenCL support",
+      "Hardware Acceleration Layer",
+      "Parallel Processing",
+      "Parallel backends API",
+      "Quaternion",
+      "Image Filtering",
+      "Geometric Image Transformations",
+      "Miscellaneous Image Transformations",
+      "Drawing Functions",
+      "Color Space Conversions",
+      "ColorMaps in OpenCV",
+      "Planar Subdivision",
+      "Histograms",
+      "Structural Analysis and Shape Descriptors",
+      "Motion Analysis and Object Tracking",
+      "Feature Detection",
+      "Object Detection",
+      "Image Segmentation",
+      "Image file reading and writing",
+      "High-level GUI",
+      "Qt New Functions",
+      "Video I/O",
+      "Query I/O API backends registry",
+      "Camera Calibration",
+      "Fisheye camera model",
+      "3D vision functionality",
+      "Stereo Correspondence",
+      "Drawing Function of Keypoints and Matches",
+      "Object Tracking",
+      "Legacy Tracking API",
+      "Optical Flow Algorithms",
+      "Deep Neural Network module",
+      "HDR imaging",
+      "Inpainting",
+      "Denoising",
+      "Seamless Cloning",
+      "Non-Photorealistic Rendering",
+      "Contrast Preserving Decolorization",
+      "Images stitching",
+      "Features Finding and Images Matching",
+      "Rotation Estimation",
+      "Autocalibration",
+      "Image Blenders",
+      "Additional photo processing algorithms",
+      "Extended Image Processing",
+      "Fourier descriptors",
+      "Structured forests for fast edge detection",
+      "Superpixels",
+      "EdgeDrawing",
+      "Fast line detector",
+      "Experimental 2D Features Matching Algorithm",
+      "Binary descriptors for lines extracted from an image",
+      "ArUco markers and boards detection for robust camera pose estimation",
+      "Improved Background-Foreground Segmentation Methods",
+      "Face Analysis",
+      "Image segmentation",
+      "Scene Text Detection",
+      "Scene Text Recognition",
+      "Shape Distance and Matching",
+      "Surface Matching",
+      "silhouette based 3D object tracking",
+      "Alpha Matting",
+      "Custom Calibration Pattern for 3D reconstruction",
+      "RGB-Depth Processing",
+      "Module-wrapper for FastCV hardware accelerated functions",
+      "Signal Processing",
+      "Math with F0-transform support",
+      "Math with F1-transform support",
+      "Fuzzy image processing",
+      "The module brings implementations of different image hashing algorithms.",
+      "The module brings implementations of intensity transformation algorithms to adjust image contrast.",
+      "Common functions and classes",
+      "Hierarchical Data Format version 5",
+      "Drawing UTF-8 strings with freetype/harfbuzz"
     ]
   end
 

--- a/py_src/doxygen_groups.py
+++ b/py_src/doxygen_groups.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Lightweight scanner for OpenCV's Doxygen group tags.
+
+OpenCV organizes its public API into hierarchical groups via Doxygen, e.g.
+
+    @defgroup imgproc Image Processing
+        @defgroup imgproc_filter Image Filtering
+        @defgroup imgproc_transform Geometric Image Transformations
+        ...
+
+Function declarations inside a `@addtogroup ... @{ ... @}` block (or carrying
+an explicit `@ingroup`) belong to that group. The Elixir bindings can carry
+this taxonomy forward to ExDoc via `@doc group: "<title>"`, which is what the
+`Evision` root module needs to make its 1400+ functions navigable.
+
+`scan(srcfiles)` returns two dicts:
+
+  * group_titles  - group_id (e.g. "imgproc_filter") -> human-readable title
+                    (e.g. "Image Filtering")
+  * func_to_group - unqualified function name (e.g. "GaussianBlur") -> group_id
+
+Names are matched case-insensitively to absorb the lower/upperCamelCase mismatch
+between C++ declarations and the binding's emitted function name.
+"""
+
+import re
+
+DEFGROUP_RE = re.compile(r"@defgroup\s+(\w+)\s+([^\n*]+)")
+ADDTOGROUP_RE = re.compile(r"@addtogroup\s+(\w+)")
+INGROUP_RE = re.compile(r"@ingroup\s+(\w+)")
+# CV_EXPORTS_W [return type] name(...
+FUNC_DECL_RE = re.compile(
+    r"CV_EXPORTS_W(?:_SIMPLE|_AS\([^)]*\))?\s+"
+    r"(?:[\w:&<>,\*\s]+?\s+)?"
+    r"(\w+)\s*\("
+)
+
+
+def _is_open(line):
+    return "@{" in line
+
+
+def _is_close(line):
+    return "@}" in line
+
+
+def scan(srcfiles):
+    titles = {}
+    func_to_group = {}
+
+    for path in srcfiles:
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                text = f.read()
+        except OSError:
+            continue
+
+        for m in DEFGROUP_RE.finditer(text):
+            titles.setdefault(m.group(1), m.group(2).strip().rstrip("*/").strip())
+
+        _scan_funcs(text, func_to_group)
+
+    return titles, func_to_group
+
+
+# Suffix/prefix variants that OpenCV (and our binding) emits without
+# repeating the @ingroup tag — e.g. `calibrateCameraExtended` inherits from
+# `calibrateCamera`, `createBackgroundSubtractorKNN` from
+# `BackgroundSubtractorKNN`. Try a few of these so coverage doesn't crater
+# on aliases.
+_VARIANT_SUFFIXES = (
+    "extended", "roextended", "withmask", "withmeta", "withstats",
+    "withalgorithm", "withaccumulator", "withlabels", "buffer",
+)
+
+
+def lookup(func_to_group, name):
+    key = name.lower()
+    g = func_to_group.get(key)
+    if g:
+        return g
+    for suf in _VARIANT_SUFFIXES:
+        if key.endswith(suf):
+            g = func_to_group.get(key[: -len(suf)])
+            if g:
+                return g
+    if key.startswith("create") and len(key) > 6:
+        g = func_to_group.get(key[6:])
+        if g:
+            return g
+    return None
+
+
+def _scan_funcs(text, func_to_group):
+    scope_stack = []
+    pending_group = None
+    pending_ingroup = None
+
+    in_block_comment = False
+    block_comment_buf = []
+
+    for raw in text.splitlines():
+        line = raw.strip()
+
+        if in_block_comment:
+            block_comment_buf.append(line)
+            if "*/" in line:
+                joined = "\n".join(block_comment_buf)
+                am = ADDTOGROUP_RE.search(joined)
+                if am:
+                    pending_group = am.group(1)
+                if "@{" in joined and pending_group is not None:
+                    scope_stack.append(pending_group)
+                    pending_group = None
+                if "@}" in joined and scope_stack:
+                    scope_stack.pop()
+                ig = INGROUP_RE.search(joined)
+                pending_ingroup = ig.group(1) if ig else None
+                in_block_comment = False
+                block_comment_buf = []
+            continue
+
+        if line.startswith("/*") and "*/" not in line:
+            pending_ingroup = None
+            in_block_comment = True
+            block_comment_buf = [line]
+            continue
+
+        am = ADDTOGROUP_RE.search(line)
+        if am:
+            pending_group = am.group(1)
+            if _is_open(line):
+                scope_stack.append(pending_group)
+                pending_group = None
+            continue
+
+        if _is_open(line) and pending_group is not None:
+            scope_stack.append(pending_group)
+            pending_group = None
+            continue
+
+        if _is_close(line) and scope_stack:
+            scope_stack.pop()
+            continue
+
+        ig = INGROUP_RE.search(line)
+        if ig:
+            pending_ingroup = ig.group(1)
+            continue
+
+        if not line:
+            continue
+
+        fm = FUNC_DECL_RE.search(line)
+        if fm:
+            fname = fm.group(1)
+            gid = pending_ingroup or (scope_stack[-1] if scope_stack else None)
+            if gid:
+                func_to_group.setdefault(fname.lower(), gid)
+
+        # Any non-blank, non-comment, non-marker line consumes the pending
+        # @ingroup: it was meant for the next declaration, even if that
+        # declaration was an enum/class our function regex can't see.
+        pending_ingroup = None
+
+
+def title_for(group_titles, group_id):
+    title = group_titles.get(group_id)
+    if title:
+        return title
+    parent = group_id.rsplit("_", 1)[0] if "_" in group_id else None
+    if parent and parent in group_titles:
+        return group_titles[parent]
+    return group_id

--- a/py_src/module_generator.py
+++ b/py_src/module_generator.py
@@ -8,6 +8,7 @@ from ir.props import ClassProp
 from helper import *
 from emit.erlang.helpers import map_uppercase_to_erlang_name
 import evision_templates as ET
+import doxygen_groups
 
 if sys.version_info[0] >= 3:
     from io import StringIO
@@ -69,6 +70,17 @@ class ModuleGenerator(object):
 
         self.erlang_ended = False
 
+        # Function-name -> OpenCV `@defgroup` id; titles[id] -> human label.
+        # Populated by `set_doc_groups()` only for modules where the binding
+        # should carry ExDoc `@doc group:` annotations (currently the root
+        # `Evision` module).
+        self.doc_func_groups = {}
+        self.doc_group_titles = {}
+
+    def set_doc_groups(self, func_to_group, group_titles):
+        self.doc_func_groups = func_to_group or {}
+        self.doc_group_titles = group_titles or {}
+
     def get_erl_nif_func_entry(self):
         return self.erl_nif_func_entry.getvalue()
 
@@ -101,8 +113,15 @@ class ModuleGenerator(object):
 
     def end_elixir(self):
         for function_name, function in self.function['elixir'].items():
+            seen_group = False
             for arity, functions in function.items():
                 docs_mfa = self.inline_docs['elixir'].get(function_name, {}).get(arity, [])
+                if not seen_group and self.doc_func_groups:
+                    group_id = doxygen_groups.lookup(self.doc_func_groups, function_name)
+                    if group_id:
+                        title = doxygen_groups.title_for(self.doc_group_titles, group_id)
+                        self.write_elixir(f'\n  @doc group: {_elixir_string(title)}\n')
+                        seen_group = True
                 if len(docs_mfa) > 0:
                     if len(docs_mfa) == 1:
                         self.write_elixir('\n  @doc """\n')
@@ -750,3 +769,9 @@ class ModuleGenerator(object):
         for function_name, function in self.function[kind].items():
             for function_arity, _function_code in function.items():
                 print(f"M={self.module_name}, F={function_name}, A={function_arity}")
+
+
+
+def _elixir_string(value):
+    """Quote a Python string into an Elixir-safe literal."""
+    return '"' + value.replace('\\', '\\\\').replace('"', '\\"') + '"'

--- a/py_src/pipeline.py
+++ b/py_src/pipeline.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from shutil import rmtree
 
 import hdr_parser
+import doxygen_groups
 import evision_templates as ET
 import evision_structures as ES
 import evision_extra_functions as EF
@@ -645,6 +646,13 @@ class Pipeline(object):
             generate_gpumat_decls=True,
             preprocessor_definitions=preprocessor_definitions,
         )
+
+        # Carry OpenCV's `@defgroup`/`@addtogroup` taxonomy into the generated
+        # `Evision` module via `@doc group:`. Surfacing 1400+ root-level
+        # functions without grouping is unnavigable; ExDoc reads this metadata
+        # via `groups_for_docs` in mix.exs.
+        self.doc_group_titles, self.doc_func_groups = doxygen_groups.scan(srcfiles)
+        self.evision_ex.set_doc_groups(self.doc_func_groups, self.doc_group_titles)
 
         self.evision_nif.write('defmodule :evision_nif do\n{}\n'.format(ET.gen_evision_nif_load_nif))
         self.evision_nif_erlang.write('-module(evision_nif).\n-compile(nowarn_export_all).\n-compile([export_all]).\n\n{}\n{}\n'.format(ET.gen_evision_nif_load_nif_erlang, ET.gen_cv_types_erlang))

--- a/scripts/inject_doc_groups.py
+++ b/scripts/inject_doc_groups.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Post-process `lib/generated/evision.ex` to inject `@doc group:` annotations.
+
+In a from-source build the codegen in `py_src/pipeline.py` already emits these
+annotations directly. This script exists for the precompiled flow: when
+`mix compile.evision_precompiled` copies a cached `evision.ex` that pre-dates
+the codegen change, this script reads OpenCV's headers locally and patches
+the file in place so `mix docs` can group functions today instead of waiting
+for the next precompiled release.
+
+Usage:
+
+    python3 scripts/inject_doc_groups.py [OPENCV_SRC_DIR] [OPENCV_CONTRIB_DIR]
+
+Both args default to ../opencv and ../opencv_contrib relative to the repo
+root. The OPENCV_SRC environment variable overrides the first arg; the
+OPENCV_CONTRIB env var overrides the second.
+"""
+
+from __future__ import print_function
+
+import glob
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO, "py_src"))
+
+import doxygen_groups  # noqa: E402
+
+
+def _collect_headers(*roots):
+    headers = []
+    for root in roots:
+        if not root or not os.path.isdir(root):
+            continue
+        for ext in ("hpp", "h"):
+            headers.extend(
+                glob.glob(
+                    os.path.join(root, "modules", "**", "include", "opencv2", "**", "*." + ext),
+                    recursive=True,
+                )
+            )
+            headers.extend(
+                glob.glob(
+                    os.path.join(root, "modules", "**", "include", "opencv2", "*." + ext),
+                    recursive=True,
+                )
+            )
+    return headers
+
+
+def _inject(source, func_to_group, group_titles):
+    # Insert `@doc group: "..."` before each `@doc """ ... """` block.
+    # Function names live a few lines below the closing triple-quote; sniff
+    # that line for `def someName(...)` and skip the keyword-arg overload
+    # since it shares the same group annotation as the canonical clause.
+    def_re = re.compile(r'^\s*def\s+([a-zA-Z_]\w*)(?:\(|\s+(?:do\b|when\b))')
+    out = []
+    i = 0
+    lines = source.splitlines(keepends=True)
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == '@doc """':
+            j = i + 1
+            while j < len(lines) and lines[j].strip() != '"""':
+                j += 1
+            func_name = None
+            k = j + 1
+            while k < min(len(lines), j + 8) and func_name is None:
+                m = def_re.match(lines[k])
+                if m:
+                    func_name = m.group(1)
+                k += 1
+            indent = line[: len(line) - len(line.lstrip())]
+            if func_name:
+                gid = doxygen_groups.lookup(func_to_group, func_name)
+                if gid:
+                    title = doxygen_groups.title_for(group_titles, gid)
+                    out.append(f'{indent}@doc group: {_elixir_string(title)}\n')
+            out.append(line)
+            i += 1
+            continue
+        out.append(line)
+        i += 1
+    return "".join(out)
+
+
+def _elixir_string(value):
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def main():
+    opencv = os.environ.get("OPENCV_SRC") or (sys.argv[1] if len(sys.argv) > 1 else None)
+    contrib = os.environ.get("OPENCV_CONTRIB") or (sys.argv[2] if len(sys.argv) > 2 else None)
+    if not opencv:
+        opencv = os.path.realpath(os.path.join(REPO, "..", "opencv"))
+    if not contrib:
+        contrib = os.path.realpath(os.path.join(REPO, "..", "opencv_contrib"))
+
+    headers = _collect_headers(opencv, contrib)
+    if not headers:
+        print(f"No OpenCV headers found under {opencv!r} or {contrib!r}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Scanning {len(headers)} OpenCV headers...")
+    titles, funcs = doxygen_groups.scan(headers)
+    print(f"  {len(titles)} groups, {len(funcs)} tagged function symbols.")
+
+    target = os.path.join(REPO, "lib", "generated", "evision.ex")
+    with open(target, "r", encoding="utf-8") as f:
+        src = f.read()
+    patched = _inject(src, funcs, titles)
+    added = patched.count("@doc group:") - src.count("@doc group:")
+    with open(target, "w", encoding="utf-8") as f:
+        f.write(patched)
+    print(f"Wrote {target} (+{added} @doc group: annotations)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

<img width="1609" height="994" alt="image" src="https://github.com/user-attachments/assets/30ecda39-83da-4bba-9559-f0571b92ac02" />



## Summary

Addresses [#192](https://github.com/cocoa-xu/evision/issues/192) (Documentation Enhancements). All four suggestions are now wired up; verified locally with `MIX_ENV=docs mix docs`.

### 1. Module groups (`groups_for_modules` + `nest_modules_by_prefix`)
The sidebar's flat list of 650+ generated modules is now split into 55 OpenCV-aligned buckets — Core Functionality, Image Processing, 2D Features Framework, DNN, ML, CUDA, plus all the contrib categories (ArUco, BgSegm, Face, XImgProc, etc.). Deep namespaces (`Evision.DNN.*`, `Evision.ML.*`, …) are folded under their parent so the sidebar stays scannable.

### 2. Function groups in the `Evision` root module (`@doc group:` via codegen)
The root module previously dumped ~1400 functions in one block. A new `py_src/doxygen_groups.py` scanner walks OpenCV's headers tracking `@addtogroup id ... @{ ... @}` scopes plus `@ingroup` overrides, and the codegen now emits `@doc group: "<title>"` per function. ExDoc reads it via the rewritten `groups_for_docs` in `mix.exs`, producing ~35 OpenCV subgroups inside `Evision` (Operations on Arrays, Image Filtering, Drawing Functions, Feature Detection, HDR Imaging, Stereo Correspondence, …).

A one-shot post-processor (`scripts/inject_doc_groups.py`) is included for the precompiled flow — it scans a local OpenCV checkout and patches `lib/generated/evision.ex` so existing precompiled releases can pick up the grouping today without waiting for the next codegen-emitted release.

### 3. MathJax
Replaced the MathJax 2.7 HTML-CSS setup with MathJax 3 (`tex-svg`) using `fontCache: 'global'` for a single shared glyph cache, `defer`-loaded, with `<pre>`/`<code>` skipped. The OpenCV macro preamble (`matTT`, `fork`, `vecthreethree`, `cameramatrix`, etc.) is preserved verbatim. SSR was suggested in the original issue; the modern MathJax 3 SVG renderer is the practical 2026 fix that gets the perf win without ExDoc-side work.

### 4. Extras pages (`groups_for_extras`)
README stays as the main entry. CHANGELOG/Cheatsheet are grouped under "Introduction", and the example livemd files are split into "Examples: Getting Started", "Examples: Image Processing" (qrcode, warp_*, stitching, pca, photo-hdr, sudoku, find_and_draw_contours), "Examples: Deep Neural Networks" (cifar10, dnn-googlenet, dnn-detection-model, densenet121), and "Examples: Machine Learning" (svm, decision tree / random forest).

## Test plan

- [x] `MIX_ENV=docs mix docs` builds without new warnings; only the pre-existing `Evision.Backend` Nx.Tensor type warning remains.
- [x] `MIX_ENV=test mix compile` clean (same caveat).
- [x] Sidebar verification: every generated module except `Evision` itself falls into a named group (`Evision` intentionally sits at the top, ungrouped).
- [x] Function-group verification: `Evision`'s sidebar now lists 30+ subsections with ~700 of ~1000 functions categorized; the rest (factories like `create*`, `*Extended` variants) stay in the default "Functions" group — OpenCV doesn't tag them at the source either.
- [x] Extras grouping verification: 17 livemd/markdown extras land in the right buckets, README stays as the main page.
- [x] CI: precompile pipelines unaffected (no C++ or NIF changes).

## Notes for reviewers

- The codegen change emits `@doc group:` only for the root `Evision` module. Submodules (`Evision.DNN`, etc.) don't get per-function groups since their function lists are already short and already implicitly grouped by being in a submodule.
- `groups_for_docs` is generated by zipping the ~80 unique OpenCV `@defgroup` titles into anonymous filter functions. ExDoc 0.34's `groups_for_docs` keyword-list shape requires atom keys, so titles are converted via `String.to_atom/1` (bounded set; safe).
- The post-process script (`scripts/inject_doc_groups.py`) is opt-in and only invoked manually — it isn't wired into `mix compile`/`mix docs`. The release codegen path remains the canonical source of these annotations.