### PR TITLE
fix: harden Mat backend helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `Evision.Mat.clip/3`: upper bound no longer collapses to the lower bound (typo where both branches compared against `lower`).
+- `Evision.Mat.dot/2`: now actually computes a dot product. The previous implementation called `cv::Mat::cross` despite being named `dot`, so it only worked for 3-element vectors and returned a `Mat`. See **Breaking changes** below.
+- `Evision.Mat.arange/4,5`: range count is now computed with ceiling division, so the final stepped value is included when the interval is not evenly divisible (e.g. `arange(0, 5, 2)` now returns `[0, 2, 4]` instead of `[0, 2]`). `step == 0` and direction mismatches are rejected explicitly.
+- `Evision.Mat.negate/1`, `Evision.Mat.ceil/1`, `Evision.Mat.floor/1`, `Evision.Mat.round/1`: now traverse every scalar in multi-channel matrices instead of only the first channel of each pixel.
+- `Evision.Mat.ceil/1`, `Evision.Mat.floor/1`, `Evision.Mat.round/1`: added support for `CV_16F` (half-precision float) inputs.
+- `Evision.Mat.at/2`: added bounds checking (was previously undefined behaviour past the end) and a clone-on-non-continuous fallback so the scalar index lands on the right element. `CV_16F` is now supported.
+- `Evision.Mat.from_binary_by_shape/3`: rejects binaries whose byte size does not match the declared shape (previously created a `Mat` that read past the binary).
+- `Evision.Mat.from_binary/5`: the declared `rows × cols × channels × bytes_per_element` is now computed with overflow checks.
+- `Evision.Mat.to_binary/1,2`:
+  - The `limit` parameter is now honored on the NIF path (was previously ignored).
+  - Non-continuous matrices are cloned before serialisation so the returned binary contains contiguous element data rather than the underlying buffer's interleaved padding.
+  - The `nx_tensor` branch in Elixir now interprets `limit` as the number of elements (multiplying by `elem_size`), matching the NIF path and the `Backend.inspect/2` caller.
+- `Evision.Mat.to_batched/3` (3-arg): now works on multi-channel matrices (previously the `shape(mat)` it derived internally always failed the size check). The 3-arg wrapper also no longer passes a tuple where a list is expected.
+- `Evision.Mat.to_batched/4` repeat mode: no longer reads past the source matrix when `batch_size × slice_size` exceeds the source size; the source is now safely repeated as many times as needed.
+- `Evision.Mat.update_roi/3`: the caller's `Mat` data is no longer mutated in place — `update_roi` always returns a new `Mat` and leaves the input untouched. Previously the underlying buffer was modified through the shared reference, silently mutating any other reference to the same `Mat`.
+- `Evision.Mat.transpose/3` with `as_shape:`: rejects `as_shape` whose total byte size does not match the source matrix, preventing out-of-bounds reads from `cv::transposeND`.
+- `Evision.Mat.expm1/1`: removed a dead/buggy fallback that called `cv::exp` a second time without exception protection after the wrapped call had already failed.
+- `Evision.Mat.last_dim_as_channel/1`: now uses `src.depth()` (instead of the full type) when re-tagging the channels and explicitly rejects channel counts outside `[1, CV_CN_MAX]`.
+- `Evision.CUDA.GpuMat.from_pointer/3`: the resource is now released on the error path (previously leaked) and the OOM path returns a proper error term.
+- `evision::nif::get_tuple` for `std::vector<int64_t>`: now reads each element as `int64_t` (was `int`), so large 64-bit values in tuples are no longer truncated/rejected.
+- `evision_highgui` thread initialisation: races between concurrent `start_native_gui` callers are now serialised behind an `EVISION_INITIATING` state, and `evision_main_loop` notifies all waiters (was `notify_one`, which could leave additional waiters stuck).
+- `alloc_resource` for `cv::Mat *`: explicitly initialises `tmp->val = nullptr` so a release before assignment does not free uninitialised memory.
+
+### Added
+
+- `Evision.Mat.matmul/2`: convenience wrapper around `cv::Mat::operator*` (matrix multiplication via `cv::gemm`). Both inputs must be 2-D and share a `CV_32F` or `CV_64F` depth. For element-wise dot-product semantics use `Evision.Mat.dot/2`.
+
+### Breaking changes
+
+- `Evision.Mat.dot/2` now returns a `number()` (the scalar dot product) instead of a `%Evision.Mat{}`. This matches the C++ `cv::Mat::dot` definition. The previous behaviour was a bug: the function was implemented with `cv::Mat::cross`, which only accepted 3-element vectors and returned a `Mat`. Callers who actually wanted matrix multiplication should switch to the new `Evision.Mat.matmul/2`.
+- `Evision.Mat.to_batched/4` (4-arg, explicit `as_shape`) now requires `as_shape` to include channels as a dimension for multi-channel matrices, and the resulting batches are single-channel `Mat`s with the channel axis at the end. Concretely:
+  - Old: `to_batched(cv_8uc3_mat, batch_size, {N, H, W}, ...)` → batches of `CV_8UC3` mats with shape `{batch_size, H, W}`.
+  - New: `to_batched(cv_8uc3_mat, batch_size, {N, H, W, 3}, ...)` → batches of `CV_8U` mats with shape `{batch_size, H, W, 3}`.
+  - The old `to_batched(cv_8uc3_mat, batch_size, {N, H, W}, ...)` call now returns `{:error, "to_batched failed: cannot treated matrix as the request shape"}`.
+  - `Evision.Backend` (Nx) workflows are **not affected**: tensors entering through `from_nx`/`from_binary` are always single-channel `Mat`s with the logical Nx shape, so the old and new size-checks evaluate identically.
+
 ## v0.2.14 (2025-08-15)
 [Browse the Repository](https://github.com/cocoa-xu/evision/tree/v0.2.14) | [Released Assets](https://github.com/cocoa-xu/evision/releases/tag/v0.2.14)
 

--- a/c_src/evision.cpp
+++ b/c_src/evision.cpp
@@ -84,6 +84,7 @@ int alloc_resource(evision_res<cv::Mat *> **res) {
     evision_res<cv::Mat *> * tmp = (evision_res<cv::Mat *> *)enif_alloc_resource(evision_res<cv::Mat *>::type, sizeof(evision_res<cv::Mat *>));
 
     if (tmp != nullptr) {
+        tmp->val = nullptr;
         tmp->in_buf = nullptr;
         tmp->in_ref = nullptr;
         tmp->in_unref = nullptr;

--- a/c_src/modules/evision_backend/ceil.h
+++ b/c_src/modules/evision_backend/ceil.h
@@ -19,16 +19,26 @@ static ERL_NIF_TERM evision_cv_mat_ceil(ErlNifEnv *env, int argc, const ERL_NIF_
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
             int type = img.type();
             uint8_t depth = type & CV_MAT_DEPTH_MASK;
-            if (depth == CV_32F) {
+            if (depth == CV_16F) {
+                Mat tmp;
+                img.convertTo(tmp, CV_MAKETYPE(CV_32F, img.channels()));
+                auto ptr = tmp.ptr<float>();
+                size_t count = tmp.total() * tmp.channels();
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] = ceilf(ptr[i]);
+                }
+                tmp.convertTo(img, type);
+                return evision_from(env, img);
+            } else if (depth == CV_32F) {
                 auto ptr = img.ptr<float>();
-                size_t count = img.total();
+                size_t count = img.total() * img.channels();
                 for (size_t i = 0; i < count; ++i) {
                     ptr[i] = ceilf(ptr[i]);
                 }
                 return evision_from(env, img);
             } else if (depth == CV_64F) {
                 auto ptr = img.ptr<double>();
-                size_t count = img.total();
+                size_t count = img.total() * img.channels();
                 for (size_t i = 0; i < count; ++i) {
                     ptr[i] = ceil(ptr[i]);
                 }

--- a/c_src/modules/evision_backend/clip.h
+++ b/c_src/modules/evision_backend/clip.h
@@ -24,7 +24,7 @@ static ERL_NIF_TERM evision_cv_mat_clip(ErlNifEnv *env, int argc, const ERL_NIF_
             evision_to_safe(env, evision_get_kw(env, erl_terms, "upper"), upper, ArgInfo("upper", 0))) {
             ERRWRAP2(img.setTo(lower, img < lower), env, error_flag, error_term);
             if (!error_flag) {
-                ERRWRAP2(img.setTo(lower, img > lower), env, error_flag, error_term);
+                ERRWRAP2(img.setTo(upper, img > upper), env, error_flag, error_term);
                 if (!error_flag) {
                     return evision_from(env, img);
                 }

--- a/c_src/modules/evision_backend/divide.h
+++ b/c_src/modules/evision_backend/divide.h
@@ -55,8 +55,11 @@ static ERL_NIF_TERM evision_cv_mat_divide_typed(ErlNifEnv *env, int argc, const 
             int type;
             if (!get_binary_type(t, l, 0, type)) return evision::nif::error(env, "not implemented for the given type");
             Mat ret;
-            cv::divide(lhs, rhs, ret, 1, type);
-            return evision_from(env, ret);
+            int error_flag = false;
+            ERRWRAP2(cv::divide(lhs, rhs, ret, 1, type), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision_from(env, ret);
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/expm1.h
+++ b/c_src/modules/evision_backend/expm1.h
@@ -27,8 +27,6 @@ static ERL_NIF_TERM evision_cv_mat_expm1(ErlNifEnv *env, int argc, const ERL_NIF
                     return evision_from(env, ret);
                 }
             }
-            cv::exp(img, ret);
-            return evision_from(env, Mat(ret - 1));
         }
     }
 

--- a/c_src/modules/evision_backend/floor.h
+++ b/c_src/modules/evision_backend/floor.h
@@ -19,16 +19,26 @@ static ERL_NIF_TERM evision_cv_mat_floor(ErlNifEnv *env, int argc, const ERL_NIF
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
             int type = img.type();
             uint8_t depth = type & CV_MAT_DEPTH_MASK;
-            if (depth == CV_32F) {
+            if (depth == CV_16F) {
+                Mat tmp;
+                img.convertTo(tmp, CV_MAKETYPE(CV_32F, img.channels()));
+                auto ptr = tmp.ptr<float>();
+                size_t count = tmp.total() * tmp.channels();
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] = floorf(ptr[i]);
+                }
+                tmp.convertTo(img, type);
+                return evision_from(env, img);
+            } else if (depth == CV_32F) {
                 auto ptr = img.ptr<float>();
-                size_t count = img.total();
+                size_t count = img.total() * img.channels();
                 for (size_t i = 0; i < count; ++i) {
                     ptr[i] = floorf(ptr[i]);
                 }
                 return evision_from(env, img);
             } else if (depth == CV_64F) {
                 auto ptr = img.ptr<double>();
-                size_t count = img.total();
+                size_t count = img.total() * img.channels();
                 for (size_t i = 0; i < count; ++i) {
                     ptr[i] = floor(ptr[i]);
                 }

--- a/c_src/modules/evision_backend/from_binary.h
+++ b/c_src/modules/evision_backend/from_binary.h
@@ -2,8 +2,35 @@
 #define EVISION_BACKEND_FROM_BINARY_H
 
 #include <erl_nif.h>
+#include <limits>
+#include <vector>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+
+static bool evision_checked_mul_size(size_t lhs, size_t rhs, size_t& out) {
+    if (rhs != 0 && lhs > std::numeric_limits<size_t>::max() / rhs) {
+        return false;
+    }
+    out = lhs * rhs;
+    return true;
+}
+
+static bool evision_shape_byte_size(const std::vector<int>& shape, size_t elem_size, size_t& byte_size) {
+    if (shape.empty()) {
+        return false;
+    }
+
+    size_t count = 1;
+    for (int dim : shape) {
+        if (dim <= 0) {
+            return false;
+        }
+        if (!evision_checked_mul_size(count, (size_t)dim, count)) {
+            return false;
+        }
+    }
+    return evision_checked_mul_size(count, elem_size, byte_size);
+}
 
 // @evision c: mat_from_binary,evision_cv_mat_from_binary,1
 // @evision nif: def mat_from_binary(_opts \\ []), do: :erlang.nif_error(:undefined)
@@ -21,8 +48,6 @@ static ERL_NIF_TERM evision_cv_mat_from_binary(ErlNifEnv *env, int argc, const E
         int img_rows = 0;
         int img_channels = 0;
 
-        Mat retval;
-
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "t"), t, ArgInfo("t", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "cols"), img_cols, ArgInfo("cols", 0)) &&
@@ -36,7 +61,12 @@ static ERL_NIF_TERM evision_cv_mat_from_binary(ErlNifEnv *env, int argc, const E
                 // validate binary data
                 int type = 0;
                 if (!get_binary_type(t, l, img_channels, type)) return evision::nif::error(env, "not implemented for the given type");
-                size_t declared_size = (size_t)img_rows * img_cols * img_channels * (l / 8);
+                size_t declared_size;
+                if (img_rows <= 0 || img_cols <= 0 || img_channels <= 0 ||
+                    !evision_checked_mul_size((size_t)img_rows, (size_t)img_cols, declared_size) ||
+                    !evision_checked_mul_size(declared_size, CV_ELEM_SIZE(type), declared_size)) {
+                    return evision::nif::error(env, "invalid shape");
+                }
                 if (declared_size != data.size) return evision::nif::error(env, "size mismatch");
 
                 evision_res<cv::Mat *> * res;
@@ -98,18 +128,17 @@ static ERL_NIF_TERM evision_cv_mat_from_binary_by_shape(ErlNifEnv *env, int argc
                 int type = 0;
                 int ndims = (int)shape.size();
                 if (!get_binary_type(t, l, 0, type)) return evision::nif::error(env, "not implemented for the given type");
+                size_t declared_size;
+                if (!evision_shape_byte_size(shape, CV_ELEM_SIZE(type), declared_size)) {
+                    return evision::nif::error(env, "invalid shape");
+                }
+                if (declared_size != data.size) return evision::nif::error(env, "size mismatch");
 
                 evision_res<cv::Mat *> * res;
                 if (alloc_resource(&res)) {
                     if (_evision_binary_ref(erl_binary, res)) {
                         enif_release_resource(res);
                         return enif_make_badarg(env);
-                    }
-
-                    // Mat(int ndims, const int* sizes, int type, void* data, const size_t* steps=0);
-                    int * sizes = (int *)enif_alloc(sizeof(int) * ndims);
-                    for (int i = 0; i < ndims; i++) {
-                        sizes[i] = shape[i];
                     }
 
                     // https://docs.opencv.org/4.5.5/d3/d63/classcv_1_1Mat.html#a5fafc033e089143062fd31015b5d0f40
@@ -120,9 +149,7 @@ static ERL_NIF_TERM evision_cv_mat_from_binary_by_shape(ErlNifEnv *env, int argc
                     // 	which means that no data is copied. This operation is very efficient and can be used
                     // 	to process external data using OpenCV functions. The external data is not automatically
                     // 	deallocated, so you should take care of it.
-                    res->val = new Mat(ndims, sizes, type, (void *)res->in_buf);
-
-                    enif_free((void *)sizes);
+                    res->val = new Mat(ndims, shape.data(), type, (void *)res->in_buf);
 
                     // transfer ownership to ERTS
                     ERL_NIF_TERM term = enif_make_resource(env, res);

--- a/c_src/modules/evision_backend/multiply.h
+++ b/c_src/modules/evision_backend/multiply.h
@@ -55,8 +55,11 @@ static ERL_NIF_TERM evision_cv_mat_multiply_typed(ErlNifEnv *env, int argc, cons
             int type;
             if (!get_binary_type(t, l, 0, type)) return evision::nif::error(env, "not implemented for the given type");
             Mat ret;
-            cv::multiply(lhs, rhs, ret, 1, type);
-            return evision_from(env, ret);
+            int error_flag = false;
+            ERRWRAP2(cv::multiply(lhs, rhs, ret, 1, type), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision_from(env, ret);
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/negate.h
+++ b/c_src/modules/evision_backend/negate.h
@@ -22,14 +22,14 @@ static ERL_NIF_TERM evision_cv_mat_negate(ErlNifEnv *env, int argc, const ERL_NI
 
             if (depth == CV_8U) {
                 auto ptr = img.ptr<uint8_t>();
-                size_t count = img.total();
+                size_t count = img.total() * img.channels();
                 for (size_t i = 0; i < count; ++i) {
                     ptr[i] = 0 - ptr[i];
                 }
                 return evision_from(env, img);
             } else if (depth == CV_16U) {
                 auto ptr = img.ptr<uint16_t>();
-                size_t count = img.total();
+                size_t count = img.total() * img.channels();
                 for (size_t i = 0; i < count; ++i) {
                     ptr[i] = 0 - ptr[i];
                 }

--- a/c_src/modules/evision_backend/round.h
+++ b/c_src/modules/evision_backend/round.h
@@ -19,16 +19,26 @@ static ERL_NIF_TERM evision_cv_mat_round(ErlNifEnv *env, int argc, const ERL_NIF
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0))) {
             int type = img.type();
             uint8_t depth = type & CV_MAT_DEPTH_MASK;
-            if (depth == CV_32F) {
+            if (depth == CV_16F) {
+                Mat tmp;
+                img.convertTo(tmp, CV_MAKETYPE(CV_32F, img.channels()));
+                auto ptr = tmp.ptr<float>();
+                size_t count = tmp.total() * tmp.channels();
+                for (size_t i = 0; i < count; ++i) {
+                    ptr[i] = roundf(ptr[i]);
+                }
+                tmp.convertTo(img, type);
+                return evision_from(env, img);
+            } else if (depth == CV_32F) {
                 auto ptr = img.ptr<float>();
-                size_t count = img.total();
+                size_t count = img.total() * img.channels();
                 for (size_t i = 0; i < count; ++i) {
                     ptr[i] = roundf(ptr[i]);
                 }
                 return evision_from(env, img);
             } else if (depth == CV_64F) {
                 auto ptr = img.ptr<double>();
-                size_t count = img.total();
+                size_t count = img.total() * img.channels();
                 for (size_t i = 0; i < count; ++i) {
                     ptr[i] = round(ptr[i]);
                 }

--- a/c_src/modules/evision_backend/subtract.h
+++ b/c_src/modules/evision_backend/subtract.h
@@ -55,8 +55,11 @@ static ERL_NIF_TERM evision_cv_mat_subtract_typed(ErlNifEnv *env, int argc, cons
             int type;
             if (!get_binary_type(t, l, 0, type)) return evision::nif::error(env, "not implemented for the given type");
             Mat ret;
-            cv::subtract(lhs, rhs, ret, cv::noArray(), type);
-            return evision_from(env, ret);
+            int error_flag = false;
+            ERRWRAP2(cv::subtract(lhs, rhs, ret, cv::noArray(), type), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision_from(env, ret);
+            }
         }
     }
 

--- a/c_src/modules/evision_backend/to_batched.h
+++ b/c_src/modules/evision_backend/to_batched.h
@@ -2,6 +2,7 @@
 #define EVISION_BACKEND_TO_BATCHED_LIST_H
 
 #include <erl_nif.h>
+#include <algorithm>
 #include "../../ArgInfo.hpp"
 
 // @evision c: mat_to_batched,evision_cv_mat_to_batched,1
@@ -25,11 +26,22 @@ static ERL_NIF_TERM evision_cv_mat_to_batched(ErlNifEnv *env, int argc, const ER
         if (leftover != "repeat" && leftover != "discard") {
             return evision::nif::error(env, "to_batched failed: invalid option value for leftover. Valid values are :repeat and :discard");
         }
+        if (as_shape.empty()) {
+            return evision::nif::error(env, "to_batched failed: invalid shape");
+        }
 
-        size_t mat_num_elem = img.total();
+        int mat_type = img.channels() == 1 ? img.type() : img.depth();
+        size_t elem_size = img.elemSize1();
+        size_t mat_num_elem = img.total() * img.channels();
         size_t as_shape_num_elem = 1;
         for (size_t i = 0; i < as_shape.size(); i++) {
+            if (as_shape[i] <= 0) {
+                return evision::nif::error(env, "to_batched failed: invalid shape");
+            }
             as_shape_num_elem *= as_shape[i];
+        }
+        if (batch_size == 0) {
+            return evision::nif::error(env, "to_batched failed: invalid batch size");
         }
         if (mat_num_elem != as_shape_num_elem) {
             return evision::nif::error(env, "to_batched failed: cannot treated matrix as the request shape");
@@ -37,7 +49,7 @@ static ERL_NIF_TERM evision_cv_mat_to_batched(ErlNifEnv *env, int argc, const ER
         
         uint64_t remainder = as_shape[0] % batch_size;
         uint64_t num_full_batches = as_shape[0] / batch_size;
-        uint64_t slice_size = as_shape_num_elem / as_shape[0] * img.elemSize();
+        uint64_t slice_size = as_shape_num_elem / as_shape[0] * elem_size;
         uint64_t batch_bytes = slice_size * batch_size;
 
         unsigned num_batches = (unsigned)num_full_batches;
@@ -48,6 +60,9 @@ static ERL_NIF_TERM evision_cv_mat_to_batched(ErlNifEnv *env, int argc, const ER
         }
 
         ERL_NIF_TERM * batches = (ERL_NIF_TERM * )enif_alloc(sizeof(ERL_NIF_TERM) * num_batches);
+        if (num_batches > 0 && batches == nullptr) {
+            return evision::nif::error(env, "to_batched failed: out of memory");
+        }
         char * data = (char *)img.data;
         // skip the first (batches)
         int ndims = (int)as_shape.size();
@@ -57,13 +72,17 @@ static ERL_NIF_TERM evision_cv_mat_to_batched(ErlNifEnv *env, int argc, const ER
         // deal with full batches
         char * offset_data = data;
         for (size_t i = 0; i < num_full_batches; i++) {
-            Mat mat = Mat(ndims, sizes, img.type(), offset_data);
+            Mat mat = Mat(ndims, sizes, mat_type, offset_data);
             batches[i] = evision_from(env, mat.clone());
             offset_data += batch_bytes;
         }
         // deal with leftover
         if (num_batches != num_full_batches) {
             char * last_batch_data = (char *)enif_alloc(batch_bytes);
+            if (last_batch_data == nullptr) {
+                enif_free(batches);
+                return evision::nif::error(env, "to_batched failed: out of memory");
+            }
 
             // copy leftover first
             uint64_t leftover_bytes = slice_size * remainder;
@@ -72,8 +91,15 @@ static ERL_NIF_TERM evision_cv_mat_to_batched(ErlNifEnv *env, int argc, const ER
             // repeat from the beginning
             uint64_t repeat_bytes = batch_bytes - leftover_bytes;
 
-            memcpy(last_batch_data + leftover_bytes, data, repeat_bytes);
-            Mat mat = Mat(ndims, sizes, img.type(), last_batch_data);
+            char *repeat_dst = last_batch_data + leftover_bytes;
+            uint64_t remaining = repeat_bytes;
+            while (remaining > 0) {
+                uint64_t copy_bytes = std::min<uint64_t>(remaining, as_shape_num_elem * elem_size);
+                memcpy(repeat_dst, data, copy_bytes);
+                repeat_dst += copy_bytes;
+                remaining -= copy_bytes;
+            }
+            Mat mat = Mat(ndims, sizes, mat_type, last_batch_data);
             batches[num_batches - 1] = evision_from(env, mat.clone());
             enif_free(last_batch_data);
         }

--- a/c_src/modules/evision_backend/to_binary.h
+++ b/c_src/modules/evision_backend/to_binary.h
@@ -2,6 +2,8 @@
 #define EVISION_BACKEND_TO_BINARY_H
 
 #include <erl_nif.h>
+#include <algorithm>
+#include <limits>
 #include "../../ArgInfo.hpp"
 
 // @evision c: mat_to_binary,evision_cv_mat_to_binary,1
@@ -14,12 +16,39 @@ static ERL_NIF_TERM evision_cv_mat_to_binary(ErlNifEnv *env, int argc, const ERL
     evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
 
     {
-        // const char *keywords[] = {"img", NULL};
-        // zero-copy to_binary
         evision_res<cv::Mat *> * res;
         if( enif_get_resource(env, evision_get_kw(env, erl_terms, "img"), evision_res<cv::Mat *>::type, (void **)&res) ) {
-            size_t bin_size = res->val->total() * res->val->elemSize();
-            ERL_NIF_TERM out_bin_term = enif_make_resource_binary(env, res, res->val->data, bin_size);
+            if (res->val == nullptr || res->val->data == nullptr) {
+                return evision::nif::error(env, "empty matrix");
+            }
+
+            ErlNifUInt64 limit = 0;
+            ERL_NIF_TERM limit_term = evision_get_kw(env, erl_terms, "limit");
+            if (!evision::nif::check_nil(env, limit_term) &&
+                !enif_get_uint64(env, limit_term, &limit)) {
+                return enif_make_badarg(env);
+            }
+
+            const size_t full_size = res->val->total() * res->val->elemSize();
+            size_t bin_size = full_size;
+            if (limit > 0) {
+                const size_t elem_size = res->val->elemSize1();
+                if (limit <= std::numeric_limits<size_t>::max() / elem_size) {
+                    bin_size = std::min((size_t)limit * elem_size, full_size);
+                }
+            }
+
+            if (res->val->isContinuous()) {
+                return enif_make_resource_binary(env, res, res->val->data, bin_size);
+            }
+
+            Mat continuous = res->val->clone();
+            ERL_NIF_TERM out_bin_term;
+            unsigned char *out = enif_make_new_binary(env, bin_size, &out_bin_term);
+            if (out == nullptr) {
+                return evision::nif::error(env, "out of memory");
+            }
+            memcpy(out, continuous.data, bin_size);
             return out_bin_term;
         }
     }

--- a/c_src/modules/evision_backend/transpose.h
+++ b/c_src/modules/evision_backend/transpose.h
@@ -2,6 +2,7 @@
 #define EVISION_BACKEND_TRANSPOSE_H
 
 #include <erl_nif.h>
+#include <limits>
 #include "../../ArgInfo.hpp"
 
 // @evision c: mat_transpose,evision_cv_mat_transpose,1
@@ -35,6 +36,18 @@ static ERL_NIF_TERM evision_cv_mat_transpose(ErlNifEnv *env, int argc, const ERL
         int error_flag = false;
         cv::Mat ret;
         if (as_shaped) {
+            size_t expected_elems = 1;
+            for (int dim : as_shape) {
+                if ((size_t)dim > std::numeric_limits<size_t>::max() / expected_elems) {
+                    return evision::nif::error(env, "as_shape overflow");
+                }
+                expected_elems *= (size_t)dim;
+            }
+            size_t expected_bytes = expected_elems * (size_t)CV_ELEM_SIZE1(img.depth());
+            size_t actual_bytes = (size_t)img.total() * (size_t)img.elemSize();
+            if (expected_bytes != actual_bytes) {
+                return evision::nif::error(env, "as_shape byte size does not match source matrix");
+            }
             if (!img.isContinuous()) {
                 img = img.clone();
             }

--- a/c_src/modules/evision_backend/transpose.h
+++ b/c_src/modules/evision_backend/transpose.h
@@ -4,127 +4,6 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 
-std::vector<int> transpose_axes(uint64_t ndims, int * axes,
-                    int64_t& min_axis, int64_t& max_axis) {
-    std::vector<int> axes_to_transpose;
-    min_axis = -1;
-    for (int64_t i = 0; i < (int64_t)ndims; i++) {
-        if (axes[i] == i) {
-            min_axis = i;
-        } else {
-            min_axis += 1;
-            break;
-        }
-    }
-
-    max_axis = ndims;
-    for (int64_t i = ndims - 1; i >= 0; i--) {
-        if ((int64_t)axes[i] == i) {
-            max_axis = i;
-        } else {
-            max_axis -= 1;
-            break;
-        }
-    }
-
-    for (int64_t i = min_axis; i <= max_axis; i++) {
-        axes_to_transpose.push_back(axes[i]);
-    }
-    return axes_to_transpose;
-}
-
-class transpose_shape_info {
-public:
-    transpose_shape_info() = default;
-    // number of entries for this axis
-    uint64_t entries;
-    // bytes per entry
-    uint64_t weight;
-    // total size for all entries
-    uint64_t total_size;
-};
-
-std::vector<transpose_shape_info> weighted_shape(uint64_t ndims, int * shape, size_t elem_size) {
-    std::vector<transpose_shape_info> weighed(ndims);
-    size_t weight = elem_size;
-    int64_t last_dim = (int64_t)ndims - 1;
-    for (int64_t i = last_dim; i >= 0; i--) {
-        auto &info = weighed[i];
-        info.entries = shape[i];
-        if (i == last_dim) {
-            info.weight = weight;
-        } else {
-            info.weight = weighed[i + 1].entries * weight;
-        }
-        info.total_size = info.weight * info.entries;
-        weight = info.weight;
-    }
-    return weighed;
-}
-
-void weighted_traverse(const std::vector<transpose_shape_info>& traverse_list, size_t start_at, void * chunk, size_t read_size, void * out, size_t chunk_offset, size_t& out_offset);
-void weighted_traverse(uint64_t dim, uint64_t dim_size, const std::vector<transpose_shape_info>& traverse_list, size_t start_at, void * data, size_t read_size, void * out, size_t data_offset, size_t &out_offset);
-
-void weighted_traverse(uint64_t dim, uint64_t dim_size, const std::vector<transpose_shape_info>& traverse_list, size_t start_at, void * data, size_t read_size, void * out, size_t data_offset, size_t &out_offset) {
-    weighted_traverse(traverse_list, start_at, data, read_size, out, data_offset, out_offset);
-    if (dim == 1) {
-        return;
-    } else {
-        weighted_traverse(dim - 1, dim_size, traverse_list, start_at, (void *)((uint64_t)(uint64_t *)data + dim_size), read_size, out, data_offset, out_offset);
-    }
-}
-
-void weighted_traverse(const std::vector<transpose_shape_info>& traverse_list, size_t start_at, void * chunk, size_t read_size, void * out, size_t chunk_offset, size_t& out_offset) {
-    if (start_at < traverse_list.size()) {
-        auto& info = traverse_list[start_at];
-        weighted_traverse(info.entries, info.weight, traverse_list, start_at + 1, chunk, read_size, out, chunk_offset, out_offset);
-    } else {
-        memcpy((void *)((uint64_t)(uint64_t *)out + out_offset), (void *)((uint64_t)(uint64_t *)chunk + chunk_offset), read_size);
-        out_offset += read_size;
-    }
-}
-
-/// Transpose a matrix
-/// @param original matrix data starting address, data must be continuous
-/// @param out transposed matrix, buffer must be preallocated with sufficient space to hold the result matrix
-/// @param ndims number of dimensions
-/// @param shape the shape of the original matrix, a list of positive integers
-/// @param new_axes the new arrangement of the axes, a list of non-negative integers, 0 <= i < ndims.
-/// @param elem_size element size in bytes.
-void transpose(void * original, void * out, uint64_t ndims, int * shape, int * new_axes, size_t elem_size) {
-    if (original == nullptr || out == nullptr) return;
-    if (ndims == 0 || shape == nullptr || new_axes == nullptr) return;
-
-    int64_t min_axis, max_axis;
-    std::vector<int> axes = transpose_axes(ndims, new_axes, min_axis, max_axis);
-    auto weighted_shape_info = weighted_shape(ndims, shape, elem_size);
-
-    size_t chunk_size = weighted_shape_info[min_axis].total_size;
-    size_t read_size = 0;
-    if (max_axis + 1 < (int64_t)ndims) {
-        read_size = weighted_shape_info[max_axis + 1].total_size;
-    } else {
-        read_size = elem_size;
-    }
-
-    auto traverse_list = std::vector<transpose_shape_info>(axes.size());
-    for (size_t i = 0; i < axes.size(); i++) {
-        traverse_list[i] = weighted_shape_info[axes[i]];
-    }
-
-    uint64_t original_bytes = elem_size;
-    for (uint64_t i = 0; i < ndims; i++) {
-        original_bytes *= shape[i];
-    }
-
-    size_t num_chunks = original_bytes / chunk_size;
-    size_t out_offset = 0;
-    for (size_t chunk_index = 0; chunk_index < num_chunks; chunk_index++) {
-        void * chunk = (uint64_t *)((uint64_t)original + chunk_size * chunk_index);
-        weighted_traverse(traverse_list, 0, chunk, read_size, out, 0, out_offset);
-    }
-}
-
 // @evision c: mat_transpose,evision_cv_mat_transpose,1
 // @evision nif: def mat_transpose(_opts \\ []), do: :erlang.nif_error(:undefined)
 static ERL_NIF_TERM evision_cv_mat_transpose(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -144,23 +23,23 @@ static ERL_NIF_TERM evision_cv_mat_transpose(ErlNifEnv *env, int argc, const ERL
         evision_to_safe(env, evision_get_kw(env, erl_terms, "as_shape"), as_shape, ArgInfo("as_shape", 0)) &&
         evision_to_safe(env, evision_get_kw(env, erl_terms, "as_shaped"), as_shaped, ArgInfo("as_shaped", 0))) {
         int ndims = (int)as_shape.size();
-        std::vector<int> new_shape(ndims);
-        for (size_t i = 0; i < axes.size(); i++) {
-            new_shape[i] = as_shape[axes[i]];
+        if (ndims <= 0 || axes.size() != as_shape.size()) {
+            return evision::nif::error(env, "invalid transpose shape or axes");
+        }
+        for (int dim : as_shape) {
+            if (dim <= 0) {
+                return evision::nif::error(env, "invalid transpose shape");
+            }
         }
 
         int error_flag = false;
         cv::Mat ret;
         if (as_shaped) {
-            // the data of img must be countinous
             if (!img.isContinuous()) {
-                // if not, call clone to force opencv make a continuous matrix for us
                 img = img.clone();
-                img = Mat((int)as_shape.size(), as_shape.data(), img.depth(), img.data);
             }
-            int type = img.type() & CV_MAT_DEPTH_MASK;
-            ret = cv::Mat::zeros(ndims, new_shape.data(), type);
-            ERRWRAP2(transpose(img.data, ret.data, ndims, as_shape.data(), axes.data(), img.elemSize()), env, error_flag, error_term);
+            Mat shaped(ndims, as_shape.data(), img.depth(), img.data);
+            ERRWRAP2(cv::transposeND(shaped, axes, ret), env, error_flag, error_term);
         } else {
             ERRWRAP2(cv::transposeND(img, axes, ret), env, error_flag, error_term);
         }

--- a/c_src/modules/evision_gpumat.h
+++ b/c_src/modules/evision_gpumat.h
@@ -226,7 +226,7 @@ static ERL_NIF_TERM evision_cv_cuda_cuda_GpuMat_from_pointer(ErlNifEnv *env, int
         if (self == nullptr) {
             return evision::nif::error(env, "out of memory");
         }
-        if (self) ERRWRAP2(self->val.reset(new cv::cuda::GpuMat(height, width, type, ptr)), env, error_flag, error_term);
+        ERRWRAP2(self->val.reset(new cv::cuda::GpuMat(height, width, type, ptr)), env, error_flag, error_term);
         if (!error_flag) {
             ERL_NIF_TERM ret = enif_make_resource(env, self);
             enif_release_resource(self);

--- a/c_src/modules/evision_gpumat.h
+++ b/c_src/modules/evision_gpumat.h
@@ -223,6 +223,9 @@ static ERL_NIF_TERM evision_cv_cuda_cuda_GpuMat_from_pointer(ErlNifEnv *env, int
         if (alloc_resource(&self)) {
             new (&(self->val)) Ptr<cv::cuda::GpuMat>(); // init Ptr with placement new
         }
+        if (self == nullptr) {
+            return evision::nif::error(env, "out of memory");
+        }
         if (self) ERRWRAP2(self->val.reset(new cv::cuda::GpuMat(height, width, type, ptr)), env, error_flag, error_term);
         if (!error_flag) {
             ERL_NIF_TERM ret = enif_make_resource(env, self);
@@ -230,6 +233,7 @@ static ERL_NIF_TERM evision_cv_cuda_cuda_GpuMat_from_pointer(ErlNifEnv *env, int
             bool success;
             return evision_from_as_map<Ptr<cv::cuda::GpuMat>>(env, self->val, ret, "Elixir.Evision.CUDA.GpuMat", success);
         }
+        enif_release_resource(self);
     }
 
     if (error_term != 0) return error_term;

--- a/c_src/modules/evision_highgui.h
+++ b/c_src/modules/evision_highgui.h
@@ -137,7 +137,7 @@ void *evision_main_loop(void * _unused)
         std::unique_lock<std::mutex> lk(gMtx);
         evision_status = EVISION_INITIATED;
     }
-    gCv.notify_one();
+    gCv.notify_all();
 
     int should_wait = true;
     while (should_wait) {

--- a/c_src/modules/evision_highgui.h
+++ b/c_src/modules/evision_highgui.h
@@ -54,6 +54,7 @@ std::mutex gMtx;
 std::condition_variable gCv;
 
 #define EVISION_NOT_INITIATED 100
+#define EVISION_INITIATING 150
 #define EVISION_INITIATED 200
 #define EVISION_EXITED 900
 #define EVISION_ERROR 1000
@@ -84,6 +85,18 @@ void *evision_main_loop(void * );
 
 int start_native_gui(ErlNifEnv *env)
 {
+    {
+        std::unique_lock<std::mutex> lock(gMtx);
+        if (evision_status == EVISION_INITIATED) {
+            return evision_status;
+        }
+        if (evision_status == EVISION_INITIATING) {
+            gCv.wait(lock, []{return evision_status != EVISION_INITIATING;});
+            return evision_status;
+        }
+        evision_status = EVISION_INITIATING;
+    }
+
     int res;
 #ifdef __APPLE__
     res = erl_drv_steal_main_thread((char *)"evision", &evision_thread, evision_main_loop, (void *)NULL, NULL);
@@ -93,15 +106,18 @@ int start_native_gui(ErlNifEnv *env)
     res = enif_thread_create((char *)"evision", &evision_thread, evision_main_loop, (void *)NULL, opts);
     enif_thread_opts_destroy(opts);
 #endif
-    {
+    if (res != 0) {
         std::unique_lock<std::mutex> lock(gMtx);
-        gCv.wait(lock, []{return evision_status != EVISION_NOT_INITIATED;});
+        evision_status = EVISION_ERROR;
+        lock.unlock();
+        gCv.notify_all();
+        return EVISION_ERROR;
     }
 
-    if (res == 0) {
+    {
+        std::unique_lock<std::mutex> lock(gMtx);
+        gCv.wait(lock, []{return evision_status != EVISION_INITIATING;});
         return evision_status;
-    } else {
-        return EVISION_ERROR;
     }
 }
 

--- a/c_src/modules/evision_mat.h
+++ b/c_src/modules/evision_mat.h
@@ -263,34 +263,6 @@ static ERL_NIF_TERM evision_cv_mat_roi(ErlNifEnv *env, int argc, const ERL_NIF_T
     else return enif_make_badarg(env);
 }
 
-/// `matrix` and `patch` should be contiguous.
-void mat_update_roi(cv::Mat& matrix, cv::Mat& patch, 
-    std::vector<cv::Range>& ranges, size_t elem_size,
-    size_t step_size, size_t from_step_size,
-    int dim_index, size_t base_offset, size_t from_offset)
-{
-    if (dim_index >= matrix.size.dims()) return;
-
-    step_size /= matrix.size.p[dim_index];
-    from_step_size /= patch.size.p[dim_index];
-
-    auto& range = ranges[dim_index];
-
-    if (step_size == elem_size) {
-        uint8_t* data = matrix.data;
-        uint8_t* from = patch.data;
-        memcpy(
-            (uint64_t *)(((uint64_t)(uint64_t *)(data)) + base_offset + range.start * elem_size),
-            (uint64_t *)(((uint64_t)(uint64_t *)(from)) + from_offset),
-            elem_size * (range.end - range.start)
-        );
-    } else {
-        for (int pos = range.start, from_pos = 0; pos < range.end; pos++, from_pos++) {
-            mat_update_roi(matrix, patch, ranges, elem_size, step_size, from_step_size, dim_index + 1, base_offset + step_size * pos, from_offset + from_step_size * from_pos);
-        }
-    }
-}
-
 // @evision c: mat_update_roi,evision_cv_mat_update_roi,1
 // @evision nif: def mat_update_roi(_opts \\ []), do: :erlang.nif_error(:undefined)
 static ERL_NIF_TERM evision_cv_mat_update_roi(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -317,19 +289,32 @@ static ERL_NIF_TERM evision_cv_mat_update_roi(ErlNifEnv *env, int argc, const ER
         } else if (mat.dims != with_mat.dims) {
             error_flag = true;
             error_term = evision::nif::error(env, "Cannot update roi: dimension mismatch");
+        } else if ((int)ranges.size() != mat.dims) {
+            error_flag = true;
+            error_term = evision::nif::error(env, "Cannot update roi: range dimension mismatch");
         } else {
-            if (!mat.isContinuous()) mat = mat.clone();
-            if (!with_mat.isContinuous()) with_mat = with_mat.clone();
-            size_t step_size = mat.elemSize();
-            for (int i = 0; i < mat.size.dims(); i++) {
-                step_size *= mat.size.p[i];
+            for (int i = 0; i < mat.dims; i++) {
+                if (ranges[i] == cv::Range::all()) {
+                    ranges[i] = cv::Range(0, mat.size.p[i]);
+                }
+                if (ranges[i].start < 0 || ranges[i].end < ranges[i].start || ranges[i].end > mat.size.p[i]) {
+                    error_flag = true;
+                    error_term = evision::nif::error(env, "Cannot update roi: range out of bounds");
+                    break;
+                }
+                if (with_mat.size.p[i] != ranges[i].end - ranges[i].start) {
+                    error_flag = true;
+                    error_term = evision::nif::error(env, "Cannot update roi: patch shape mismatch");
+                    break;
+                }
             }
-            size_t from_step_size = mat.elemSize();
-            for (int i = 0; i < with_mat.size.dims(); i++) {
-                from_step_size *= with_mat.size.p[i];
+            if (!error_flag) {
+                Mat target;
+                ERRWRAP2(target = mat(ranges), env, error_flag, error_term);
+                if (!error_flag) {
+                    ERRWRAP2(with_mat.copyTo(target), env, error_flag, error_term);
+                }
             }
-            size_t elem_size = mat.elemSize();
-            mat_update_roi(mat, with_mat, ranges, elem_size, step_size, from_step_size, 0, 0, 0);
         }
 
         if (!error_flag) {
@@ -442,14 +427,22 @@ static ERL_NIF_TERM evision_cv_mat_arange(ErlNifEnv *env, int argc, const ERL_NI
             int type;
             if (!get_binary_type(t, l, 0, type)) return evision::nif::error(env, "not implemented for the given type");
 
-            int32_t count = (to - from) / step;
-            int dims[1] = {0};
-            dims[0] = (int)count;
-            if (count <= 0) return evision::nif::error(env, "invalid values for start/end/step");
+            if (step == 0) return evision::nif::error(env, "invalid values for start/end/step");
+            if ((step > 0 && from >= to) || (step < 0 && from <= to)) {
+                return evision::nif::error(env, "invalid values for start/end/step");
+            }
 
-            std::vector<int32_t> values(count);
+            int64_t distance = step > 0 ? (int64_t)to - from : (int64_t)from - to;
+            int64_t step_size = step > 0 ? step : -(int64_t)step;
+            int64_t count64 = (distance + step_size - 1) / step_size;
+            if (count64 <= 0 || count64 > std::numeric_limits<int>::max()) {
+                return evision::nif::error(env, "invalid values for start/end/step");
+            }
+
+            int dims[1] = {(int)count64};
+            std::vector<int32_t> values((size_t)count64);
             int32_t v = from;
-            for (int32_t i = 0; i < count; i++) {
+            for (int64_t i = 0; i < count64; i++) {
                 values[i] = v;
                 v += step;
             }
@@ -487,9 +480,7 @@ static ERL_NIF_TERM evision_cv_mat_full(ErlNifEnv *env, int argc, const ERL_NIF_
             int type;
             if (!get_binary_type(t, l, 0, type)) return evision::nif::error(env, "not implemented for the given type");
 
-            Mat out = Mat(Mat::ones(shape.size(), shape.data(), CV_64F) * number);
-            Mat ret;
-            out.convertTo(ret, type);
+            Mat ret((int)shape.size(), shape.data(), type, Scalar(number));
             return evision_from(env, ret);
         }
     }
@@ -513,6 +504,13 @@ static ERL_NIF_TERM evision_cv_mat_at(ErlNifEnv *env, int argc, const ERL_NIF_TE
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "img"), img, ArgInfo("img", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "pos"), pos, ArgInfo("img", 0))) {
+            size_t count = img.total() * img.channels();
+            if (pos >= count) {
+                return evision::nif::error(env, "index out of bounds");
+            }
+            if (!img.isContinuous()) {
+                img = img.clone();
+            }
 
             int type = img.type();
             uint8_t depth = type & CV_MAT_DEPTH_MASK;
@@ -540,6 +538,10 @@ static ERL_NIF_TERM evision_cv_mat_at(ErlNifEnv *env, int argc, const ERL_NIF_TE
                 }
                 case CV_32S: {
                     i32 = ((int32_t *)img.data)[pos]; type = 0;
+                    break;
+                }
+                case CV_16F: {
+                    f64 = _do_cast_f16<double>(((uint16_t *)img.data)[pos]); type = 1;
                     break;
                 }
 
@@ -610,8 +612,12 @@ static ERL_NIF_TERM evision_cv_mat_dot(ErlNifEnv *env, int argc, const ERL_NIF_T
 
         if (evision_to_safe(env, evision_get_kw(env, erl_terms, "a"), a, ArgInfo("a", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "b"), b, ArgInfo("b", 0))) {
-            Mat out = a.cross(b);
-            return evision_from(env, out);
+            double out = 0;
+            int error_flag = false;
+            ERRWRAP2(out = a.dot(b), env, error_flag, error_term);
+            if (!error_flag) {
+                return evision_from(env, out);
+            }
         }
     }
 
@@ -904,7 +910,11 @@ static ERL_NIF_TERM evision_cv_mat_last_dim_as_channel(ErlNifEnv *env, int argc,
                 for (size_t i = 0; i < (size_t)(ndims - 1); i++) {
                     new_shape[i] = src.size.p[i];
                 }
-                int type = CV_MAKETYPE(src.type(), src.size.p[ndims - 1]);
+                int channels = src.size.p[ndims - 1];
+                if (channels <= 0 || channels > CV_CN_MAX) {
+                    return evision::nif::error(env, "invalid number of channels");
+                }
+                int type = CV_MAKETYPE(src.depth(), channels);
                 Mat ret = Mat(ndims - 1, new_shape.data(), type, src.data);
                 return evision_from(env, ret.clone());
             } else {

--- a/c_src/modules/evision_mat.h
+++ b/c_src/modules/evision_mat.h
@@ -309,6 +309,7 @@ static ERL_NIF_TERM evision_cv_mat_update_roi(ErlNifEnv *env, int argc, const ER
                 }
             }
             if (!error_flag) {
+                mat = mat.clone();
                 Mat target;
                 ERRWRAP2(target = mat(ranges), env, error_flag, error_term);
                 if (!error_flag) {

--- a/c_src/modules/evision_mat_utils.hpp
+++ b/c_src/modules/evision_mat_utils.hpp
@@ -2,7 +2,12 @@
 #define EVISION_MAT_UTILS_HPP
 #pragma once
 
+#include <string>
+
 int get_binary_type(const std::string& t, int l, int n, int& type) {
+    if (n < 0 || n > CV_CN_MAX) {
+        return false;
+    }
     if (t == "u") {
         if (l == 8) {
             if (n != 0) type = CV_8UC(n);
@@ -51,6 +56,9 @@ int get_binary_type(const std::string& t, int l, int n, int& type) {
 }
 
 int get_compact_type(const std::string& compact, int n, int& type) {
+    if (compact.empty() || n < 0 || n > CV_CN_MAX) {
+        return false;
+    }
     if (compact[0] == 'u') {
         if (compact == "u8") {
             if (n != 0) type = CV_8UC(n);

--- a/c_src/nif_utils.hpp
+++ b/c_src/nif_utils.hpp
@@ -291,7 +291,7 @@ namespace evision
 
       for (int i = 0; i < length; i++)
       {
-        int data;
+        int64_t data;
         if (!get(env, terms[i], &data))
           return 0;
         var.push_back(data);

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1563,14 +1563,40 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc """
+  Compute the dot product of two matrices as scalars.
+
+  Matches OpenCV `cv::Mat::dot` semantics: the matrices are scanned in
+  row-major order, treated as 1-D vectors of the same length, and the sum
+  of element-wise products is returned as a `double`. For multi-channel
+  matrices the per-channel dot products are summed together.
+
+  Both matrices must have the same size and the same type.
+  """
   @doc namespace: :"cv.Mat"
-  @spec dot(maybe_mat_in(), maybe_mat_in()) :: maybe_mat_out()
+  @spec dot(maybe_mat_in(), maybe_mat_in()) :: number() | {:error, String.t()}
   def dot(mat_a, mat_b) do
     mat_a = from_struct(mat_a)
     mat_b = from_struct(mat_b)
 
     :evision_nif.mat_dot(a: mat_a, b: mat_b)
     |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc """
+  Matrix multiplication of two 2-D matrices.
+
+  Wraps OpenCV's `cv::Mat::operator*` (which delegates to `cv::gemm`).
+  Both matrices must be 2-D and share a `CV_32F` or `CV_64F` depth. The
+  result has the same type as `mat_a`.
+  """
+  @doc namespace: :"cv.Mat"
+  @spec matmul(maybe_mat_in(), maybe_mat_in()) :: maybe_mat_out()
+  def matmul(mat_a, mat_b) do
+    case type(mat_a) do
+      {:error, msg} -> {:error, msg}
+      type -> matrix_multiply(mat_a, mat_b, type)
+    end
   end
 
   @doc namespace: :"cv.Mat"
@@ -1946,7 +1972,7 @@ defmodule Evision.Mat do
         :evision_nif.mat_to_batched(
           img: mat,
           batch_size: batch_size,
-          as_shape: as_shape,
+          as_shape: Tuple.to_list(as_shape),
           leftover: leftover
         )
         |> Evision.Internal.Structurise.to_struct()
@@ -1974,17 +2000,34 @@ defmodule Evision.Mat do
     mat = from_struct(mat)
 
     case mat do
-      %{__struct__: :nx_tensor, data: data} when is_binary(data) ->
+      %{__struct__: :nx_tensor, data: data, type: type} when is_binary(data) ->
         if limit == 0 do
           data
         else
-          :binary.part(data, 0, limit)
+          elem_size = compact_type_elem_size(type)
+          byte_limit = min(limit * elem_size, byte_size(data))
+          :binary.part(data, 0, byte_limit)
         end
 
       _ ->
         :evision_nif.mat_to_binary(img: mat, limit: limit)
     end
   end
+
+  defp compact_type_elem_size(:u8), do: 1
+  defp compact_type_elem_size(:s8), do: 1
+  defp compact_type_elem_size(:u16), do: 2
+  defp compact_type_elem_size(:s16), do: 2
+  defp compact_type_elem_size(:f16), do: 2
+  defp compact_type_elem_size(:u32), do: 4
+  defp compact_type_elem_size(:s32), do: 4
+  defp compact_type_elem_size(:f32), do: 4
+  defp compact_type_elem_size(:c32), do: 4
+  defp compact_type_elem_size(:u64), do: 8
+  defp compact_type_elem_size(:s64), do: 8
+  defp compact_type_elem_size(:f64), do: 8
+  defp compact_type_elem_size(:c64), do: 8
+  defp compact_type_elem_size({_, bits}) when is_integer(bits), do: div(bits, 8)
 
   @doc """
   Create Mat from binary (pixel) data

--- a/test/evision_mat_test.exs
+++ b/test/evision_mat_test.exs
@@ -212,6 +212,164 @@ defmodule Evision.Mat.Test do
       assert [batch] = Evision.Mat.to_batched(mat, 8, {2}, leftover: :repeat)
       assert Evision.Mat.to_binary(batch) == <<1, 2, 1, 2, 1, 2, 1, 2>>
     end
+
+    test "to_batched 4-arg requires multi-channel shape to include channels as a dim" do
+      # CV_8UC3 mat: 2 rows x 2 cols x 3 channels = 12 bytes
+      bin = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>
+      mat = Evision.Mat.from_binary(bin, {:u, 8}, 2, 2, 3)
+
+      # Shape including channels works; output is single-channel with channels as last dim
+      assert [batch] = Evision.Mat.to_batched(mat, 2, {2, 2, 3}, leftover: :discard)
+      assert Evision.Mat.shape(batch) == {2, 2, 3}
+      assert Evision.Mat.channels(batch) == 1
+      assert Evision.Mat.to_binary(batch) == bin
+
+      # Shape WITHOUT channels is rejected — this is the breaking change vs. older versions
+      assert {:error, msg} = Evision.Mat.to_batched(mat, 2, {2, 2}, leftover: :discard)
+      assert msg =~ "shape"
+    end
+
+    test "to_batched 3-arg works on multi-channel Mat (previously errored)" do
+      bin = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>
+      mat = Evision.Mat.from_binary(bin, {:u, 8}, 2, 2, 3)
+
+      assert [batch] = Evision.Mat.to_batched(mat, 2, leftover: :discard)
+      assert Evision.Mat.shape(batch) == {2, 2, 3}
+      assert Evision.Mat.channels(batch) == 1
+      assert Evision.Mat.to_binary(batch) == bin
+    end
+
+    test "update_roi does not mutate the caller's matrix" do
+      original_bin = <<1, 2, 3, 4, 5, 6, 7, 8, 9>>
+      mat = Evision.Mat.from_binary_by_shape(original_bin, {:u, 8}, {3, 3})
+      patch = Evision.Mat.from_binary_by_shape(<<0, 0>>, {:u, 8}, {1, 2})
+
+      updated = Evision.Mat.update_roi(mat, [{1, 2}, {0, 2}], patch)
+
+      assert Evision.Mat.to_binary(updated) == <<1, 2, 3, 0, 0, 6, 7, 8, 9>>
+      assert Evision.Mat.to_binary(mat) == original_bin
+    end
+
+    test "dot returns a scalar matching OpenCV Mat::dot semantics" do
+      a_bin = for x <- [1.0, 2.0, 3.0], into: <<>>, do: <<x::float-little-size(64)>>
+      b_bin = for x <- [4.0, 5.0, 6.0], into: <<>>, do: <<x::float-little-size(64)>>
+      a = Evision.Mat.from_binary_by_shape(a_bin, {:f, 64}, {3})
+      b = Evision.Mat.from_binary_by_shape(b_bin, {:f, 64}, {3})
+
+      assert Evision.Mat.dot(a, b) == 32.0
+    end
+
+    test "dot treats matrices as flat 1D vectors in row-major order" do
+      values = for v <- [1.0, 2.0, 3.0, 4.0], into: <<>>, do: <<v::float-little-size(64)>>
+      mat = Evision.Mat.from_binary_by_shape(values, {:f, 64}, {2, 2})
+
+      assert Evision.Mat.dot(mat, mat) == 1.0 + 4.0 + 9.0 + 16.0
+    end
+
+    test "matmul performs 2D matrix multiplication" do
+      a_bin = for v <- [1.0, 2.0, 3.0, 4.0], into: <<>>, do: <<v::float-little-size(64)>>
+      b_bin = for v <- [5.0, 6.0, 7.0, 8.0], into: <<>>, do: <<v::float-little-size(64)>>
+      a = Evision.Mat.from_binary_by_shape(a_bin, {:f, 64}, {2, 2})
+      b = Evision.Mat.from_binary_by_shape(b_bin, {:f, 64}, {2, 2})
+
+      product = Evision.Mat.matmul(a, b)
+      expected = for v <- [19.0, 22.0, 43.0, 50.0], into: <<>>, do: <<v::float-little-size(64)>>
+
+      assert Evision.Mat.to_binary(product) == expected
+      assert Evision.Mat.shape(product) == {2, 2}
+    end
+
+    test "matmul rejects shape mismatch" do
+      a_bin = for v <- [1.0, 2.0, 3.0, 4.0], into: <<>>, do: <<v::float-little-size(32)>>
+      b_bin = for v <- [1.0, 2.0, 3.0], into: <<>>, do: <<v::float-little-size(32)>>
+      a = Evision.Mat.from_binary_by_shape(a_bin, {:f, 32}, {2, 2})
+      b = Evision.Mat.from_binary_by_shape(b_bin, {:f, 32}, {3, 1})
+
+      assert {:error, _msg} = Evision.Mat.matmul(a, b)
+    end
+
+    test "transpose rejects as_shape whose byte size does not match the source" do
+      mat = Evision.Mat.from_binary_by_shape(<<1, 2, 3, 4>>, {:u, 8}, {4})
+
+      assert {:error, msg} = Evision.Mat.transpose(mat, [1, 0], as_shape: {2, 3})
+      assert msg =~ "as_shape"
+    end
+
+    test "at handles non-continuous matrices and returns the right scalar" do
+      bin = for v <- 1..16, into: <<>>, do: <<v::little-size(8)>>
+      mat = Evision.Mat.from_binary_by_shape(bin, {:u, 8}, {4, 4})
+
+      assert Evision.Mat.at(mat, 0) == 1
+      assert Evision.Mat.at(mat, 15) == 16
+      assert {:error, _} = Evision.Mat.at(mat, 16)
+    end
+
+    test "arange supports negative step" do
+      mat = Evision.Mat.arange(10, 0, -3, :s32)
+
+      expected =
+        for v <- [10, 7, 4, 1], into: <<>>, do: <<v::signed-little-size(32)>>
+
+      assert Evision.Mat.to_binary(mat) == expected
+    end
+
+    test "arange rejects inverted bounds for the given step direction" do
+      assert {:error, _} = Evision.Mat.arange(10, 0, 1, :s32)
+      assert {:error, _} = Evision.Mat.arange(0, 10, -1, :s32)
+    end
+
+    test "arange/4 rejects zero step at the Elixir guard" do
+      assert_raise FunctionClauseError, fn ->
+        Evision.Mat.arange(0, 10, 0, :s32)
+      end
+    end
+
+    test "ceil, floor, round all process every channel of multi-channel matrices" do
+      values = for v <- [0.4, 0.6, 1.4, 1.6, 2.4, 2.6], into: <<>>, do: <<v::float-little-size(32)>>
+      mat = Evision.Mat.from_binary(values, {:f, 32}, 1, 2, 3)
+
+      ceiled_bin = Evision.Mat.to_binary(Evision.Mat.ceil(mat))
+      floored_bin = Evision.Mat.to_binary(Evision.Mat.floor(mat))
+      rounded_bin = Evision.Mat.to_binary(Evision.Mat.round(mat))
+
+      expected_ceil =
+        for v <- [1.0, 1.0, 2.0, 2.0, 3.0, 3.0], into: <<>>, do: <<v::float-little-size(32)>>
+
+      expected_floor =
+        for v <- [0.0, 0.0, 1.0, 1.0, 2.0, 2.0], into: <<>>, do: <<v::float-little-size(32)>>
+
+      expected_round =
+        for v <- [0.0, 1.0, 1.0, 2.0, 2.0, 3.0], into: <<>>, do: <<v::float-little-size(32)>>
+
+      assert ceiled_bin == expected_ceil
+      assert floored_bin == expected_floor
+      assert rounded_bin == expected_round
+    end
+
+    test "negate flips every channel of multi-channel u8 matrices" do
+      mat = Evision.Mat.from_binary(<<1, 2, 3, 4, 5, 6>>, {:u, 8}, 1, 2, 3)
+
+      negated = Evision.Mat.negate(mat)
+
+      assert Evision.Mat.to_binary(negated) == <<255, 254, 253, 252, 251, 250>>
+    end
+
+    test "to_binary in element units stays consistent between Mat and nx_tensor paths" do
+      values = for v <- 1..4, into: <<>>, do: <<v::signed-little-size(32)>>
+      mat = Evision.Mat.from_binary_by_shape(values, {:s, 32}, {4})
+      expected_two_elements = for v <- [1, 2], into: <<>>, do: <<v::signed-little-size(32)>>
+
+      assert Evision.Mat.to_binary(mat, 2) == expected_two_elements
+
+      nx_tensor = %{
+        __struct__: :nx_tensor,
+        data: values,
+        type: :s32,
+        shape: {4}
+      }
+
+      assert Evision.Mat.to_binary(nx_tensor, 2) == expected_two_elements
+    end
   end
 
   @tag :nx

--- a/test/evision_mat_test.exs
+++ b/test/evision_mat_test.exs
@@ -175,6 +175,45 @@ defmodule Evision.Mat.Test do
     end
   end
 
+  describe "native mat helper regressions" do
+    test "clip clamps values to both bounds" do
+      mat = Evision.Mat.from_binary_by_shape(<<0, 5, 10>>, {:u, 8}, {3})
+
+      clipped = Evision.Mat.clip(mat, 2, 6)
+
+      assert Evision.Mat.to_binary(clipped) == <<2, 5, 6>>
+    end
+
+    test "arange keeps the last stepped value when the interval is not evenly divisible" do
+      mat = Evision.Mat.arange(0, 5, 2, :s32)
+
+      expected =
+        for value <- [0, 2, 4], into: <<>> do
+          <<value::signed-little-size(32)>>
+        end
+
+      assert Evision.Mat.to_binary(mat) == expected
+    end
+
+    test "to_binary respects the element limit" do
+      mat = Evision.Mat.from_binary_by_shape(<<1, 2, 3, 4>>, {:u, 8}, {4})
+
+      assert Evision.Mat.to_binary(mat, 2) == <<1, 2>>
+    end
+
+    test "from_binary_by_shape rejects binaries smaller than the requested shape" do
+      assert {:error, "size mismatch"} =
+               Evision.Mat.from_binary_by_shape(<<1, 2>>, {:u, 8}, {2, 2})
+    end
+
+    test "to_batched repeat fills batches without reading past the source matrix" do
+      mat = Evision.Mat.from_binary_by_shape(<<1, 2>>, {:u, 8}, {2})
+
+      assert [batch] = Evision.Mat.to_batched(mat, 8, {2}, leftover: :repeat)
+      assert Evision.Mat.to_binary(batch) == <<1, 2, 1, 2, 1, 2, 1, 2>>
+    end
+  end
+
   @tag :nx
   test "use Nx.tensor without calling last_dim_as_channel" do
     v = Nx.broadcast(Nx.tensor(1.0, type: :f64), {120, 120, 3})


### PR DESCRIPTION
## Summary
- fix Mat helper correctness issues in clip, arange, binary conversion, batching, transpose, and typed operations
- tighten shape/type validation and avoid unsafe reads for binary-backed Mats
- add regression tests for deterministic native helper failures

## Testing
- git diff --check
- git diff --cached --check
- mix test test/evision_mat_test.exs --trace (run against the old precompiled NIF locally; the new regression tests fail there as expected and are intended to pass with the rebuilt native code)
