### PR TITLE
fix: get evision loading on FreeBSD again

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ brew install tesseract
 
 evision searches `/opt/homebrew/lib`, `/usr/local/lib`, and `/opt/local/lib` for the Tesseract dylib at load time, so Homebrew (both Apple Silicon and Intel) and MacPorts work out of the box. For Nix or other custom prefixes, set `DYLD_LIBRARY_PATH` to the directory containing `libtesseract.5.dylib` before starting your application. See [#287](https://github.com/cocoa-xu/evision/issues/287) for details.
 
+#### FreeBSD: install OpenBLAS
+
+The precompiled FreeBSD binaries link against OpenBLAS (a transitive dependency of OpenCV's `calib3d` module) and it is **not bundled** with the tarball. Without it, `evision.so` fails to load at on_load with `Shared object "libopenblas.so.0" not found, required by "libopencv_calib3d.so"`.
+
+```sh
+pkg install openblas
+```
+
 <details>
 
 <summary>Advanced Options</summary>

--- a/mix.exs
+++ b/mix.exs
@@ -227,6 +227,16 @@ defmodule Mix.Tasks.Compile.EvisionPrecompiled do
             arch
           end
 
+        # FreeBSD's system_architecture is `arch-vendor-osversion` (e.g. amd64-portbld-freebsd13.5),
+        # but the 3-tuple parser above puts the vendor in the `os` slot. Canonical precompiled
+        # names use `unknown` as the vendor and normalize arch to LLVM-style.
+        {arch, os} =
+          if abi == "freebsd" do
+            {if(arch == "amd64", do: "x86_64", else: arch), "unknown"}
+          else
+            {arch, os}
+          end
+
         abi = System.get_env("TARGET_ABI", abi)
         os = System.get_env("TARGET_OS", os)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1480,6 +1480,7 @@ defmodule Evision.MixProject do
           c_src/evision.cpp
           c_src/nif_utils.hpp
           cc_toolchain
+          cmake
           lib/assets
           lib/evision
           lib/mix

--- a/py_src/evision_templates.py
+++ b/py_src/evision_templates.py
@@ -231,7 +231,10 @@ init() ->
         Dir ->
             filename:join(Dir, ?LIBNAME)
     end,
-    evision_windows_fix:run_once(),
+    case os:type() of
+        {win32, _} -> evision_windows_fix:run_once();
+        _ -> ok
+    end,
     erlang:load_nif(SoName, 0).
 
 not_loaded(Line) ->


### PR DESCRIPTION
## Summary

Three independent bugs were blocking evision on FreeBSD; reproduced on a fresh FreeBSD 13.4 amd64 VM. After this branch, the precompiled flow downloads `evision-nif_2.16-x86_64-unknown-freebsd-contrib-0.2.16.tar.gz`, the NIF loads cleanly, and `Evision.Mat.zeros({3,3}, :u8)` returns a real Mat.

### 1. Erlang NIF loader template called `evision_windows_fix:run_once/0` unconditionally (`py_src/evision_templates.py`)

Commit 19e538c fixed this for the Elixir template but the Erlang one (used by rebar3/Erlang releases) still made the unconditional call. On any non-Windows host where `evision_windows_fix` isn't on the code path, on_load raised `undef` and crashed the VM — the exact stacktrace from #290. Guarded with `case os:type() of {win32, _} -> ... ; _ -> ok end`.

### 2. FreeBSD target detection produced a name no precompiled tarball matched (`mix.exs`)

Erlang reports `system_architecture` on FreeBSD as `amd64-portbld-freebsd13.5` — a 3-tuple of `arch-vendor-osversion`. The 3-part parser in `get_target/0` treats the middle field as `os`, so after abi cleanup the target id came out as `amd64-portbld-freebsd`. The canonical name in `@available_targets` is `x86_64-unknown-freebsd`, so `available_for_target?/1` returned false, `deploy_type/1` fell back to `:build_from_source`, and FreeBSD users never used precompiled binaries. (This is why #276's user had to compile OpenCV from source.)

Added a post-normalization step: when abi resolves to `"freebsd"`, rewrite `amd64 → x86_64` and replace the vendor field with `"unknown"`. macOS happened to already round-trip correctly through the same broken parser (`x86_64-apple-darwin` ≡ canonical), so this only touches the FreeBSD path.

### 3. Hex package missed `cmake/` directory (`mix.exs`)

`Makefile:185` does `cp cmake/OpenCVDetectCUDAUtils.cmake ...` during source build, but the `package` `files:` whitelist didn't include `cmake/`, so the 0.2.16 hex tarball is missing the file and any source build fails with `cp: cmake/OpenCVDetectCUDAUtils.cmake: No such file or directory`. Added `cmake` to the list.

### 4. README: pkg install openblas (`README.md`)

The precompiled FreeBSD tarball links against `libopenblas.so.0` (transitive dep of OpenCV's `calib3d`), which isn't bundled. Without it the NIF fails at on_load even for users who never touch calib3d — same eager-rtld-resolution gotcha already documented for macOS/Tesseract. Added a parallel "FreeBSD: install OpenBLAS" subsection.

Fixes #276. Fixes #290 (for the Erlang path; Elixir path was already fixed in 19e538c, the issue #290 user just needs to upgrade past 0.2.14).

## Test plan

Reproduced on FreeBSD 13.4-RELEASE amd64 in QEMU/KVM:

- [x] `mix new repro --sup` with `{:evision, path: "..."}` dep
- [x] `pkg install -y erlang elixir cmake gmake python bash git pkgconf ca_root_nss openblas`
- [x] Before the branch: `mix compile` falls back to source build, fails at `cp ... cmake/OpenCVDetectCUDAUtils.cmake`
- [x] After the branch: `mix compile` logs `Current target x86_64-unknown-freebsd has precompiled binaries`, downloads the tarball, extracts to priv, compiles 685 .ex files
- [x] `Evision.Mat.zeros({3, 3}, :u8)` returns `%Evision.Mat{channels: 1, dims: 2, type: {:u, 8}, shape: {3, 3}, ...}` — no `evision_windows_fix:run_once` undef
- [x] Erlang template change: textually mirrors the existing Elixir guard added in 19e538c
