### PR TITLE
Implement Nx.Backend callbacks on Evision.Backend (72/85)

### DIFF
--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -13,6 +13,7 @@
 #include "ceil.h"
 #include "clip.h"
 #include "cmp.h"
+#include "conv.h"
 #include "cumulative.h"
 #include "divide.h"
 #include "expm1.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -21,6 +21,7 @@
 #include "from_binary.h"
 #include "gather.h"
 #include "indexed.h"
+#include "linalg.h"
 #include "logical_and.h"
 #include "logical_or.h"
 #include "logical_xor.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -35,5 +35,6 @@
 #include "to_batched.h"
 #include "to_binary.h"
 #include "transpose.h"
+#include "unary_math.h"
 
 #endif // EVISION_BACKEND_BACKEND_H

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -35,6 +35,7 @@
 #include "shift.h"
 #include "sign.h"
 #include "sort.h"
+#include "strided_copy.h"
 #include "subtract.h"
 #include "take.h"
 #include "to_batched.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -28,6 +28,7 @@
 #include "multiply.h"
 #include "negate.h"
 #include "predicate.h"
+#include "put_slice.h"
 #include "reduce.h"
 #include "reshape.h"
 #include "round.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -22,6 +22,7 @@
 #include "matrix_multiply.h"
 #include "multiply.h"
 #include "negate.h"
+#include "reduce.h"
 #include "reshape.h"
 #include "round.h"
 #include "sign.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -28,6 +28,7 @@
 #include "reduce.h"
 #include "reshape.h"
 #include "round.h"
+#include "select.h"
 #include "sign.h"
 #include "sort.h"
 #include "subtract.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -39,6 +39,7 @@
 #include "strided_copy.h"
 #include "subtract.h"
 #include "take.h"
+#include "take_along_axis.h"
 #include "to_batched.h"
 #include "to_binary.h"
 #include "transpose.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -11,6 +11,7 @@
 #include "ceil.h"
 #include "clip.h"
 #include "cmp.h"
+#include "cumulative.h"
 #include "divide.h"
 #include "expm1.h"
 #include "eye.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -45,5 +45,6 @@
 #include "to_binary.h"
 #include "transpose.h"
 #include "unary_math.h"
+#include "window.h"
 
 #endif // EVISION_BACKEND_BACKEND_H

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -28,6 +28,7 @@
 #include "sign.h"
 #include "sort.h"
 #include "subtract.h"
+#include "take.h"
 #include "to_batched.h"
 #include "to_binary.h"
 #include "transpose.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -3,6 +3,7 @@
 
 #include "abs.h"
 #include "add.h"
+#include "bit_unary.h"
 #include "bitwise_and.h"
 #include "bitwise_not.h"
 #include "bitwise_or.h"
@@ -30,6 +31,7 @@
 #include "reshape.h"
 #include "round.h"
 #include "select.h"
+#include "shift.h"
 #include "sign.h"
 #include "sort.h"
 #include "subtract.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -17,6 +17,7 @@
 #include "floor.h"
 #include "from_binary.h"
 #include "gather.h"
+#include "indexed.h"
 #include "logical_and.h"
 #include "logical_or.h"
 #include "logical_xor.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -16,6 +16,7 @@
 #include "eye.h"
 #include "floor.h"
 #include "from_binary.h"
+#include "gather.h"
 #include "logical_and.h"
 #include "logical_or.h"
 #include "logical_xor.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -3,6 +3,7 @@
 
 #include "abs.h"
 #include "add.h"
+#include "binop.h"
 #include "bit_unary.h"
 #include "bitwise_and.h"
 #include "bitwise_not.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -25,6 +25,7 @@
 #include "matrix_multiply.h"
 #include "multiply.h"
 #include "negate.h"
+#include "predicate.h"
 #include "reduce.h"
 #include "reshape.h"
 #include "round.h"

--- a/c_src/modules/evision_backend/backend.h
+++ b/c_src/modules/evision_backend/backend.h
@@ -25,6 +25,7 @@
 #include "reshape.h"
 #include "round.h"
 #include "sign.h"
+#include "sort.h"
 #include "subtract.h"
 #include "to_batched.h"
 #include "to_binary.h"

--- a/c_src/modules/evision_backend/binop.h
+++ b/c_src/modules/evision_backend/binop.h
@@ -1,0 +1,101 @@
+#ifndef EVISION_BACKEND_BINOP_H
+#define EVISION_BACKEND_BINOP_H
+
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Elementwise binary ops without an OpenCV primitive (Nx.atan2 / pow / quotient /
+// remainder). op 0=atan2, 1=pow, 2=quotient, 3=remainder. l and r share the output
+// type and shape (broadcast + cast by the caller; f16/bf16 widened to f32).
+
+template <typename T>
+static void evision_binop_float(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst, int op) {
+    const T *lp = (const T *)l.data;
+    const T *rp = (const T *)r.data;
+    T *dp = (T *)dst.data;
+    size_t n = l.total();
+    for (size_t i = 0; i < n; i++) {
+        T a = lp[i], b = rp[i];
+        switch (op) {
+            case 0: dp[i] = std::atan2(a, b); break;
+            case 1: dp[i] = std::pow(a, b); break;
+            case 3: dp[i] = std::fmod(a, b); break;
+            default: dp[i] = (T)0; break;
+        }
+    }
+}
+
+// Integer pow is exponentiation-by-squaring in the unsigned counterpart, so it
+// wraps modulo 2^width to match Integer.pow truncated to the type; quotient/remainder
+// are C / and % (toward zero, like Elixir div/rem), guarded against divide-by-zero.
+template <typename T, typename Acc>
+static void evision_binop_int(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst, int op) {
+    const T *lp = (const T *)l.data;
+    const T *rp = (const T *)r.data;
+    T *dp = (T *)dst.data;
+    size_t n = l.total();
+    for (size_t i = 0; i < n; i++) {
+        T a = lp[i], b = rp[i];
+        switch (op) {
+            case 1: {
+                Acc base = (Acc)a, result = 1;
+                T e = b;
+                while (e > 0) {
+                    if (e & 1) result = (Acc)(result * base);
+                    base = (Acc)(base * base);
+                    e >>= 1;
+                }
+                dp[i] = (T)result;
+                break;
+            }
+            case 2: dp[i] = (b == 0) ? (T)0 : (T)(a / b); break;
+            case 3: dp[i] = (b == 0) ? (T)0 : (T)(a % b); break;
+            default: dp[i] = (T)0; break;
+        }
+    }
+}
+
+// @evision c: mat_binop, evision_cv_mat_binop, 1
+// @evision nif: def mat_binop(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_binop(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat l, r;
+        int op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            Mat lc = l.isContinuous() ? l : l.clone();
+            Mat rc = r.isContinuous() ? r : r.clone();
+            Mat dst = lc.clone();
+            switch (dst.depth()) {
+                case CV_8U:  evision_binop_int<uint8_t, uint8_t>(lc, rc, dst, op); break;
+                case CV_8S:  evision_binop_int<int8_t, uint8_t>(lc, rc, dst, op); break;
+                case CV_16U: evision_binop_int<uint16_t, uint16_t>(lc, rc, dst, op); break;
+                case CV_16S: evision_binop_int<int16_t, uint16_t>(lc, rc, dst, op); break;
+                case CV_32S: evision_binop_int<int32_t, uint32_t>(lc, rc, dst, op); break;
+                case CV_32U: evision_binop_int<uint32_t, uint32_t>(lc, rc, dst, op); break;
+                case CV_64S: evision_binop_int<int64_t, uint64_t>(lc, rc, dst, op); break;
+                case CV_64U: evision_binop_int<uint64_t, uint64_t>(lc, rc, dst, op); break;
+                case CV_32F: evision_binop_float<float>(lc, rc, dst, op); break;
+                case CV_64F: evision_binop_float<double>(lc, rc, dst, op); break;
+                default: return evision::nif::error(env, "mat_binop: unsupported depth");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_BINOP_H

--- a/c_src/modules/evision_backend/bit_unary.h
+++ b/c_src/modules/evision_backend/bit_unary.h
@@ -1,0 +1,76 @@
+#ifndef EVISION_BACKEND_BIT_UNARY_H
+#define EVISION_BACKEND_BIT_UNARY_H
+
+#include <cstdint>
+#include <type_traits>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+static inline int evision_popcount_u64(uint64_t x) {
+    int c = 0;
+    while (x) { c += (int)(x & 1); x >>= 1; }
+    return c;
+}
+
+static inline int evision_clz_width(uint64_t x, int width) {
+    int c = 0;
+    for (int b = width - 1; b >= 0; b--) {
+        if (x & ((uint64_t)1 << b)) break;
+        c++;
+    }
+    return c;
+}
+
+// Per-element bit op preserving the integer type (Nx.count_leading_zeros /
+// population_count). op 0 = clz (within the type's bit width), 1 = popcount. The
+// element's raw bits are read as unsigned, matching Nx's unsigned read; the count
+// is written back in the same type.
+template <typename T>
+static void evision_bit_unary(cv::Mat &m, int op) {
+    typedef typename std::make_unsigned<T>::type U;
+    T *p = (T *)m.data;
+    size_t n = m.total();
+    int width = (int)(sizeof(T) * 8);
+    for (size_t i = 0; i < n; i++) {
+        uint64_t x = (uint64_t)(U)p[i];
+        int r = (op == 0) ? evision_clz_width(x, width) : evision_popcount_u64(x);
+        p[i] = (T)r;
+    }
+}
+
+// @evision c: mat_bit_unary, evision_cv_mat_bit_unary, 1
+// @evision nif: def mat_bit_unary(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_bit_unary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        int op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            Mat dst = src.clone();
+            switch (dst.depth()) {
+                case CV_8U:  evision_bit_unary<uint8_t>(dst, op); break;
+                case CV_8S:  evision_bit_unary<int8_t>(dst, op); break;
+                case CV_16U: evision_bit_unary<uint16_t>(dst, op); break;
+                case CV_16S: evision_bit_unary<int16_t>(dst, op); break;
+                case CV_32S: evision_bit_unary<int32_t>(dst, op); break;
+                case CV_32U: evision_bit_unary<uint32_t>(dst, op); break;
+                case CV_64S: evision_bit_unary<int64_t>(dst, op); break;
+                case CV_64U: evision_bit_unary<uint64_t>(dst, op); break;
+                default: return evision::nif::error(env, "mat_bit_unary: integer types only");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_BIT_UNARY_H

--- a/c_src/modules/evision_backend/conv.h
+++ b/c_src/modules/evision_backend/conv.h
@@ -1,0 +1,140 @@
+#ifndef EVISION_BACKEND_CONV_H
+#define EVISION_BACKEND_CONV_H
+
+#include <vector>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// N-d cross-correlation (Nx.conv) on already-permuted canonical layouts: input [N, Cin,
+// *spatial], kernel [O, Cin/G, *spatial], output [N/Bg, O, *spatial]. The caller does the
+// input/kernel/output permutations (via transpose) and the float cast; this computes the
+// canonical result. Dilations/padding are handled by index math (no materialized zeros), so
+// only original kernel positions that land on a real input element contribute -- summed in
+// channel-major, spatial-minor order to match Nx exactly. G = feature groups, Bg = batch groups.
+
+template <typename T>
+static void conv_typed(const T *I, const T *K, T *Out, int d,
+                       const std::vector<int> &in_shape, const std::vector<int> &k_shape,
+                       const std::vector<int> &out_shape, const std::vector<int> &stride,
+                       const std::vector<int> &pad_lo, const std::vector<int> &in_dil,
+                       const std::vector<int> &k_dil, int G, int Bg) {
+    int rank = d + 2;
+    int Cin_pg = k_shape[1];
+    int O = k_shape[0];
+    int Nout = out_shape[0];
+    int O_per_G = O / G;
+    int O_per_Bg = O / Bg;
+
+    auto strides_of = [&](const std::vector<int> &shp) {
+        std::vector<int64_t> st((size_t)rank);
+        int64_t a = 1;
+        for (int i = rank - 1; i >= 0; i--) { st[(size_t)i] = a; a *= shp[(size_t)i]; }
+        return st;
+    };
+    std::vector<int64_t> in_st = strides_of(in_shape);
+    std::vector<int64_t> k_st = strides_of(k_shape);
+
+    std::vector<int64_t> dilated_in((size_t)d);
+    for (int s = 0; s < d; s++) dilated_in[(size_t)s] = (int64_t)(in_shape[(size_t)(2 + s)] - 1) * in_dil[(size_t)s] + 1;
+
+    int64_t out_total = 1;
+    for (int i = 0; i < rank; i++) out_total *= out_shape[(size_t)i];
+    int64_t k_spatial = 1;
+    for (int s = 0; s < d; s++) k_spatial *= k_shape[(size_t)(2 + s)];
+
+    std::vector<int> oidx((size_t)rank, 0), kp((size_t)d, 0);
+    for (int64_t flat = 0; flat < out_total; flat++) {
+        int bprime = oidx[0];
+        int o = oidx[1];
+        int fg = o / O_per_G;
+        int jchunk = o / O_per_Bg;
+        int n = bprime + jchunk * Nout;
+        int cbase = fg * Cin_pg;
+
+        T acc = (T)0;
+        for (int ic = 0; ic < Cin_pg; ic++) {
+            int64_t in_base = (int64_t)n * in_st[0] + (int64_t)(cbase + ic) * in_st[1];
+            int64_t k_base = (int64_t)o * k_st[0] + (int64_t)ic * k_st[1];
+            std::fill(kp.begin(), kp.end(), 0);
+
+            for (int64_t kq = 0; kq < k_spatial; kq++) {
+                bool valid = true;
+                int64_t in_off = in_base;
+                for (int s = 0; s < d; s++) {
+                    int64_t cd = (int64_t)oidx[(size_t)(2 + s)] * stride[(size_t)s] +
+                                 (int64_t)kp[(size_t)s] * k_dil[(size_t)s] - pad_lo[(size_t)s];
+                    if (cd < 0 || cd >= dilated_in[(size_t)s]) { valid = false; break; }
+                    if (in_dil[(size_t)s] != 1 && (cd % in_dil[(size_t)s]) != 0) { valid = false; break; }
+                    int64_t orig = (in_dil[(size_t)s] == 1) ? cd : cd / in_dil[(size_t)s];
+                    in_off += orig * in_st[(size_t)(2 + s)];
+                }
+                if (valid) {
+                    int64_t k_off = k_base;
+                    for (int s = 0; s < d; s++) k_off += (int64_t)kp[(size_t)s] * k_st[(size_t)(2 + s)];
+                    acc += I[in_off] * K[k_off];
+                }
+                for (int s = d - 1; s >= 0; s--) { if (++kp[(size_t)s] < k_shape[(size_t)(2 + s)]) break; kp[(size_t)s] = 0; }
+            }
+        }
+
+        Out[flat] = acc;
+        for (int s = rank - 1; s >= 0; s--) { if (++oidx[(size_t)s] < out_shape[(size_t)s]) break; oidx[(size_t)s] = 0; }
+    }
+}
+
+// @evision c: mat_conv, evision_cv_mat_conv, 1
+// @evision nif: def mat_conv(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_conv(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat input, kernel;
+        std::vector<int> in_shape, k_shape, out_shape, stride, pad_lo, in_dil, k_dil;
+        int feature_groups = 1, batch_groups = 1;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "input"), input, ArgInfo("input", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "kernel"), kernel, ArgInfo("kernel", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "in_shape"), in_shape, ArgInfo("in_shape", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "k_shape"), k_shape, ArgInfo("k_shape", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "out_shape"), out_shape, ArgInfo("out_shape", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "strides"), stride, ArgInfo("strides", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "pad_lo"), pad_lo, ArgInfo("pad_lo", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "input_dilation"), in_dil, ArgInfo("input_dilation", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "kernel_dilation"), k_dil, ArgInfo("kernel_dilation", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "feature_groups"), feature_groups, ArgInfo("feature_groups", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "batch_groups"), batch_groups, ArgInfo("batch_groups", 0))) {
+            int d = (int)in_shape.size() - 2;
+            Mat in_c = input.isContinuous() ? input : input.clone();
+            Mat k_c = kernel.isContinuous() ? kernel : kernel.clone();
+
+            int64_t out_total = 1;
+            for (size_t i = 0; i < out_shape.size(); i++) out_total *= out_shape[i];
+            Mat dst(1, (int)(out_total > 0 ? out_total : 1), input.type());
+
+            switch (input.depth()) {
+                case CV_32F:
+                    conv_typed<float>((const float *)in_c.data, (const float *)k_c.data, (float *)dst.data,
+                                      d, in_shape, k_shape, out_shape, stride, pad_lo, in_dil, k_dil,
+                                      feature_groups, batch_groups);
+                    break;
+                case CV_64F:
+                    conv_typed<double>((const double *)in_c.data, (const double *)k_c.data, (double *)dst.data,
+                                       d, in_shape, k_shape, out_shape, stride, pad_lo, in_dil, k_dil,
+                                       feature_groups, batch_groups);
+                    break;
+                default:
+                    return evision::nif::error(env, "conv: unsupported depth (expected f32/f64)");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_CONV_H

--- a/c_src/modules/evision_backend/cumulative.h
+++ b/c_src/modules/evision_backend/cumulative.h
@@ -1,0 +1,76 @@
+#ifndef EVISION_BACKEND_CUMULATIVE_H
+#define EVISION_BACKEND_CUMULATIVE_H
+
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Row-wise prefix scan (Nx.cumulative_*): op 0=sum, 1=product, 2=min, 3=max,
+// accumulating left-to-right (or right-to-left when reverse). Output has the same
+// shape and type as the 2D single-channel input, which the caller has already cast
+// to the output type; integer sum/product use an unsigned accumulator so wraparound
+// is well-defined (two's complement), matching Nx's modular semantics.
+template <typename T, typename Acc>
+static void evision_scan_rows(const cv::Mat &src, cv::Mat &dst, int op, bool reverse) {
+    int cols = src.cols;
+    for (int r = 0; r < src.rows; r++) {
+        const T *sp = src.ptr<T>(r);
+        T *dp = dst.ptr<T>(r);
+        if (cols == 0) continue;
+        int start = reverse ? cols - 1 : 0;
+        int step = reverse ? -1 : 1;
+        T running = sp[start];
+        dp[start] = running;
+        for (int k = 1; k < cols; k++) {
+            int c = start + step * k;
+            T v = sp[c];
+            switch (op) {
+                case 0: running = (T)((Acc)running + (Acc)v); break;
+                case 1: running = (T)((Acc)running * (Acc)v); break;
+                case 2: running = (v < running) ? v : running; break;
+                case 3: running = (v > running) ? v : running; break;
+            }
+            dp[c] = running;
+        }
+    }
+}
+
+// @evision c: mat_cumulative, evision_cv_mat_cumulative, 1
+// @evision nif: def mat_cumulative(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_cumulative(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        int op = 0, reverse = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "reverse"), reverse, ArgInfo("reverse", 0))) {
+            Mat dst(src.rows, src.cols, src.type());
+            bool rev = reverse != 0;
+            switch (src.depth()) {
+                case CV_8U:  evision_scan_rows<uint8_t, uint32_t>(src, dst, op, rev); break;
+                case CV_8S:  evision_scan_rows<int8_t, uint32_t>(src, dst, op, rev); break;
+                case CV_16U: evision_scan_rows<uint16_t, uint32_t>(src, dst, op, rev); break;
+                case CV_16S: evision_scan_rows<int16_t, uint32_t>(src, dst, op, rev); break;
+                case CV_32S: evision_scan_rows<int32_t, uint32_t>(src, dst, op, rev); break;
+                case CV_32U: evision_scan_rows<uint32_t, uint32_t>(src, dst, op, rev); break;
+                case CV_64S: evision_scan_rows<int64_t, uint64_t>(src, dst, op, rev); break;
+                case CV_64U: evision_scan_rows<uint64_t, uint64_t>(src, dst, op, rev); break;
+                case CV_32F: evision_scan_rows<float, float>(src, dst, op, rev); break;
+                case CV_64F: evision_scan_rows<double, double>(src, dst, op, rev); break;
+                default: return evision::nif::error(env, "mat_cumulative: unsupported depth");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_CUMULATIVE_H

--- a/c_src/modules/evision_backend/cumulative.h
+++ b/c_src/modules/evision_backend/cumulative.h
@@ -1,6 +1,8 @@
 #ifndef EVISION_BACKEND_CUMULATIVE_H
 #define EVISION_BACKEND_CUMULATIVE_H
 
+#include <cmath>
+#include <type_traits>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
@@ -10,6 +12,22 @@
 // shape and type as the 2D single-channel input, which the caller has already cast
 // to the output type; integer sum/product use an unsigned accumulator so wraparound
 // is well-defined (two's complement), matching Nx's modular semantics.
+template <typename T>
+static inline T evision_scan_min(T acc, T v) {
+    if constexpr (std::is_floating_point<T>::value) {
+        if (std::isnan(acc) || std::isnan(v)) return std::isnan(acc) ? acc : v;
+    }
+    return (v < acc) ? v : acc;
+}
+
+template <typename T>
+static inline T evision_scan_max(T acc, T v) {
+    if constexpr (std::is_floating_point<T>::value) {
+        if (std::isnan(acc) || std::isnan(v)) return std::isnan(acc) ? acc : v;
+    }
+    return (v > acc) ? v : acc;
+}
+
 template <typename T, typename Acc>
 static void evision_scan_rows(const cv::Mat &src, cv::Mat &dst, int op, bool reverse) {
     int cols = src.cols;
@@ -27,8 +45,8 @@ static void evision_scan_rows(const cv::Mat &src, cv::Mat &dst, int op, bool rev
             switch (op) {
                 case 0: running = (T)((Acc)running + (Acc)v); break;
                 case 1: running = (T)((Acc)running * (Acc)v); break;
-                case 2: running = (v < running) ? v : running; break;
-                case 3: running = (v > running) ? v : running; break;
+                case 2: running = evision_scan_min(running, v); break;
+                case 3: running = evision_scan_max(running, v); break;
             }
             dp[c] = running;
         }

--- a/c_src/modules/evision_backend/from_binary.h
+++ b/c_src/modules/evision_backend/from_binary.h
@@ -16,10 +16,7 @@ static bool evision_checked_mul_size(size_t lhs, size_t rhs, size_t& out) {
 }
 
 static bool evision_shape_byte_size(const std::vector<int>& shape, size_t elem_size, size_t& byte_size) {
-    if (shape.empty()) {
-        return false;
-    }
-
+    // An empty shape is a scalar (0-dim Mat): the empty product is 1 element.
     size_t count = 1;
     for (int dim : shape) {
         if (dim <= 0) {

--- a/c_src/modules/evision_backend/gather.h
+++ b/c_src/modules/evision_backend/gather.h
@@ -1,0 +1,78 @@
+#ifndef EVISION_BACKEND_GATHER_H
+#define EVISION_BACKEND_GATHER_H
+
+#include <cstring>
+#include <vector>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Gather over the leading axes (Nx.gather). The tensor is pre-transposed so the
+// indexed axes lead; each consecutive `depth`-tuple in `indices` is a coordinate
+// over `dims` (the leading dim sizes) selecting one contiguous `inner`-element
+// block. Type-agnostic byte copy; indices are int64 and every coordinate is
+// bounds-checked against its axis to match Nx.
+// @evision c: mat_gather, evision_cv_mat_gather, 1
+// @evision nif: def mat_gather(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_gather(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src, indices, dims;
+        int inner = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "dims"), dims, ArgInfo("dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "inner"), inner, ArgInfo("inner", 0))) {
+            Mat src_c = src.isContinuous() ? src : src.clone();
+            Mat idx_c = indices.isContinuous() ? indices : indices.clone();
+            Mat dim_c = dims.isContinuous() ? dims : dims.clone();
+            const uchar *sp = src_c.data;
+            const int64_t *ip = (const int64_t *)idx_c.data;
+            const int64_t *dimp = (const int64_t *)dim_c.data;
+
+            int64_t depth = (int64_t)dim_c.total();
+            int64_t total_idx = (int64_t)idx_c.total();
+            if (depth <= 0 || total_idx % depth != 0)
+                return evision::nif::error(env, "gather: indices size not a multiple of coordinate depth");
+            int64_t num_gathers = total_idx / depth;
+
+            // mult[k] = number of elements spanned by one step along leading axis k
+            // (product of the trailing leading dims times the inner block size).
+            std::vector<int64_t> mult((size_t)depth);
+            int64_t acc = inner;
+            for (int64_t k = depth - 1; k >= 0; k--) {
+                mult[(size_t)k] = acc;
+                acc *= dimp[(size_t)k];
+            }
+
+            size_t elem_size = src_c.elemSize();
+            size_t inner_bytes = (size_t)inner * elem_size;
+            Mat dst(1, (int)(num_gathers * inner), src.type());
+            uchar *dp = dst.data;
+
+            for (int64_t g = 0; g < num_gathers; g++) {
+                int64_t offset = 0;
+                for (int64_t k = 0; k < depth; k++) {
+                    int64_t c = ip[g * depth + k];
+                    if (c < 0 || c >= dimp[(size_t)k])
+                        return evision::nif::error(env, "gather: index out of bounds");
+                    offset += c * mult[(size_t)k];
+                }
+                std::memcpy(dp + (size_t)g * inner_bytes,
+                            sp + (size_t)offset * elem_size,
+                            inner_bytes);
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_GATHER_H

--- a/c_src/modules/evision_backend/indexed.h
+++ b/c_src/modules/evision_backend/indexed.h
@@ -1,0 +1,109 @@
+#ifndef EVISION_BACKEND_INDEXED_H
+#define EVISION_BACKEND_INDEXED_H
+
+#include <cstring>
+#include <vector>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// out[coord] += src_block, element-wise, in the element's own type. Integer adds
+// use an unsigned accumulator so wraparound is well-defined (two's complement),
+// matching Nx's modular semantics; floats add directly.
+template <typename T, typename Acc>
+static inline void scatter_add_block(unsigned char *dst, const unsigned char *src, int64_t n) {
+    T *d = (T *)dst;
+    const T *s = (const T *)src;
+    for (int64_t i = 0; i < n; i++) d[i] = (T)((Acc)d[i] + (Acc)s[i]);
+}
+
+// Scatter into a copy of `src` (Nx.indexed_put / indexed_add). `src` is pre-cast
+// to the output type and pre-transposed so the indexed axes lead; each consecutive
+// `depth`-tuple in `indices` is a coordinate over `dims` (the leading dim sizes)
+// addressing one contiguous `inner`-element block. op 0 overwrites the block
+// (type-agnostic byte copy, last write wins for duplicate coords); op 1 accumulates
+// it (typed). Coordinates are bounds-checked per axis to match Nx.
+// @evision c: mat_indexed, evision_cv_mat_indexed, 1
+// @evision nif: def mat_indexed(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_indexed(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src, indices, updates, dims;
+        int inner = 0, op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "updates"), updates, ArgInfo("updates", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "dims"), dims, ArgInfo("dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "inner"), inner, ArgInfo("inner", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            // clone so the immutable source Mat is never mutated; clone() is continuous.
+            Mat result = src.clone();
+            Mat upd_c = updates.isContinuous() ? updates : updates.clone();
+            Mat idx_c = indices.isContinuous() ? indices : indices.clone();
+            Mat dim_c = dims.isContinuous() ? dims : dims.clone();
+
+            const int64_t *ip = (const int64_t *)idx_c.data;
+            const int64_t *dimp = (const int64_t *)dim_c.data;
+            int64_t depth = (int64_t)dim_c.total();
+            int64_t total_idx = (int64_t)idx_c.total();
+            if (depth <= 0 || total_idx % depth != 0)
+                return evision::nif::error(env, "indexed: indices size not a multiple of coordinate depth");
+            int64_t num_updates = total_idx / depth;
+
+            std::vector<int64_t> mult((size_t)depth);
+            int64_t acc = inner;
+            for (int64_t k = depth - 1; k >= 0; k--) {
+                mult[(size_t)k] = acc;
+                acc *= dimp[(size_t)k];
+            }
+
+            uchar *rp = result.data;
+            const uchar *up = upd_c.data;
+            size_t elem_size = result.elemSize();
+            size_t inner_bytes = (size_t)inner * elem_size;
+            int depth_id = result.type() & CV_MAT_DEPTH_MASK;
+
+            for (int64_t g = 0; g < num_updates; g++) {
+                int64_t offset = 0;
+                for (int64_t k = 0; k < depth; k++) {
+                    int64_t c = ip[g * depth + k];
+                    if (c < 0 || c >= dimp[(size_t)k])
+                        return evision::nif::error(env, "indexed: index out of bounds");
+                    offset += c * mult[(size_t)k];
+                }
+                uchar *dstblk = rp + (size_t)offset * elem_size;
+                const uchar *srcblk = up + (size_t)g * inner_bytes;
+
+                if (op == 0) {
+                    std::memcpy(dstblk, srcblk, inner_bytes);
+                    continue;
+                }
+
+                switch (depth_id) {
+                    case CV_8U:  scatter_add_block<uint8_t, uint32_t>(dstblk, srcblk, inner); break;
+                    case CV_8S:  scatter_add_block<int8_t, uint32_t>(dstblk, srcblk, inner); break;
+                    case CV_16U: scatter_add_block<uint16_t, uint32_t>(dstblk, srcblk, inner); break;
+                    case CV_16S: scatter_add_block<int16_t, uint32_t>(dstblk, srcblk, inner); break;
+                    case CV_32S: scatter_add_block<int32_t, uint32_t>(dstblk, srcblk, inner); break;
+                    case CV_32U: scatter_add_block<uint32_t, uint32_t>(dstblk, srcblk, inner); break;
+                    case CV_64S: scatter_add_block<int64_t, uint64_t>(dstblk, srcblk, inner); break;
+                    case CV_64U: scatter_add_block<uint64_t, uint64_t>(dstblk, srcblk, inner); break;
+                    case CV_32F: scatter_add_block<float, float>(dstblk, srcblk, inner); break;
+                    case CV_64F: scatter_add_block<double, double>(dstblk, srcblk, inner); break;
+                    default: return evision::nif::error(env, "indexed_add: unsupported dtype");
+                }
+            }
+            return evision_from(env, result);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_INDEXED_H

--- a/c_src/modules/evision_backend/linalg.h
+++ b/c_src/modules/evision_backend/linalg.h
@@ -1,0 +1,295 @@
+#ifndef EVISION_BACKEND_LINALG_H
+#define EVISION_BACKEND_LINALG_H
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+#include <vector>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Decompositions OpenCV exposes no factor-extraction for. All inputs/outputs are f64
+// (the caller casts to/from out.type) and a single n*n (or m*n) matrix; the caller loops
+// over batch dims. determinant/solve/SVD/eigen are handled directly via cv in Elixir.
+
+// Cholesky-Banachiewicz lower factor L (L*L^T = A), upper entries zero. A must be
+// symmetric positive definite.
+// @evision c: mat_cholesky, evision_cv_mat_cholesky, 1
+// @evision nif: def mat_cholesky(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_cholesky(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat a;
+        int n = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "a"), a, ArgInfo("a", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "n"), n, ArgInfo("n", 0))) {
+            Mat a_c = a.isContinuous() ? a : a.clone();
+            const double *ap = (const double *)a_c.data;
+            Mat l = Mat::zeros(n, n, CV_64F);
+            double *lp = (double *)l.data;
+
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j <= i; j++) {
+                    double sum = ap[i * n + j];
+                    for (int k = 0; k < j; k++) sum -= lp[i * n + k] * lp[j * n + k];
+
+                    if (i == j) {
+                        if (sum <= 0.0)
+                            return evision::nif::error(env, "cholesky: matrix is not positive definite");
+                        lp[i * n + j] = std::sqrt(sum);
+                    } else {
+                        lp[i * n + j] = sum / lp[j * n + j];
+                    }
+                }
+            }
+            return evision_from(env, l);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+// Partial-pivot LU returning {P, L, U} (all n*n) with A = P*L*U, L unit lower, U upper.
+// @evision c: mat_lu, evision_cv_mat_lu, 1
+// @evision nif: def mat_lu(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_lu(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat a;
+        int n = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "a"), a, ArgInfo("a", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "n"), n, ArgInfo("n", 0))) {
+            Mat m = a.clone();  // mutated in place into the row-permuted A
+            double *mp = (double *)m.data;
+            std::vector<int> perm((size_t)n);
+            for (int i = 0; i < n; i++) perm[(size_t)i] = i;
+
+            // bring the max-abs element of each column onto the diagonal
+            for (int j = 0; j < n - 1; j++) {
+                int maxi = j;
+                double maxv = std::fabs(mp[j * n + j]);
+                for (int i = j + 1; i < n; i++) {
+                    double v = std::fabs(mp[i * n + j]);
+                    if (v > maxv) { maxv = v; maxi = i; }
+                }
+                if (maxi != j) {
+                    for (int k = 0; k < n; k++) std::swap(mp[j * n + k], mp[maxi * n + k]);
+                    std::swap(perm[(size_t)j], perm[(size_t)maxi]);
+                }
+            }
+
+            // Doolittle: m (= permuted A) = L * U
+            Mat L = Mat::zeros(n, n, CV_64F);
+            Mat U = Mat::zeros(n, n, CV_64F);
+            double *lp = (double *)L.data;
+            double *up = (double *)U.data;
+            for (int i = 0; i < n; i++) {
+                for (int k = i; k < n; k++) {
+                    double sum = 0.0;
+                    for (int t = 0; t < i; t++) sum += lp[i * n + t] * up[t * n + k];
+                    up[i * n + k] = mp[i * n + k] - sum;
+                }
+                lp[i * n + i] = 1.0;
+                double diag = up[i * n + i];
+                for (int k = i + 1; k < n; k++) {
+                    double sum = 0.0;
+                    for (int t = 0; t < i; t++) sum += lp[k * n + t] * up[t * n + i];
+                    lp[k * n + i] = diag != 0.0 ? (mp[k * n + i] - sum) / diag : 0.0;
+                }
+            }
+
+            // P with A = P*L*U: row perm[i] of P is the i-th unit column
+            Mat P = Mat::zeros(n, n, CV_64F);
+            double *pp = (double *)P.data;
+            for (int i = 0; i < n; i++) pp[perm[(size_t)i] * n + i] = 1.0;
+
+            return enif_make_tuple3(env, evision_from(env, P), evision_from(env, L), evision_from(env, U));
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+// Householder QR returning {Q, R} with A = Q*R. reduced (complete=0): Q is m*n, R is n*n;
+// complete: Q is m*m, R is m*n. Requires m >= n.
+// @evision c: mat_qr, evision_cv_mat_qr, 1
+// @evision nif: def mat_qr(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_qr(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat a;
+        int m = 0, n = 0, complete = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "a"), a, ArgInfo("a", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "m"), m, ArgInfo("m", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "n"), n, ArgInfo("n", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "complete"), complete, ArgInfo("complete", 0))) {
+            if (m < n)
+                return evision::nif::error(env, "qr: tensor must have at least as many rows as columns");
+
+            Mat R = a.clone();                 // m x n, mutated into the upper factor
+            Mat Q = Mat::eye(m, m, CV_64F);     // accumulated orthogonal factor
+            double *rp = (double *)R.data;
+            double *qp = (double *)Q.data;
+            std::vector<double> v((size_t)m);
+
+            for (int k = 0; k < n; k++) {
+                double normx = 0.0;
+                for (int i = k; i < m; i++) normx += rp[i * n + k] * rp[i * n + k];
+                normx = std::sqrt(normx);
+                if (normx == 0.0) continue;
+
+                double alpha = (rp[k * n + k] > 0.0) ? -normx : normx;
+                for (int i = 0; i < m; i++) v[(size_t)i] = 0.0;
+                v[(size_t)k] = rp[k * n + k] - alpha;
+                for (int i = k + 1; i < m; i++) v[(size_t)i] = rp[i * n + k];
+
+                double vnorm2 = 0.0;
+                for (int i = k; i < m; i++) vnorm2 += v[(size_t)i] * v[(size_t)i];
+                if (vnorm2 == 0.0) continue;
+
+                // R <- R - (2/vnorm2) v (v^T R)
+                for (int j = 0; j < n; j++) {
+                    double s = 0.0;
+                    for (int i = k; i < m; i++) s += v[(size_t)i] * rp[i * n + j];
+                    s = 2.0 * s / vnorm2;
+                    for (int i = k; i < m; i++) rp[i * n + j] -= s * v[(size_t)i];
+                }
+                // Q <- Q - (2/vnorm2) (Q v) v^T
+                for (int i = 0; i < m; i++) {
+                    double s = 0.0;
+                    for (int l = k; l < m; l++) s += qp[i * m + l] * v[(size_t)l];
+                    s = 2.0 * s / vnorm2;
+                    for (int l = k; l < m; l++) qp[i * m + l] -= s * v[(size_t)l];
+                }
+            }
+
+            if (complete) {
+                return enif_make_tuple2(env, evision_from(env, Q), evision_from(env, R));
+            }
+
+            // reduced: first n columns of Q (m x n), first n rows of R (n x n)
+            Mat Qr(m, n, CV_64F);
+            double *qrp = (double *)Qr.data;
+            for (int i = 0; i < m; i++)
+                for (int j = 0; j < n; j++) qrp[i * n + j] = qp[i * m + j];
+
+            Mat Rr(n, n, CV_64F);
+            double *rrp = (double *)Rr.data;
+            for (int i = 0; i < n; i++)
+                for (int j = 0; j < n; j++) rrp[i * n + j] = rp[i * n + j];
+
+            return enif_make_tuple2(env, evision_from(env, Qr), evision_from(env, Rr));
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+// Triangular system solve by substitution, reading only the relevant triangle (Nx
+// semantics). a is n*n; b is br*bc (2D, vectors passed as n*1). lower/left_side/transpose
+// select the variant; the result has b's shape.
+// @evision c: mat_triangular_solve, evision_cv_mat_triangular_solve, 1
+// @evision nif: def mat_triangular_solve(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_triangular_solve(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat a, b;
+        int n = 0, lower = 0, left_side = 0, transpose = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "a"), a, ArgInfo("a", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "b"), b, ArgInfo("b", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "n"), n, ArgInfo("n", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "lower"), lower, ArgInfo("lower", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "left_side"), left_side, ArgInfo("left_side", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "transpose"), transpose, ArgInfo("transpose", 0))) {
+            Mat a_c = a.isContinuous() ? a : a.clone();
+            Mat b_c = b.isContinuous() ? b : b.clone();
+            const double *ad = (const double *)a_c.data;
+            const double *bd = (const double *)b_c.data;
+            int br = b_c.rows, bc = b_c.cols;
+            Mat X(br, bc, CV_64F);
+            double *xd = (double *)X.data;
+
+            // op(A)(i,j) is A or A^T; eff_lower says whether op(A) is lower-triangular
+            auto opA = [&](int i, int j) -> double { return transpose ? ad[j * n + i] : ad[i * n + j]; };
+            bool eff_lower = ((lower != 0) != (transpose != 0));
+
+            if (left_side) {
+                // op(A) X = B, B is n x bc, solve each column
+                bool lo = eff_lower;
+                for (int c = 0; c < bc; c++) {
+                    if (lo) {
+                        for (int i = 0; i < n; i++) {
+                            double s = bd[i * bc + c];
+                            for (int j = 0; j < i; j++) s -= opA(i, j) * xd[j * bc + c];
+                            double d = opA(i, i);
+                            if (d == 0.0) return evision::nif::error(env, "triangular_solve: singular matrix");
+                            xd[i * bc + c] = s / d;
+                        }
+                    } else {
+                        for (int i = n - 1; i >= 0; i--) {
+                            double s = bd[i * bc + c];
+                            for (int j = i + 1; j < n; j++) s -= opA(i, j) * xd[j * bc + c];
+                            double d = opA(i, i);
+                            if (d == 0.0) return evision::nif::error(env, "triangular_solve: singular matrix");
+                            xd[i * bc + c] = s / d;
+                        }
+                    }
+                }
+            } else {
+                // X op(A) = B, B is br x n. Transpose to M y = row, M = op(A)^T
+                bool lo = !eff_lower;
+                auto M = [&](int i, int j) -> double { return opA(j, i); };
+                for (int r = 0; r < br; r++) {
+                    if (lo) {
+                        for (int i = 0; i < n; i++) {
+                            double s = bd[r * bc + i];
+                            for (int j = 0; j < i; j++) s -= M(i, j) * xd[r * bc + j];
+                            double d = M(i, i);
+                            if (d == 0.0) return evision::nif::error(env, "triangular_solve: singular matrix");
+                            xd[r * bc + i] = s / d;
+                        }
+                    } else {
+                        for (int i = n - 1; i >= 0; i--) {
+                            double s = bd[r * bc + i];
+                            for (int j = i + 1; j < n; j++) s -= M(i, j) * xd[r * bc + j];
+                            double d = M(i, i);
+                            if (d == 0.0) return evision::nif::error(env, "triangular_solve: singular matrix");
+                            xd[r * bc + i] = s / d;
+                        }
+                    }
+                }
+            }
+
+            return evision_from(env, X);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_LINALG_H

--- a/c_src/modules/evision_backend/linalg.h
+++ b/c_src/modules/evision_backend/linalg.h
@@ -123,8 +123,8 @@ static ERL_NIF_TERM evision_cv_mat_lu(ErlNifEnv *env, int argc, const ERL_NIF_TE
     return enif_make_badarg(env);
 }
 
-// Householder QR returning {Q, R} with A = Q*R. reduced (complete=0): Q is m*n, R is n*n;
-// complete: Q is m*m, R is m*n. Requires m >= n.
+// Householder QR returning {Q, R} with A = Q*R. reduced (complete=0): Q is m*k, R is k*n;
+// complete: Q is m*m, R is m*n, where k = min(m, n).
 // @evision c: mat_qr, evision_cv_mat_qr, 1
 // @evision nif: def mat_qr(_opts \\ []), do: :erlang.nif_error(:undefined)
 static ERL_NIF_TERM evision_cv_mat_qr(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -142,16 +142,14 @@ static ERL_NIF_TERM evision_cv_mat_qr(ErlNifEnv *env, int argc, const ERL_NIF_TE
             evision_to_safe(env, evision_get_kw(env, erl_terms, "m"), m, ArgInfo("m", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "n"), n, ArgInfo("n", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "complete"), complete, ArgInfo("complete", 0))) {
-            if (m < n)
-                return evision::nif::error(env, "qr: tensor must have at least as many rows as columns");
-
             Mat R = a.clone();                 // m x n, mutated into the upper factor
             Mat Q = Mat::eye(m, m, CV_64F);     // accumulated orthogonal factor
             double *rp = (double *)R.data;
             double *qp = (double *)Q.data;
             std::vector<double> v((size_t)m);
+            int kmax = std::min(m, n);
 
-            for (int k = 0; k < n; k++) {
+            for (int k = 0; k < kmax; k++) {
                 double normx = 0.0;
                 for (int i = k; i < m; i++) normx += rp[i * n + k] * rp[i * n + k];
                 normx = std::sqrt(normx);
@@ -186,15 +184,15 @@ static ERL_NIF_TERM evision_cv_mat_qr(ErlNifEnv *env, int argc, const ERL_NIF_TE
                 return enif_make_tuple2(env, evision_from(env, Q), evision_from(env, R));
             }
 
-            // reduced: first n columns of Q (m x n), first n rows of R (n x n)
-            Mat Qr(m, n, CV_64F);
+            // reduced: first k columns of Q (m x k), first k rows of R (k x n)
+            Mat Qr(m, kmax, CV_64F);
             double *qrp = (double *)Qr.data;
             for (int i = 0; i < m; i++)
-                for (int j = 0; j < n; j++) qrp[i * n + j] = qp[i * m + j];
+                for (int j = 0; j < kmax; j++) qrp[i * kmax + j] = qp[i * m + j];
 
-            Mat Rr(n, n, CV_64F);
+            Mat Rr(kmax, n, CV_64F);
             double *rrp = (double *)Rr.data;
-            for (int i = 0; i < n; i++)
+            for (int i = 0; i < kmax; i++)
                 for (int j = 0; j < n; j++) rrp[i * n + j] = rp[i * n + j];
 
             return enif_make_tuple2(env, evision_from(env, Qr), evision_from(env, Rr));

--- a/c_src/modules/evision_backend/predicate.h
+++ b/c_src/modules/evision_backend/predicate.h
@@ -1,0 +1,69 @@
+#ifndef EVISION_BACKEND_PREDICATE_H
+#define EVISION_BACKEND_PREDICATE_H
+
+#include <cmath>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Elementwise predicate -> u8 {0,1} (Nx.is_nan / is_infinity / logical_not).
+// op 0 = is_nan, 1 = is_infinity, 2 = is_zero (logical_not). The nan/inf checks go
+// through double, so integer inputs are always finite (0); f16/bf16 are widened to
+// f32 by the caller, so only real C types reach here. Output is a flat [1, n] u8
+// mat the caller reshapes to the input shape.
+template <typename T>
+static void evision_predicate(const cv::Mat &src, cv::Mat &dst, int op) {
+    const T *sp = (const T *)src.data;
+    unsigned char *dp = dst.data;
+    size_t n = src.total();
+    for (size_t i = 0; i < n; i++) {
+        T x = sp[i];
+        unsigned char r = 0;
+        switch (op) {
+            case 0: r = std::isnan((double)x) ? 1 : 0; break;
+            case 1: r = std::isinf((double)x) ? 1 : 0; break;
+            case 2: r = (x == (T)0) ? 1 : 0; break;
+            default: break;
+        }
+        dp[i] = r;
+    }
+}
+
+// @evision c: mat_predicate, evision_cv_mat_predicate, 1
+// @evision nif: def mat_predicate(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_predicate(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        int op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            Mat src_c = src.isContinuous() ? src : src.clone();
+            Mat dst(1, (int)src_c.total(), CV_8U);
+            switch (src_c.depth()) {
+                case CV_8U:  evision_predicate<uint8_t>(src_c, dst, op); break;
+                case CV_8S:  evision_predicate<int8_t>(src_c, dst, op); break;
+                case CV_16U: evision_predicate<uint16_t>(src_c, dst, op); break;
+                case CV_16S: evision_predicate<int16_t>(src_c, dst, op); break;
+                case CV_32S: evision_predicate<int32_t>(src_c, dst, op); break;
+                case CV_32U: evision_predicate<uint32_t>(src_c, dst, op); break;
+                case CV_64S: evision_predicate<int64_t>(src_c, dst, op); break;
+                case CV_64U: evision_predicate<uint64_t>(src_c, dst, op); break;
+                case CV_32F: evision_predicate<float>(src_c, dst, op); break;
+                case CV_64F: evision_predicate<double>(src_c, dst, op); break;
+                default: return evision::nif::error(env, "mat_predicate: unsupported depth");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_PREDICATE_H

--- a/c_src/modules/evision_backend/put_slice.h
+++ b/c_src/modules/evision_backend/put_slice.h
@@ -1,0 +1,75 @@
+#ifndef EVISION_BACKEND_PUT_SLICE_H
+#define EVISION_BACKEND_PUT_SLICE_H
+
+#include <cstring>
+#include <vector>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Scatter a dense block into a copy of `base` (Nx.put_slice; also the building block
+// for concatenate). dst = clone(base); for each element of `slice` at multi-index
+// (j_0..j_{r-1}), write it to dst at (starts[k] + j_k). Type-agnostic byte copy via
+// an odometer tracking the destination offset; the block is bounds-checked up front.
+// @evision c: mat_put_slice, evision_cv_mat_put_slice, 1
+// @evision nif: def mat_put_slice(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_put_slice(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat base, slice;
+        std::vector<int> base_dims, slice_dims, starts;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "base"), base, ArgInfo("base", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "slice"), slice, ArgInfo("slice", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "base_dims"), base_dims, ArgInfo("base_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "slice_dims"), slice_dims, ArgInfo("slice_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "starts"), starts, ArgInfo("starts", 0))) {
+            int r = (int)base_dims.size();
+            if ((int)slice_dims.size() != r || (int)starts.size() != r)
+                return evision::nif::error(env, "put_slice: rank mismatch");
+
+            std::vector<int64_t> base_stride((size_t)(r > 0 ? r : 1));
+            int64_t acc = 1;
+            for (int k = r - 1; k >= 0; k--) { base_stride[(size_t)k] = acc; acc *= base_dims[(size_t)k]; }
+
+            int64_t slice_total = 1;
+            for (int k = 0; k < r; k++) {
+                slice_total *= slice_dims[(size_t)k];
+                if (starts[(size_t)k] < 0 || starts[(size_t)k] + slice_dims[(size_t)k] > base_dims[(size_t)k])
+                    return evision::nif::error(env, "put_slice: slice out of bounds");
+            }
+
+            Mat dst = base.clone();
+            Mat sl = slice.isContinuous() ? slice : slice.clone();
+            size_t elem = dst.elemSize();
+            const uchar *sp = sl.data;
+            uchar *dp = dst.data;
+
+            if (slice_total > 0) {
+                std::vector<int64_t> idx((size_t)(r > 0 ? r : 1), 0);
+                int64_t dst_off = 0;
+                for (int k = 0; k < r; k++) dst_off += (int64_t)starts[(size_t)k] * base_stride[(size_t)k];
+                for (int64_t s = 0; s < slice_total; s++) {
+                    std::memcpy(dp + (size_t)dst_off * elem, sp + (size_t)s * elem, elem);
+                    for (int k = r - 1; k >= 0; k--) {
+                        idx[(size_t)k]++;
+                        dst_off += base_stride[(size_t)k];
+                        if (idx[(size_t)k] < slice_dims[(size_t)k]) break;
+                        idx[(size_t)k] = 0;
+                        dst_off -= (int64_t)slice_dims[(size_t)k] * base_stride[(size_t)k];
+                    }
+                }
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_PUT_SLICE_H

--- a/c_src/modules/evision_backend/reduce.h
+++ b/c_src/modules/evision_backend/reduce.h
@@ -5,17 +5,32 @@
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
 
-// Row-wise sum (op 0) / product (op 1), accumulating left-to-right. Input is a 2D
-// single-channel Mat already cast to the accumulator type (CV_64F / CV_64S /
-// CV_64U) by the caller, so integer promotion (s64/u64, modular) and f64 float
-// accumulation match Nx; output is [rows, 1] of the same type.
+// Row-wise reduction: sum (op 0) / product (op 1) accumulate left-to-right, max
+// (op 2) / min (op 3) seed from the first element. Input is a 2D single-channel
+// Mat already cast to the accumulator type (CV_64F / CV_64S / CV_64U) by the
+// caller, so integer promotion (s64/u64, modular) and f64 accumulation match Nx;
+// output is [rows, 1] of the same type.
 
 template <typename T>
 static void evision_reduce_rows(const cv::Mat &src, cv::Mat &dst, int op) {
     for (int r = 0; r < src.rows; r++) {
         const T *sp = src.ptr<T>(r);
-        T acc = (op == 1) ? (T)1 : (T)0;
-        for (int c = 0; c < src.cols; c++) acc = (op == 1) ? (T)(acc * sp[c]) : (T)(acc + sp[c]);
+        T acc;
+        switch (op) {
+            case 1: acc = (T)1; break;
+            case 2: case 3: acc = sp[0]; break;
+            default: acc = (T)0; break;
+        }
+        int start = (op == 2 || op == 3) ? 1 : 0;
+        for (int c = start; c < src.cols; c++) {
+            T v = sp[c];
+            switch (op) {
+                case 0: acc = (T)(acc + v); break;
+                case 1: acc = (T)(acc * v); break;
+                case 2: acc = (v > acc) ? v : acc; break;
+                case 3: acc = (v < acc) ? v : acc; break;
+            }
+        }
         dst.ptr<T>(r)[0] = acc;
     }
 }

--- a/c_src/modules/evision_backend/reduce.h
+++ b/c_src/modules/evision_backend/reduce.h
@@ -1,0 +1,52 @@
+#ifndef EVISION_BACKEND_REDUCE_H
+#define EVISION_BACKEND_REDUCE_H
+
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Row-wise sum (op 0) / product (op 1), accumulating left-to-right. Input is a 2D
+// single-channel Mat already cast to the accumulator type (CV_64F / CV_64S /
+// CV_64U) by the caller, so integer promotion (s64/u64, modular) and f64 float
+// accumulation match Nx; output is [rows, 1] of the same type.
+
+template <typename T>
+static void evision_reduce_rows(const cv::Mat &src, cv::Mat &dst, int op) {
+    for (int r = 0; r < src.rows; r++) {
+        const T *sp = src.ptr<T>(r);
+        T acc = (op == 1) ? (T)1 : (T)0;
+        for (int c = 0; c < src.cols; c++) acc = (op == 1) ? (T)(acc * sp[c]) : (T)(acc + sp[c]);
+        dst.ptr<T>(r)[0] = acc;
+    }
+}
+
+// @evision c: mat_reduce, evision_cv_mat_reduce, 1
+// @evision nif: def mat_reduce(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_reduce(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        int op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            Mat dst(src.rows, 1, src.type());
+            switch (src.depth()) {
+                case CV_64F: evision_reduce_rows<double>(src, dst, op); break;
+                case CV_64S: evision_reduce_rows<int64_t>(src, dst, op); break;
+                case CV_64U: evision_reduce_rows<uint64_t>(src, dst, op); break;
+                default: return evision::nif::error(env, "mat_reduce: unsupported depth");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_REDUCE_H

--- a/c_src/modules/evision_backend/reduce.h
+++ b/c_src/modules/evision_backend/reduce.h
@@ -1,6 +1,8 @@
 #ifndef EVISION_BACKEND_REDUCE_H
 #define EVISION_BACKEND_REDUCE_H
 
+#include <cmath>
+#include <type_traits>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
@@ -10,6 +12,22 @@
 // Mat already cast to the accumulator type (CV_64F / CV_64S / CV_64U) by the
 // caller, so integer promotion (s64/u64, modular) and f64 accumulation match Nx;
 // output is [rows, 1] of the same type.
+
+template <typename T>
+static inline T evision_reduce_max(T acc, T v) {
+    if constexpr (std::is_floating_point<T>::value) {
+        if (std::isnan(acc) || std::isnan(v)) return std::isnan(acc) ? acc : v;
+    }
+    return (v > acc) ? v : acc;
+}
+
+template <typename T>
+static inline T evision_reduce_min(T acc, T v) {
+    if constexpr (std::is_floating_point<T>::value) {
+        if (std::isnan(acc) || std::isnan(v)) return std::isnan(acc) ? acc : v;
+    }
+    return (v < acc) ? v : acc;
+}
 
 template <typename T>
 static void evision_reduce_rows(const cv::Mat &src, cv::Mat &dst, int op) {
@@ -27,8 +45,8 @@ static void evision_reduce_rows(const cv::Mat &src, cv::Mat &dst, int op) {
             switch (op) {
                 case 0: acc = (T)(acc + v); break;
                 case 1: acc = (T)(acc * v); break;
-                case 2: acc = (v > acc) ? v : acc; break;
-                case 3: acc = (v < acc) ? v : acc; break;
+                case 2: acc = evision_reduce_max(acc, v); break;
+                case 3: acc = evision_reduce_min(acc, v); break;
             }
         }
         dst.ptr<T>(r)[0] = acc;

--- a/c_src/modules/evision_backend/select.h
+++ b/c_src/modules/evision_backend/select.h
@@ -1,0 +1,48 @@
+#ifndef EVISION_BACKEND_SELECT_H
+#define EVISION_BACKEND_SELECT_H
+
+#include <cstring>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Elementwise select (Nx.select): result = mask ? on_true : on_false. All three
+// have the same shape (broadcast by the caller); on_true/on_false are already the
+// output type and mask is u8. Type-agnostic byte copy: start from on_true, then
+// overwrite the elements where the mask is zero with on_false.
+// @evision c: mat_select, evision_cv_mat_select, 1
+// @evision nif: def mat_select(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_select(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat mask, on_true, on_false;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "mask"), mask, ArgInfo("mask", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "on_true"), on_true, ArgInfo("on_true", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "on_false"), on_false, ArgInfo("on_false", 0))) {
+            Mat mc = mask.isContinuous() ? mask : mask.clone();
+            Mat fc = on_false.isContinuous() ? on_false : on_false.clone();
+            Mat dst = on_true.clone();
+
+            const unsigned char *mp = mc.data;
+            const unsigned char *fp = fc.data;
+            unsigned char *dp = dst.data;
+            size_t elem_size = dst.elemSize();
+            size_t n = dst.total();
+            for (size_t i = 0; i < n; i++) {
+                if (mp[i] == 0)
+                    std::memcpy(dp + i * elem_size, fp + i * elem_size, elem_size);
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_SELECT_H

--- a/c_src/modules/evision_backend/shift.h
+++ b/c_src/modules/evision_backend/shift.h
@@ -1,0 +1,74 @@
+#ifndef EVISION_BACKEND_SHIFT_H
+#define EVISION_BACKEND_SHIFT_H
+
+#include <cstdint>
+#include <type_traits>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Elementwise integer shift (Nx.left_shift / right_shift). `l` and `r` share the
+// output type and shape. op 0 = left (<<), 1 = right (>>). Left shifts compute in
+// the unsigned counterpart (modular, no signed-overflow UB); right shifts use the
+// native >> (arithmetic for signed, logical for unsigned). A shift >= bit width
+// yields 0, except a right shift of a negative signed value yields -1 -- matching
+// Nx's arbitrary-precision shift truncated to the type.
+template <typename T>
+static void evision_shift(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst, int op) {
+    typedef typename std::make_unsigned<T>::type U;
+    const T *lp = (const T *)l.data;
+    const T *rp = (const T *)r.data;
+    T *dp = (T *)dst.data;
+    size_t n = l.total();
+    uint64_t width = (uint64_t)(sizeof(T) * 8);
+    for (size_t i = 0; i < n; i++) {
+        T a = lp[i];
+        T b = rp[i];
+        if (op == 0) {
+            dp[i] = ((uint64_t)b >= width) ? (T)0 : (T)((U)a << b);
+        } else if ((uint64_t)b >= width) {
+            dp[i] = (std::is_signed<T>::value && a < 0) ? (T)(-1) : (T)0;
+        } else {
+            dp[i] = (T)(a >> b);
+        }
+    }
+}
+
+// @evision c: mat_shift, evision_cv_mat_shift, 1
+// @evision nif: def mat_shift(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_shift(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat l, r;
+        int op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            Mat lc = l.isContinuous() ? l : l.clone();
+            Mat rc = r.isContinuous() ? r : r.clone();
+            Mat dst = lc.clone();
+            switch (dst.depth()) {
+                case CV_8U:  evision_shift<uint8_t>(lc, rc, dst, op); break;
+                case CV_8S:  evision_shift<int8_t>(lc, rc, dst, op); break;
+                case CV_16U: evision_shift<uint16_t>(lc, rc, dst, op); break;
+                case CV_16S: evision_shift<int16_t>(lc, rc, dst, op); break;
+                case CV_32S: evision_shift<int32_t>(lc, rc, dst, op); break;
+                case CV_32U: evision_shift<uint32_t>(lc, rc, dst, op); break;
+                case CV_64S: evision_shift<int64_t>(lc, rc, dst, op); break;
+                case CV_64U: evision_shift<uint64_t>(lc, rc, dst, op); break;
+                default: return evision::nif::error(env, "mat_shift: integer types only");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_SHIFT_H

--- a/c_src/modules/evision_backend/sort.h
+++ b/c_src/modules/evision_backend/sort.h
@@ -2,15 +2,28 @@
 #define EVISION_BACKEND_SORT_H
 
 #include <algorithm>
+#include <cmath>
 #include <numeric>
+#include <type_traits>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
 
-// Row-wise sort/argsort for the wide integer depths (CV_32U/CV_64S/CV_64U) that
-// cv::sort/cv::sortIdx do not support. Input is a 2D single-channel Mat; each row
-// is sorted independently. argsort uses a stable sort so ties keep ascending
-// index order, matching Nx (and Nx.BinaryBackend) for both directions.
+// Row-wise sort/argsort for depths that need custom handling. Floats use Nx's
+// NaN order: ascending puts NaNs last, descending puts them first.
+
+template <typename T>
+static inline bool evision_sort_before(T a, T b, bool descending) {
+    if constexpr (std::is_floating_point<T>::value) {
+        bool a_nan = std::isnan(a);
+        bool b_nan = std::isnan(b);
+        if (a_nan || b_nan) {
+            if (a_nan && b_nan) return false;
+            return descending ? a_nan : b_nan;
+        }
+    }
+    return descending ? (a > b) : (a < b);
+}
 
 template <typename T>
 static void evision_sort_rows(const cv::Mat &src, cv::Mat &dst, bool descending) {
@@ -18,8 +31,9 @@ static void evision_sort_rows(const cv::Mat &src, cv::Mat &dst, bool descending)
         const T *sp = src.ptr<T>(r);
         T *dp = dst.ptr<T>(r);
         std::copy(sp, sp + src.cols, dp);
-        if (descending) std::sort(dp, dp + src.cols, std::greater<T>());
-        else std::sort(dp, dp + src.cols, std::less<T>());
+        std::sort(dp, dp + src.cols, [descending](T a, T b) {
+            return evision_sort_before(a, b, descending);
+        });
     }
 }
 
@@ -29,10 +43,9 @@ static void evision_argsort_rows(const cv::Mat &src, cv::Mat &dst, bool descendi
         const T *sp = src.ptr<T>(r);
         int32_t *dp = dst.ptr<int32_t>(r);
         std::iota(dp, dp + src.cols, 0);
-        if (descending)
-            std::stable_sort(dp, dp + src.cols, [sp](int32_t a, int32_t b) { return sp[a] > sp[b]; });
-        else
-            std::stable_sort(dp, dp + src.cols, [sp](int32_t a, int32_t b) { return sp[a] < sp[b]; });
+        std::stable_sort(dp, dp + src.cols, [sp, descending](int32_t a, int32_t b) {
+            return evision_sort_before(sp[a], sp[b], descending);
+        });
     }
 }
 
@@ -56,6 +69,8 @@ static ERL_NIF_TERM evision_cv_mat_sort_rows(ErlNifEnv *env, int argc, const ERL
                 case CV_32U: evision_sort_rows<uint32_t>(src, dst, descending != 0); break;
                 case CV_64S: evision_sort_rows<int64_t>(src, dst, descending != 0); break;
                 case CV_64U: evision_sort_rows<uint64_t>(src, dst, descending != 0); break;
+                case CV_32F: evision_sort_rows<float>(src, dst, descending != 0); break;
+                case CV_64F: evision_sort_rows<double>(src, dst, descending != 0); break;
                 default: return evision::nif::error(env, "mat_sort_rows: unsupported depth");
             }
             return evision_from(env, dst);
@@ -85,6 +100,8 @@ static ERL_NIF_TERM evision_cv_mat_argsort_rows(ErlNifEnv *env, int argc, const 
                 case CV_32U: evision_argsort_rows<uint32_t>(src, dst, descending != 0); break;
                 case CV_64S: evision_argsort_rows<int64_t>(src, dst, descending != 0); break;
                 case CV_64U: evision_argsort_rows<uint64_t>(src, dst, descending != 0); break;
+                case CV_32F: evision_argsort_rows<float>(src, dst, descending != 0); break;
+                case CV_64F: evision_argsort_rows<double>(src, dst, descending != 0); break;
                 default: return evision::nif::error(env, "mat_argsort_rows: unsupported depth");
             }
             return evision_from(env, dst);

--- a/c_src/modules/evision_backend/sort.h
+++ b/c_src/modules/evision_backend/sort.h
@@ -1,0 +1,97 @@
+#ifndef EVISION_BACKEND_SORT_H
+#define EVISION_BACKEND_SORT_H
+
+#include <algorithm>
+#include <numeric>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Row-wise sort/argsort for the wide integer depths (CV_32U/CV_64S/CV_64U) that
+// cv::sort/cv::sortIdx do not support. Input is a 2D single-channel Mat; each row
+// is sorted independently. argsort uses a stable sort so ties keep ascending
+// index order, matching Nx (and Nx.BinaryBackend) for both directions.
+
+template <typename T>
+static void evision_sort_rows(const cv::Mat &src, cv::Mat &dst, bool descending) {
+    for (int r = 0; r < src.rows; r++) {
+        const T *sp = src.ptr<T>(r);
+        T *dp = dst.ptr<T>(r);
+        std::copy(sp, sp + src.cols, dp);
+        if (descending) std::sort(dp, dp + src.cols, std::greater<T>());
+        else std::sort(dp, dp + src.cols, std::less<T>());
+    }
+}
+
+template <typename T>
+static void evision_argsort_rows(const cv::Mat &src, cv::Mat &dst, bool descending) {
+    for (int r = 0; r < src.rows; r++) {
+        const T *sp = src.ptr<T>(r);
+        int32_t *dp = dst.ptr<int32_t>(r);
+        std::iota(dp, dp + src.cols, 0);
+        if (descending)
+            std::stable_sort(dp, dp + src.cols, [sp](int32_t a, int32_t b) { return sp[a] > sp[b]; });
+        else
+            std::stable_sort(dp, dp + src.cols, [sp](int32_t a, int32_t b) { return sp[a] < sp[b]; });
+    }
+}
+
+// @evision c: mat_sort_rows, evision_cv_mat_sort_rows, 1
+// @evision nif: def mat_sort_rows(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_sort_rows(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        int descending = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "descending"), descending, ArgInfo("descending", 0))) {
+            Mat dst(src.rows, src.cols, src.type());
+            switch (src.depth()) {
+                case CV_32U: evision_sort_rows<uint32_t>(src, dst, descending != 0); break;
+                case CV_64S: evision_sort_rows<int64_t>(src, dst, descending != 0); break;
+                case CV_64U: evision_sort_rows<uint64_t>(src, dst, descending != 0); break;
+                default: return evision::nif::error(env, "mat_sort_rows: unsupported depth");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+// @evision c: mat_argsort_rows, evision_cv_mat_argsort_rows, 1
+// @evision nif: def mat_argsort_rows(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_argsort_rows(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        int descending = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "descending"), descending, ArgInfo("descending", 0))) {
+            Mat dst(src.rows, src.cols, CV_32S);
+            switch (src.depth()) {
+                case CV_32U: evision_argsort_rows<uint32_t>(src, dst, descending != 0); break;
+                case CV_64S: evision_argsort_rows<int64_t>(src, dst, descending != 0); break;
+                case CV_64U: evision_argsort_rows<uint64_t>(src, dst, descending != 0); break;
+                default: return evision::nif::error(env, "mat_argsort_rows: unsupported depth");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_SORT_H

--- a/c_src/modules/evision_backend/strided_copy.h
+++ b/c_src/modules/evision_backend/strided_copy.h
@@ -1,0 +1,78 @@
+#ifndef EVISION_BACKEND_STRIDED_COPY_H
+#define EVISION_BACKEND_STRIDED_COPY_H
+
+#include <cstring>
+#include <vector>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// General strided copy (Nx.slice / reverse). For each output element at multi-index
+// (i_0..i_{r-1}), reads src at input index (starts[k] + i_k * strides[k]) per axis;
+// strides may be negative (reverse). Type-agnostic byte copy via an odometer that
+// tracks the input offset incrementally. Per-axis bounds are validated up front.
+// @evision c: mat_strided_copy, evision_cv_mat_strided_copy, 1
+// @evision nif: def mat_strided_copy(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_strided_copy(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        std::vector<int> in_dims, out_dims, starts, strides;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "in_dims"), in_dims, ArgInfo("in_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "out_dims"), out_dims, ArgInfo("out_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "starts"), starts, ArgInfo("starts", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "strides"), strides, ArgInfo("strides", 0))) {
+            int r = (int)in_dims.size();
+            if ((int)out_dims.size() != r || (int)starts.size() != r || (int)strides.size() != r)
+                return evision::nif::error(env, "strided_copy: rank mismatch");
+
+            std::vector<int64_t> in_stride((size_t)(r > 0 ? r : 1));
+            int64_t acc = 1;
+            for (int k = r - 1; k >= 0; k--) { in_stride[(size_t)k] = acc; acc *= in_dims[(size_t)k]; }
+
+            int64_t out_total = 1;
+            for (int k = 0; k < r; k++) {
+                out_total *= out_dims[(size_t)k];
+                if (out_dims[(size_t)k] <= 0) continue;
+                int64_t lo = starts[(size_t)k];
+                int64_t hi = (int64_t)starts[(size_t)k] + (int64_t)(out_dims[(size_t)k] - 1) * strides[(size_t)k];
+                if (lo < 0 || lo >= in_dims[(size_t)k] || hi < 0 || hi >= in_dims[(size_t)k])
+                    return evision::nif::error(env, "strided_copy: index out of bounds");
+            }
+
+            Mat src_c = src.isContinuous() ? src : src.clone();
+            size_t elem = src_c.elemSize();
+            Mat dst(1, (int)(out_total > 0 ? out_total : 1), src.type());
+            const uchar *sp = src_c.data;
+            uchar *dp = dst.data;
+
+            if (out_total > 0) {
+                std::vector<int64_t> idx((size_t)(r > 0 ? r : 1), 0);
+                int64_t in_off = 0;
+                for (int k = 0; k < r; k++) in_off += (int64_t)starts[(size_t)k] * in_stride[(size_t)k];
+                for (int64_t o = 0; o < out_total; o++) {
+                    std::memcpy(dp + (size_t)o * elem, sp + (size_t)in_off * elem, elem);
+                    for (int k = r - 1; k >= 0; k--) {
+                        idx[(size_t)k]++;
+                        in_off += (int64_t)strides[(size_t)k] * in_stride[(size_t)k];
+                        if (idx[(size_t)k] < out_dims[(size_t)k]) break;
+                        idx[(size_t)k] = 0;
+                        in_off -= (int64_t)out_dims[(size_t)k] * strides[(size_t)k] * in_stride[(size_t)k];
+                    }
+                }
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_STRIDED_COPY_H

--- a/c_src/modules/evision_backend/take.h
+++ b/c_src/modules/evision_backend/take.h
@@ -1,0 +1,57 @@
+#ifndef EVISION_BACKEND_TAKE_H
+#define EVISION_BACKEND_TAKE_H
+
+#include <cstring>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Gather along one axis (Nx.take). Type-agnostic byte copy:
+// out[o, i, inner-block] = src[o, indices[i], inner-block], where o in [0,outer),
+// i in [0,num_idx). indices are int64; bounds are checked to match Nx.
+// @evision c: mat_take, evision_cv_mat_take, 1
+// @evision nif: def mat_take(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_take(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src, indices;
+        int outer = 0, axis_dim = 0, inner = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "outer"), outer, ArgInfo("outer", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "axis_dim"), axis_dim, ArgInfo("axis_dim", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "inner"), inner, ArgInfo("inner", 0))) {
+            Mat src_c = src.isContinuous() ? src : src.clone();
+            Mat idx_c = indices.isContinuous() ? indices : indices.clone();
+            const uchar *sp = src_c.data;
+            const int64_t *ip = (const int64_t *)idx_c.data;
+            int64_t num_idx = (int64_t)idx_c.total();
+            size_t inner_bytes = (size_t)inner * src_c.elemSize();
+
+            Mat dst(1, (int)((int64_t)outer * num_idx * inner), src.type());
+            uchar *dp = dst.data;
+
+            for (int64_t o = 0; o < outer; o++) {
+                for (int64_t i = 0; i < num_idx; i++) {
+                    int64_t idx = ip[i];
+                    if (idx < 0 || idx >= axis_dim)
+                        return evision::nif::error(env, "take: index out of bounds");
+                    std::memcpy(dp + (size_t)(o * num_idx + i) * inner_bytes,
+                                sp + (size_t)(o * axis_dim + idx) * inner_bytes,
+                                inner_bytes);
+                }
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_TAKE_H

--- a/c_src/modules/evision_backend/take_along_axis.h
+++ b/c_src/modules/evision_backend/take_along_axis.h
@@ -1,0 +1,78 @@
+#ifndef EVISION_BACKEND_TAKE_ALONG_AXIS_H
+#define EVISION_BACKEND_TAKE_ALONG_AXIS_H
+
+#include <cstring>
+#include <vector>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Per-element gather along one axis (Nx.take_along_axis). out has the indices' shape;
+// out[j_0..j_{r-1}] = src[j with the `axis` coord replaced by indices[j]]. The non-axis
+// part of the input offset is tracked by an odometer (the axis stride is skipped), and
+// each element adds indices[p] * axis_stride. int64 indices, bounds-checked.
+// @evision c: mat_take_along_axis, evision_cv_mat_take_along_axis, 1
+// @evision nif: def mat_take_along_axis(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_take_along_axis(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src, indices;
+        std::vector<int> in_dims, out_dims;
+        int axis = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "in_dims"), in_dims, ArgInfo("in_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "out_dims"), out_dims, ArgInfo("out_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "axis"), axis, ArgInfo("axis", 0))) {
+            int r = (int)in_dims.size();
+            if ((int)out_dims.size() != r || axis < 0 || axis >= r)
+                return evision::nif::error(env, "take_along_axis: bad rank or axis");
+
+            std::vector<int64_t> in_stride((size_t)(r > 0 ? r : 1));
+            int64_t acc = 1;
+            for (int k = r - 1; k >= 0; k--) { in_stride[(size_t)k] = acc; acc *= in_dims[(size_t)k]; }
+
+            int64_t out_total = 1;
+            for (int k = 0; k < r; k++) out_total *= out_dims[(size_t)k];
+            int64_t axis_dim = in_dims[(size_t)axis];
+            int64_t axis_stride = in_stride[(size_t)axis];
+
+            Mat src_c = src.isContinuous() ? src : src.clone();
+            Mat idx_c = indices.isContinuous() ? indices : indices.clone();
+            const int64_t *ip = (const int64_t *)idx_c.data;
+            size_t elem = src_c.elemSize();
+            Mat dst(1, (int)(out_total > 0 ? out_total : 1), src.type());
+            const uchar *sp = src_c.data;
+            uchar *dp = dst.data;
+
+            if (out_total > 0) {
+                std::vector<int64_t> idx((size_t)(r > 0 ? r : 1), 0);
+                int64_t base = 0;
+                for (int64_t p = 0; p < out_total; p++) {
+                    int64_t iv = ip[p];
+                    if (iv < 0 || iv >= axis_dim)
+                        return evision::nif::error(env, "take_along_axis: index out of bounds");
+                    std::memcpy(dp + (size_t)p * elem, sp + (size_t)(base + iv * axis_stride) * elem, elem);
+                    for (int k = r - 1; k >= 0; k--) {
+                        idx[(size_t)k]++;
+                        if (k != axis) base += in_stride[(size_t)k];
+                        if (idx[(size_t)k] < out_dims[(size_t)k]) break;
+                        idx[(size_t)k] = 0;
+                        if (k != axis) base -= (int64_t)out_dims[(size_t)k] * in_stride[(size_t)k];
+                    }
+                }
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_TAKE_ALONG_AXIS_H

--- a/c_src/modules/evision_backend/unary_math.h
+++ b/c_src/modules/evision_backend/unary_math.h
@@ -1,0 +1,71 @@
+#ifndef EVISION_BACKEND_UNARY_MATH_H
+#define EVISION_BACKEND_UNARY_MATH_H
+
+#include <cmath>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Element-wise unary float math (Nx trig / hyperbolic / erf / etc.) that OpenCV
+// has no primitive for. The caller passes a single-channel f32/f64 mat already
+// cast to the output type; ops that produce floats from any input. Op codes match
+// Evision.Backend's @uop_* constants.
+template <typename T>
+static void evision_unary_math(cv::Mat &m, int op) {
+    T *p = (T *)m.data;
+    size_t n = m.total();
+    for (size_t i = 0; i < n; i++) {
+        T x = p[i];
+        switch (op) {
+            case 0:  p[i] = std::sin(x); break;
+            case 1:  p[i] = std::cos(x); break;
+            case 2:  p[i] = std::tan(x); break;
+            case 3:  p[i] = std::asin(x); break;
+            case 4:  p[i] = std::acos(x); break;
+            case 5:  p[i] = std::atan(x); break;
+            case 6:  p[i] = std::sinh(x); break;
+            case 7:  p[i] = std::cosh(x); break;
+            case 8:  p[i] = std::tanh(x); break;
+            case 9:  p[i] = std::asinh(x); break;
+            case 10: p[i] = std::acosh(x); break;
+            case 11: p[i] = std::atanh(x); break;
+            case 12: p[i] = std::erf(x); break;
+            case 13: p[i] = std::erfc(x); break;
+            case 14: p[i] = std::cbrt(x); break;
+            case 15: p[i] = std::log1p(x); break;
+            case 16: p[i] = (T)1 / std::sqrt(x); break;
+            case 17: p[i] = (T)1 / ((T)1 + std::exp(-x)); break;
+            default: break;
+        }
+    }
+}
+
+// @evision c: mat_unary_math, evision_cv_mat_unary_math, 1
+// @evision nif: def mat_unary_math(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_unary_math(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        int op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            Mat dst = src.clone();
+            switch (dst.depth()) {
+                case CV_32F: evision_unary_math<float>(dst, op); break;
+                case CV_64F: evision_unary_math<double>(dst, op); break;
+                default: return evision::nif::error(env, "mat_unary_math: expected f32 or f64");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_UNARY_MATH_H

--- a/c_src/modules/evision_backend/window.h
+++ b/c_src/modules/evision_backend/window.h
@@ -2,7 +2,9 @@
 #define EVISION_BACKEND_WINDOW_H
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
+#include <type_traits>
 #include <vector>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
@@ -13,6 +15,22 @@
 // widened to f32 by the caller. Padding is not materialized: out-of-range source coords are
 // skipped, which equals folding the per-op identity (0 sum / 1 product / -inf max / +inf min)
 // that Nx pads with. op: 0 sum, 1 product, 2 max, 3 min.
+
+template <typename T>
+static inline T window_max_value(T acc, T v) {
+    if constexpr (std::is_floating_point<T>::value) {
+        if (std::isnan(acc) || std::isnan(v)) return std::isnan(acc) ? acc : v;
+    }
+    return (v > acc) ? v : acc;
+}
+
+template <typename T>
+static inline T window_min_value(T acc, T v) {
+    if constexpr (std::is_floating_point<T>::value) {
+        if (std::isnan(acc) || std::isnan(v)) return std::isnan(acc) ? acc : v;
+    }
+    return (v < acc) ? v : acc;
+}
 
 template <typename T>
 static T window_identity(int op) {
@@ -61,8 +79,8 @@ static void window_reduce_typed(const T *sp, T *dp, int r,
                 switch (op) {
                     case 0: av = (T)(av + x); break;
                     case 1: av = (T)(av * x); break;
-                    case 2: av = (x > av) ? x : av; break;
-                    case 3: av = (x < av) ? x : av; break;
+                    case 2: av = window_max_value(av, x); break;
+                    case 3: av = window_min_value(av, x); break;
                 }
             }
             for (int k = r - 1; k >= 0; k--) { if (++w_idx[(size_t)k] < win_dims[(size_t)k]) break; w_idx[(size_t)k] = 0; }

--- a/c_src/modules/evision_backend/window.h
+++ b/c_src/modules/evision_backend/window.h
@@ -1,0 +1,233 @@
+#ifndef EVISION_BACKEND_WINDOW_H
+#define EVISION_BACKEND_WINDOW_H
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+#include <erl_nif.h>
+#include "../../ArgInfo.hpp"
+#include "../evision_mat_utils.hpp"
+
+// Sliding-window ops (Nx.window_*). Windows preserve the input dtype (no accumulator
+// upcast, unlike reduce), so everything is templated over the element type T; f16/bf16 are
+// widened to f32 by the caller. Padding is not materialized: out-of-range source coords are
+// skipped, which equals folding the per-op identity (0 sum / 1 product / -inf max / +inf min)
+// that Nx pads with. op: 0 sum, 1 product, 2 max, 3 min.
+
+template <typename T>
+static T window_identity(int op) {
+    switch (op) {
+        case 1: return (T)1;
+        case 2: return std::numeric_limits<T>::has_infinity
+                           ? -std::numeric_limits<T>::infinity()
+                           : std::numeric_limits<T>::lowest();
+        case 3: return std::numeric_limits<T>::has_infinity
+                           ? std::numeric_limits<T>::infinity()
+                           : std::numeric_limits<T>::max();
+        default: return (T)0;
+    }
+}
+
+template <typename T>
+static void window_reduce_typed(const T *sp, T *dp, int r,
+                                const std::vector<int> &in_dims, const std::vector<int> &out_dims,
+                                const std::vector<int> &win_dims, const std::vector<int> &strides,
+                                const std::vector<int> &pad_lo, const std::vector<int> &dil, int op) {
+    std::vector<int64_t> in_stride((size_t)r);
+    int64_t acc = 1;
+    for (int k = r - 1; k >= 0; k--) { in_stride[(size_t)k] = acc; acc *= in_dims[(size_t)k]; }
+
+    int64_t out_total = 1, win_total = 1;
+    for (int k = 0; k < r; k++) { out_total *= out_dims[(size_t)k]; win_total *= win_dims[(size_t)k]; }
+
+    T init = window_identity<T>(op);
+    std::vector<int> op_idx((size_t)r, 0), w_idx((size_t)r, 0);
+
+    for (int64_t p = 0; p < out_total; p++) {
+        T av = init;
+        std::fill(w_idx.begin(), w_idx.end(), 0);
+
+        for (int64_t wq = 0; wq < win_total; wq++) {
+            bool inrange = true;
+            int64_t soff = 0;
+            for (int k = 0; k < r; k++) {
+                int64_t s = (int64_t)op_idx[(size_t)k] * strides[(size_t)k] +
+                            (int64_t)w_idx[(size_t)k] * dil[(size_t)k] - pad_lo[(size_t)k];
+                if (s < 0 || s >= in_dims[(size_t)k]) { inrange = false; break; }
+                soff += s * in_stride[(size_t)k];
+            }
+            if (inrange) {
+                T x = sp[soff];
+                switch (op) {
+                    case 0: av = (T)(av + x); break;
+                    case 1: av = (T)(av * x); break;
+                    case 2: av = (x > av) ? x : av; break;
+                    case 3: av = (x < av) ? x : av; break;
+                }
+            }
+            for (int k = r - 1; k >= 0; k--) { if (++w_idx[(size_t)k] < win_dims[(size_t)k]) break; w_idx[(size_t)k] = 0; }
+        }
+
+        dp[p] = av;
+        for (int k = r - 1; k >= 0; k--) { if (++op_idx[(size_t)k] < out_dims[(size_t)k]) break; op_idx[(size_t)k] = 0; }
+    }
+}
+
+#define EVISION_WINDOW_DISPATCH(FN, SRC, DST, ...)                              \
+    switch ((SRC).depth()) {                                                    \
+        case CV_8U:  FN<uint8_t>((const uint8_t *)(SRC).data, (uint8_t *)(DST).data, __VA_ARGS__); break;   \
+        case CV_8S:  FN<int8_t>((const int8_t *)(SRC).data, (int8_t *)(DST).data, __VA_ARGS__); break;      \
+        case CV_16U: FN<uint16_t>((const uint16_t *)(SRC).data, (uint16_t *)(DST).data, __VA_ARGS__); break;\
+        case CV_16S: FN<int16_t>((const int16_t *)(SRC).data, (int16_t *)(DST).data, __VA_ARGS__); break;   \
+        case CV_32S: FN<int32_t>((const int32_t *)(SRC).data, (int32_t *)(DST).data, __VA_ARGS__); break;   \
+        case CV_32U: FN<uint32_t>((const uint32_t *)(SRC).data, (uint32_t *)(DST).data, __VA_ARGS__); break;\
+        case CV_64S: FN<int64_t>((const int64_t *)(SRC).data, (int64_t *)(DST).data, __VA_ARGS__); break;   \
+        case CV_64U: FN<uint64_t>((const uint64_t *)(SRC).data, (uint64_t *)(DST).data, __VA_ARGS__); break;\
+        case CV_32F: FN<float>((const float *)(SRC).data, (float *)(DST).data, __VA_ARGS__); break;         \
+        case CV_64F: FN<double>((const double *)(SRC).data, (double *)(DST).data, __VA_ARGS__); break;      \
+        default: return evision::nif::error(env, "window: unsupported depth");                              \
+    }
+
+// @evision c: mat_window_reduce, evision_cv_mat_window_reduce, 1
+// @evision nif: def mat_window_reduce(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_window_reduce(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src;
+        std::vector<int> in_dims, out_dims, win_dims, strides, pad_lo, dil;
+        int op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "in_dims"), in_dims, ArgInfo("in_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "out_dims"), out_dims, ArgInfo("out_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "win_dims"), win_dims, ArgInfo("win_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "strides"), strides, ArgInfo("strides", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "pad_lo"), pad_lo, ArgInfo("pad_lo", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "dilations"), dil, ArgInfo("dilations", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            int r = (int)in_dims.size();
+            Mat src_c = src.isContinuous() ? src : src.clone();
+            int64_t out_total = 1;
+            for (int k = 0; k < r; k++) out_total *= out_dims[(size_t)k];
+            Mat dst(1, (int)(out_total > 0 ? out_total : 1), src.type());
+
+            EVISION_WINDOW_DISPATCH(window_reduce_typed, src_c, dst,
+                                    r, in_dims, out_dims, win_dims, strides, pad_lo, dil, op)
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+// Select-and-scatter (Nx.window_scatter_max/min). For each window, pick the last position
+// achieving the extreme (max via >=, min via <=) and add that window's source value there;
+// duplicate targets accumulate. Output is the input shape, filled with init. op: 0 max, 1 min.
+// `sp` (input, for selection) and `srcvals` (per-window values) are both in the output type T;
+// dilation is always 1 for scatter.
+template <typename T>
+static void window_scatter_typed(const T *sp, const T *srcvals, T *dp, int r,
+                                 const std::vector<int> &in_dims, const std::vector<int> &win_dims,
+                                 const std::vector<int> &strides, const std::vector<int> &pad_lo,
+                                 const std::vector<int> &grid, T init, int op) {
+    std::vector<int64_t> in_stride((size_t)r);
+    int64_t acc = 1;
+    for (int k = r - 1; k >= 0; k--) { in_stride[(size_t)k] = acc; acc *= in_dims[(size_t)k]; }
+
+    int64_t in_total = 1, grid_total = 1, win_total = 1;
+    for (int k = 0; k < r; k++) {
+        in_total *= in_dims[(size_t)k];
+        grid_total *= grid[(size_t)k];
+        win_total *= win_dims[(size_t)k];
+    }
+    for (int64_t i = 0; i < in_total; i++) dp[i] = init;
+
+    std::vector<int> g_idx((size_t)r, 0), w_idx((size_t)r, 0);
+    for (int64_t p = 0; p < grid_total; p++) {
+        bool seeded = false;
+        T best = init;
+        int64_t best_off = -1;
+        std::fill(w_idx.begin(), w_idx.end(), 0);
+
+        for (int64_t wq = 0; wq < win_total; wq++) {
+            bool inrange = true;
+            int64_t soff = 0;
+            for (int k = 0; k < r; k++) {
+                int64_t s = (int64_t)g_idx[(size_t)k] * strides[(size_t)k] + w_idx[(size_t)k] - pad_lo[(size_t)k];
+                if (s < 0 || s >= in_dims[(size_t)k]) { inrange = false; break; }
+                soff += s * in_stride[(size_t)k];
+            }
+            T val = inrange ? sp[soff] : init;
+            if (!seeded) {
+                best = val;
+                best_off = inrange ? soff : -1;
+                seeded = true;
+            } else {
+                bool sel = (op == 0) ? (val >= best) : (val <= best);
+                if (sel) { best = val; best_off = inrange ? soff : -1; }
+            }
+            for (int k = r - 1; k >= 0; k--) { if (++w_idx[(size_t)k] < win_dims[(size_t)k]) break; w_idx[(size_t)k] = 0; }
+        }
+
+        if (best_off >= 0) dp[best_off] = (T)(dp[best_off] + srcvals[p]);
+        for (int k = r - 1; k >= 0; k--) { if (++g_idx[(size_t)k] < grid[(size_t)k]) break; g_idx[(size_t)k] = 0; }
+    }
+}
+
+// @evision c: mat_window_scatter, evision_cv_mat_window_scatter, 1
+// @evision nif: def mat_window_scatter(_opts \\ []), do: :erlang.nif_error(:undefined)
+static ERL_NIF_TERM evision_cv_mat_window_scatter(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    using namespace cv;
+    using namespace evision::nif;
+    std::map<std::string, ERL_NIF_TERM> erl_terms;
+    int nif_opts_index = 0;
+    evision::nif::parse_arg(env, nif_opts_index, argv, erl_terms);
+
+    {
+        Mat src, source;
+        std::vector<int> in_dims, win_dims, strides, pad_lo, grid;
+        double init = 0.0;
+        int op = 0;
+
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "source"), source, ArgInfo("source", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "init"), init, ArgInfo("init", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "in_dims"), in_dims, ArgInfo("in_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "win_dims"), win_dims, ArgInfo("win_dims", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "strides"), strides, ArgInfo("strides", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "pad_lo"), pad_lo, ArgInfo("pad_lo", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "grid"), grid, ArgInfo("grid", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
+            int r = (int)in_dims.size();
+            Mat src_c = src.isContinuous() ? src : src.clone();
+            Mat source_c = source.isContinuous() ? source : source.clone();
+            int64_t in_total = 1;
+            for (int k = 0; k < r; k++) in_total *= in_dims[(size_t)k];
+            Mat dst(1, (int)(in_total > 0 ? in_total : 1), src.type());
+
+            switch (src.depth()) {
+                case CV_8U:  window_scatter_typed<uint8_t>((const uint8_t *)src_c.data, (const uint8_t *)source_c.data, (uint8_t *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (uint8_t)init, op); break;
+                case CV_8S:  window_scatter_typed<int8_t>((const int8_t *)src_c.data, (const int8_t *)source_c.data, (int8_t *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (int8_t)init, op); break;
+                case CV_16U: window_scatter_typed<uint16_t>((const uint16_t *)src_c.data, (const uint16_t *)source_c.data, (uint16_t *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (uint16_t)init, op); break;
+                case CV_16S: window_scatter_typed<int16_t>((const int16_t *)src_c.data, (const int16_t *)source_c.data, (int16_t *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (int16_t)init, op); break;
+                case CV_32S: window_scatter_typed<int32_t>((const int32_t *)src_c.data, (const int32_t *)source_c.data, (int32_t *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (int32_t)init, op); break;
+                case CV_32U: window_scatter_typed<uint32_t>((const uint32_t *)src_c.data, (const uint32_t *)source_c.data, (uint32_t *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (uint32_t)init, op); break;
+                case CV_64S: window_scatter_typed<int64_t>((const int64_t *)src_c.data, (const int64_t *)source_c.data, (int64_t *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (int64_t)init, op); break;
+                case CV_64U: window_scatter_typed<uint64_t>((const uint64_t *)src_c.data, (const uint64_t *)source_c.data, (uint64_t *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (uint64_t)init, op); break;
+                case CV_32F: window_scatter_typed<float>((const float *)src_c.data, (const float *)source_c.data, (float *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, (float)init, op); break;
+                case CV_64F: window_scatter_typed<double>((const double *)src_c.data, (const double *)source_c.data, (double *)dst.data, r, in_dims, win_dims, strides, pad_lo, grid, init, op); break;
+                default: return evision::nif::error(env, "window_scatter: unsupported depth");
+            }
+            return evision_from(env, dst);
+        }
+    }
+
+    return enif_make_badarg(env);
+}
+
+#endif // EVISION_BACKEND_WINDOW_H

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -747,6 +747,8 @@ defmodule Evision.Backend do
   # a custom NIF, and half floats are widened to f32 (lossless) so cv can handle them.
   @wide_int_types [{:u, 32}, {:s, 64}, {:u, 64}]
   @half_types [{:f, 16}, {:bf, 16}]
+  @float_sort_types [{:f, 32}, {:f, 64}]
+  @custom_sort_types @wide_int_types ++ @float_sort_types
 
   @impl true
   def sort(out, %T{shape: shape, type: type} = tensor, opts) do
@@ -771,14 +773,14 @@ defmodule Evision.Backend do
     |> to_nx(out)
   end
 
-  defp sort_values(m2d, type, descending?) when type in @wide_int_types do
+  defp sort_values(m2d, type, descending?) when type in @custom_sort_types do
     reject_error(Evision.Mat.sort_rows(m2d, descending?))
   end
 
   defp sort_values(m2d, type, descending?) when type in @half_types do
     m2d
     |> as_mat_type({:f, 32})
-    |> Evision.sort(sort_flags(descending?))
+    |> Evision.Mat.sort_rows(descending?)
     |> reject_error()
     |> as_mat_type(type)
   end
@@ -787,8 +789,15 @@ defmodule Evision.Backend do
     reject_error(Evision.sort(m2d, sort_flags(descending?)))
   end
 
-  defp sort_indices(m2d, type, descending?) when type in @wide_int_types do
+  defp sort_indices(m2d, type, descending?) when type in @custom_sort_types do
     reject_error(Evision.Mat.argsort_rows(m2d, descending?))
+  end
+
+  defp sort_indices(m2d, type, descending?) when type in @half_types do
+    m2d
+    |> as_mat_type({:f, 32})
+    |> Evision.Mat.argsort_rows(descending?)
+    |> reject_error()
   end
 
   # cv::sortIdx is stable ascending but not descending, so sort the order-reversing
@@ -1212,6 +1221,17 @@ defmodule Evision.Backend do
   end
 
   @impl true
+  def concatenate(%T{type: out_type, shape: shape} = out, tensors, 0) do
+    bin =
+      tensors
+      |> Enum.map(fn t -> t |> from_nx() |> as_mat_type(out_type) |> to_binary_mat!() end)
+      |> IO.iodata_to_binary()
+
+    Evision.Mat.from_binary_by_shape(bin, out_type, shape)
+    |> reject_error()
+    |> to_nx(out)
+  end
+
   def concatenate(%T{type: out_type, shape: shape} = out, tensors, axis) do
     rank = tuple_size(shape)
     base = Evision.Mat.full(shape, 0, out_type) |> reject_error() |> to_nx(out)
@@ -1658,7 +1678,14 @@ defmodule Evision.Backend do
     end
   end
 
-  defp to_binary_f64(mat), do: reject_error(Evision.Mat.to_binary(mat, 0))
+  defp to_binary_f64(mat), do: to_binary_mat!(mat)
+
+  defp to_binary_mat!(mat) do
+    case Evision.Mat.to_binary(mat, 0) do
+      {:error, msg} -> raise RuntimeError, msg
+      binary -> binary
+    end
+  end
 
   # Concatenate f64 mats (batch order) then reshape/cast to the output template.
   defp stack_f64(%T{type: out_type, shape: shape} = out, mats) do

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1376,6 +1376,96 @@ defmodule Evision.Backend do
   defp maybe_narrow(mat, type, type), do: mat
   defp maybe_narrow(mat, _work_type, out_type), do: as_mat_type(mat, out_type)
 
+  ## Linear algebra
+
+  # Each callback receives `out` tensors already shaped and typed by Nx, so the only job
+  # is to produce matching values. cv covers determinant/solve/SVD/eigen; cholesky, lu, qr
+  # and triangular_solve have no cv factor extraction and go through custom NIFs. All ops
+  # compute in f64 (cast back to out.type) and loop over the leading batch dims.
+
+  @impl true
+  def determinant(%T{type: out_type, shape: out_shape} = out, %T{shape: shape} = tensor) do
+    {_batch, n, _n} = mat_dims(shape)
+
+    bin =
+      for m <- split_2d(tensor, n, n), into: <<>> do
+        <<determinant_one(m)::float-64-native>>
+      end
+
+    Evision.Mat.from_binary_by_shape(bin, {:f, 64}, out_shape)
+    |> reject_error()
+    |> as_mat_type(out_type)
+    |> to_nx(out)
+  end
+
+  defp determinant_one(mat) do
+    case Evision.determinant(mat) do
+      {:error, msg} -> raise RuntimeError, msg
+      d when is_number(d) -> d * 1.0
+    end
+  end
+
+  @impl true
+  def solve(out, %T{shape: a_shape} = a, %T{shape: b_shape} = b) do
+    {batch, n, _n} = mat_dims(a_shape)
+    {b_trailing, vector?} = rhs_trailing(a_shape, b_shape)
+
+    Enum.zip_with(split_2d(a, n, n), split_into(b, batch, b_trailing), fn am, bm ->
+      bm = if vector?, do: reject_error(Evision.Mat.reshape(bm, [n, 1])), else: bm
+      solve_one(am, bm)
+    end)
+    |> then(&stack_f64(out, &1))
+  end
+
+  defp solve_one(a, b) do
+    case Evision.solve(a, b, flags: Evision.DecompTypes.cv_DECOMP_LU()) do
+      %Evision.Mat{} = x -> x
+      {:error, msg} -> raise RuntimeError, msg
+      _ -> raise ArgumentError, "can't solve for singular matrix"
+    end
+  end
+
+  # {product of leading dims, second-last dim, last dim} for a batched matrix shape.
+  defp mat_dims(shape) do
+    [n, m | lead] = shape |> Tuple.to_list() |> Enum.reverse()
+    {Enum.product(lead), m, n}
+  end
+
+  # b's per-matrix trailing shape (drop a's leading batch dims) + whether it is a vector.
+  defp rhs_trailing(a_shape, b_shape) do
+    trailing =
+      b_shape |> Tuple.to_list() |> Enum.drop(tuple_size(a_shape) - 2) |> List.to_tuple()
+
+    {trailing, tuple_size(trailing) == 1}
+  end
+
+  # Split a batched {batch.., rows, cols} tensor into a list of {rows, cols} f64 mats.
+  defp split_2d(tensor, rows, cols),
+    do: split_into(tensor, div(Nx.size(tensor), rows * cols), {rows, cols})
+
+  defp split_into(tensor, batch, trailing) do
+    bin = tensor |> from_nx() |> as_mat_type({:f, 64}) |> to_binary_f64()
+    chunk = div(byte_size(bin), batch)
+
+    for i <- 0..(batch - 1) do
+      binary_part(bin, i * chunk, chunk)
+      |> Evision.Mat.from_binary_by_shape({:f, 64}, trailing)
+      |> reject_error()
+    end
+  end
+
+  defp to_binary_f64(mat), do: reject_error(Evision.Mat.to_binary(mat, 0))
+
+  # Concatenate f64 mats (batch order) then reshape/cast to the output template.
+  defp stack_f64(%T{type: out_type, shape: shape} = out, mats) do
+    bin = mats |> Enum.map(&to_binary_f64/1) |> IO.iodata_to_binary()
+
+    Evision.Mat.from_binary_by_shape(bin, {:f, 64}, shape)
+    |> reject_error()
+    |> as_mat_type(out_type)
+    |> to_nx(out)
+  end
+
   @doc false
   def from_nx(%T{data: %EB{ref: mat_ref}}), do: mat_ref
   def from_nx(%T{} = tensor) do

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1425,6 +1425,38 @@ defmodule Evision.Backend do
     end
   end
 
+  @impl true
+  def svd({u_out, s_out, vt_out}, %T{shape: shape} = tensor, opts) do
+    {_batch, m, n} = mat_dims(shape)
+    flags = if opts[:full_matrices?], do: Evision.SVD.Flags.cv_FULL_UV(), else: 0
+
+    results =
+      for am <- split_2d(tensor, m, n) do
+        {w, u, vt} = Evision.svdDecomp(am, flags: flags)
+        {u, w, vt}
+      end
+
+    {stack_f64(u_out, Enum.map(results, &elem(&1, 0))),
+     stack_f64(s_out, Enum.map(results, &elem(&1, 1))),
+     stack_f64(vt_out, Enum.map(results, &elem(&1, 2)))}
+  end
+
+  @impl true
+  def eigh({vals_out, vecs_out}, %T{shape: shape} = tensor, _opts) do
+    {_batch, n, _n} = mat_dims(shape)
+
+    results =
+      for am <- split_2d(tensor, n, n) do
+        {evals, evecs} = Evision.eigen(am)
+        # cv stores eigenvectors as rows in descending-eigenvalue order; Nx wants them as
+        # columns (column i pairing with eigenvalue i), so transpose.
+        {evals, reject_error(Evision.Mat.transpose(evecs, [1, 0], as_shape: {n, n}))}
+      end
+
+    {stack_f64(vals_out, Enum.map(results, &elem(&1, 0))),
+     stack_f64(vecs_out, Enum.map(results, &elem(&1, 1)))}
+  end
+
   # {product of leading dims, second-last dim, last dim} for a batched matrix shape.
   defp mat_dims(shape) do
     [n, m | lead] = shape |> Tuple.to_list() |> Enum.reverse()

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1119,6 +1119,39 @@ defmodule Evision.Backend do
     end
   end
 
+  ## Elementwise binary (no cv primitive)
+
+  @bop_atan2 0
+  @bop_pow 1
+  @bop_quotient 2
+  @bop_remainder 3
+
+  @impl true
+  def atan2(out, l, r), do: binary_math(out, l, r, @bop_atan2)
+
+  @impl true
+  def pow(out, l, r), do: binary_math(out, l, r, @bop_pow)
+
+  @impl true
+  def quotient(out, l, r), do: binary_math(out, l, r, @bop_quotient)
+
+  @impl true
+  def remainder(out, l, r), do: binary_math(out, l, r, @bop_remainder)
+
+  # Broadcast l and r to the output shape and cast both to the output type (f16/bf16
+  # widened to f32 since the NIF covers only real C types), then narrow the result back.
+  defp binary_math(%T{type: out_type, shape: shape} = out, l, r, op) do
+    work_type = if out_type in @half_types, do: {:f, 32}, else: out_type
+    {l, r} = enforce_same_shape(l, r, shape)
+    lm = as_mat_type(from_nx(l), work_type)
+    rm = as_mat_type(from_nx(r), work_type)
+
+    Evision.Mat.binop(lm, rm, op)
+    |> reject_error()
+    |> maybe_narrow(work_type, out_type)
+    |> to_nx(out)
+  end
+
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
   # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -912,6 +912,30 @@ defmodule Evision.Backend do
     |> to_nx(out)
   end
 
+  @impl true
+  def gather(%T{shape: out_shape} = out, tensor, %T{shape: indices_shape} = indices, opts) do
+    axes = opts[:axes]
+    tensor_axes = Nx.axes(tensor)
+
+    tensor =
+      if List.starts_with?(tensor_axes, axes) do
+        tensor
+      else
+        Nx.transpose(tensor, axes: axes ++ (tensor_axes -- axes))
+      end
+
+    depth = elem(indices_shape, tuple_size(indices_shape) - 1)
+    {lead, leftover} = tensor.shape |> Tuple.to_list() |> Enum.split(depth)
+    dims = from_nx(Nx.tensor(lead, type: {:s, 64}))
+    idx = as_mat_type(from_nx(indices), {:s, 64})
+
+    Evision.Mat.gather(from_nx(tensor), idx, dims, Enum.product(leftover))
+    |> reject_error()
+    |> Evision.Mat.reshape(reduce_out_dims(out_shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
   @doc false
   def from_nx(%T{data: %EB{ref: mat_ref}}), do: mat_ref
   def from_nx(%T{} = tensor) do

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1196,6 +1196,34 @@ defmodule Evision.Backend do
     |> to_nx(out)
   end
 
+  @impl true
+  def put_slice(%T{shape: shape} = out, tensor, start_indices, slice) do
+    starts = clamp_starts(start_indices, shape, Tuple.to_list(slice.shape))
+    do_put_slice(out, tensor, slice, starts)
+  end
+
+  defp do_put_slice(%T{type: out_type, shape: shape} = out, base, %T{shape: slice_shape} = slice, starts) do
+    base_mat = as_mat_type(from_nx(base), out_type)
+    slice_mat = as_mat_type(from_nx(slice), out_type)
+
+    Evision.Mat.put_slice(base_mat, slice_mat, Tuple.to_list(shape), Tuple.to_list(slice_shape), starts)
+    |> reject_error()
+    |> to_nx(out)
+  end
+
+  @impl true
+  def concatenate(%T{type: out_type, shape: shape} = out, tensors, axis) do
+    rank = tuple_size(shape)
+    base = Evision.Mat.full(shape, 0, out_type) |> reject_error() |> to_nx(out)
+
+    tensors
+    |> Enum.reduce({base, 0}, fn t, {acc, offset} ->
+      starts = List.duplicate(0, rank) |> List.replace_at(axis, offset)
+      {do_put_slice(out, acc, t, starts), offset + elem(t.shape, axis)}
+    end)
+    |> elem(0)
+  end
+
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
   # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -753,7 +753,7 @@ defmodule Evision.Backend do
     descending? = opts[:direction] == :desc
 
     from_nx(tensor)
-    |> sort_along_axis(shape, opts[:axis], &sort_values(&1, type, descending?))
+    |> along_axis(shape, opts[:axis], &sort_values(&1, type, descending?))
     |> to_nx(out)
   end
 
@@ -762,7 +762,7 @@ defmodule Evision.Backend do
     descending? = opts[:direction] == :desc
 
     from_nx(tensor)
-    |> sort_along_axis(shape, opts[:axis], fn m2d ->
+    |> along_axis(shape, opts[:axis], fn m2d ->
       m2d
       |> sort_indices(type, descending?)
       |> Evision.Mat.as_type(out_type)
@@ -812,9 +812,9 @@ defmodule Evision.Backend do
 
   defp as_mat_type(mat, type), do: reject_error(Evision.Mat.as_type(mat, type))
 
-  # Reduce an n-d sort/argsort along `axis` to cv's 2D per-row form: move the
+  # Reduce an n-d row-wise op along `axis` to cv's 2D per-row form: move the
   # target axis last, flatten to [n, axis_len], apply `fun`, then restore.
-  defp sort_along_axis(mat, shape, axis, fun) do
+  defp along_axis(mat, shape, axis, fun) do
     rank = tuple_size(shape)
     identity = Enum.to_list(0..(rank - 1))
     perm = (identity -- [axis]) ++ [axis]
@@ -845,6 +845,47 @@ defmodule Evision.Backend do
     |> Enum.with_index()
     |> Enum.sort_by(&elem(&1, 0))
     |> Enum.map(&elem(&1, 1))
+  end
+
+  ## Cumulative
+
+  @scan_sum 0
+  @scan_product 1
+  @scan_min 2
+  @scan_max 3
+
+  @impl true
+  def cumulative_sum(out, tensor, opts), do: cumulative(out, tensor, opts, @scan_sum)
+
+  @impl true
+  def cumulative_product(out, tensor, opts), do: cumulative(out, tensor, opts, @scan_product)
+
+  @impl true
+  def cumulative_min(out, tensor, opts), do: cumulative(out, tensor, opts, @scan_min)
+
+  @impl true
+  def cumulative_max(out, tensor, opts), do: cumulative(out, tensor, opts, @scan_max)
+
+  # Prefix scan along `axis` (output keeps the input shape and type). Half floats
+  # are widened to f32 (lossless) since the scan NIF covers only real C types.
+  defp cumulative(%T{type: type, shape: shape} = out, tensor, opts, op) do
+    reverse? = opts[:reverse]
+
+    from_nx(tensor)
+    |> along_axis(shape, opts[:axis], &scan(&1, type, op, reverse?))
+    |> to_nx(out)
+  end
+
+  defp scan(m2d, type, op, reverse?) when type in @half_types do
+    m2d
+    |> as_mat_type({:f, 32})
+    |> Evision.Mat.cumulative(op, reverse?)
+    |> reject_error()
+    |> as_mat_type(type)
+  end
+
+  defp scan(m2d, _type, op, reverse?) do
+    reject_error(Evision.Mat.cumulative(m2d, op, reverse?))
   end
 
   ## Reductions

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -896,6 +896,22 @@ defmodule Evision.Backend do
   defp reduce_out_dims({}), do: [1]
   defp reduce_out_dims(shape), do: Tuple.to_list(shape)
 
+  ## Indexing
+
+  @impl true
+  def take(%T{shape: out_shape} = out, %T{shape: shape} = tensor, indices, axis) do
+    dims = Tuple.to_list(shape)
+    outer = dims |> Enum.take(axis) |> Enum.product()
+    inner = dims |> Enum.drop(axis + 1) |> Enum.product()
+    idx = as_mat_type(from_nx(indices), {:s, 64})
+
+    Evision.Mat.take(from_nx(tensor), idx, outer, elem(shape, axis), inner)
+    |> reject_error()
+    |> Evision.Mat.reshape(reduce_out_dims(out_shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
   @doc false
   def from_nx(%T{data: %EB{ref: mat_ref}}), do: mat_ref
   def from_nx(%T{} = tensor) do

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1457,6 +1457,50 @@ defmodule Evision.Backend do
      stack_f64(vecs_out, Enum.map(results, &elem(&1, 1)))}
   end
 
+  @impl true
+  def cholesky(%T{shape: shape} = out, tensor) do
+    {_batch, n, _n} = mat_dims(shape)
+
+    split_2d(tensor, n, n)
+    |> Enum.map(&reject_error(Evision.Mat.cholesky(&1, n)))
+    |> then(&stack_f64(out, &1))
+  end
+
+  @impl true
+  def lu({p_out, l_out, u_out}, %T{shape: shape} = tensor, _opts) do
+    {_batch, n, _n} = mat_dims(shape)
+    results = split_2d(tensor, n, n) |> Enum.map(&reject_error_tuple(Evision.Mat.lu(&1, n)))
+
+    {stack_f64(p_out, Enum.map(results, &elem(&1, 0))),
+     stack_f64(l_out, Enum.map(results, &elem(&1, 1))),
+     stack_f64(u_out, Enum.map(results, &elem(&1, 2)))}
+  end
+
+  @impl true
+  def qr({q_out, r_out}, %T{shape: shape} = tensor, opts) do
+    {_batch, m, n} = mat_dims(shape)
+    complete = bool_int(opts[:mode] == :complete)
+    results = split_2d(tensor, m, n) |> Enum.map(&reject_error_tuple(Evision.Mat.qr(&1, m, n, complete)))
+
+    {stack_f64(q_out, Enum.map(results, &elem(&1, 0))),
+     stack_f64(r_out, Enum.map(results, &elem(&1, 1)))}
+  end
+
+  @impl true
+  def triangular_solve(out, %T{shape: a_shape} = a, %T{shape: b_shape} = b, opts) do
+    {batch, n, _n} = mat_dims(a_shape)
+    {b_trailing, vector?} = rhs_trailing(a_shape, b_shape)
+    lower = bool_int(opts[:lower])
+    left = bool_int(opts[:left_side])
+    trans = bool_int(opts[:transform_a] == :transpose)
+
+    Enum.zip_with(split_2d(a, n, n), split_into(b, batch, b_trailing), fn am, bm ->
+      bm = if vector?, do: reject_error(Evision.Mat.reshape(bm, [n, 1])), else: bm
+      reject_error(Evision.Mat.triangular_solve(am, bm, n, lower, left, trans))
+    end)
+    |> then(&stack_f64(out, &1))
+  end
+
   # {product of leading dims, second-last dim, last dim} for a batched matrix shape.
   defp mat_dims(shape) do
     [n, m | lead] = shape |> Tuple.to_list() |> Enum.reverse()
@@ -1497,6 +1541,12 @@ defmodule Evision.Backend do
     |> as_mat_type(out_type)
     |> to_nx(out)
   end
+
+  defp bool_int(true), do: 1
+  defp bool_int(_), do: 0
+
+  defp reject_error_tuple({:error, msg}), do: raise(RuntimeError, msg)
+  defp reject_error_tuple(tuple) when is_tuple(tuple), do: tuple
 
   @doc false
   def from_nx(%T{data: %EB{ref: mat_ref}}), do: mat_ref

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -936,6 +936,54 @@ defmodule Evision.Backend do
     |> to_nx(out)
   end
 
+  @scatter_put 0
+  @scatter_add 1
+
+  @impl true
+  def indexed_add(out, target, indices, updates, opts),
+    do: indexed_op(out, target, indices, updates, opts, @scatter_add)
+
+  @impl true
+  def indexed_put(out, target, indices, updates, opts),
+    do: indexed_op(out, target, indices, updates, opts, @scatter_put)
+
+  # Mirrors Nx.BinaryBackend's with_permutation: scatter into `target`, transposing
+  # the indexed `axes` to the front first (and the result back) when they are not
+  # already leading, so the leftover axes form one contiguous block per coordinate.
+  defp indexed_op(%T{shape: out_shape} = out, target, indices, updates, opts, op) do
+    axes = opts[:axes]
+    target_axes = Nx.axes(target)
+
+    if List.starts_with?(target_axes, axes) do
+      scatter(out, target, indices, updates, op)
+    else
+      perm = axes ++ (target_axes -- axes)
+      perm_shape = perm |> Enum.map(&elem(out_shape, &1)) |> List.to_tuple()
+
+      scatter(%{out | shape: perm_shape}, Nx.transpose(target, axes: perm), indices, updates, op)
+      |> Nx.transpose(axes: inverse_perm(perm))
+    end
+  end
+
+  defp scatter(%T{type: out_type, shape: shape} = out, target, %T{shape: indices_shape} = indices, updates, op) do
+    work_type = if op == @scatter_add and out_type in @half_types, do: {:f, 32}, else: out_type
+    depth = elem(indices_shape, 1)
+    {lead, leftover} = shape |> Tuple.to_list() |> Enum.split(depth)
+    dims = from_nx(Nx.tensor(lead, type: {:s, 64}))
+    idx = as_mat_type(from_nx(indices), {:s, 64})
+    base = as_mat_type(from_nx(target), work_type)
+    upd = as_mat_type(from_nx(updates), work_type)
+
+    base
+    |> Evision.Mat.indexed(idx, upd, dims, Enum.product(leftover), op)
+    |> reject_error()
+    |> maybe_narrow(work_type, out_type)
+    |> to_nx(out)
+  end
+
+  defp maybe_narrow(mat, type, type), do: mat
+  defp maybe_narrow(mat, _work_type, out_type), do: as_mat_type(mat, out_type)
+
   @doc false
   def from_nx(%T{data: %EB{ref: mat_ref}}), do: mat_ref
   def from_nx(%T{} = tensor) do

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -741,6 +741,112 @@ defmodule Evision.Backend do
   defp reduce_arg(mat, :min, axis, last_index?),
     do: Evision.reduceArgMin(mat, axis, lastIndex: last_index?)
 
+  ## Sorting
+
+  # cv::sort/sortIdx support these depths directly; wider integer depths go through
+  # a custom NIF, and half floats are widened to f32 (lossless) so cv can handle them.
+  @wide_int_types [{:u, 32}, {:s, 64}, {:u, 64}]
+  @half_types [{:f, 16}, {:bf, 16}]
+
+  @impl true
+  def sort(out, %T{shape: shape, type: type} = tensor, opts) do
+    descending? = opts[:direction] == :desc
+
+    from_nx(tensor)
+    |> sort_along_axis(shape, opts[:axis], &sort_values(&1, type, descending?))
+    |> to_nx(out)
+  end
+
+  @impl true
+  def argsort(%T{type: out_type} = out, %T{shape: shape, type: type} = tensor, opts) do
+    descending? = opts[:direction] == :desc
+
+    from_nx(tensor)
+    |> sort_along_axis(shape, opts[:axis], fn m2d ->
+      m2d
+      |> sort_indices(type, descending?)
+      |> Evision.Mat.as_type(out_type)
+      |> reject_error()
+    end)
+    |> to_nx(out)
+  end
+
+  defp sort_values(m2d, type, descending?) when type in @wide_int_types do
+    reject_error(Evision.Mat.sort_rows(m2d, descending?))
+  end
+
+  defp sort_values(m2d, type, descending?) when type in @half_types do
+    m2d
+    |> as_mat_type({:f, 32})
+    |> Evision.sort(sort_flags(descending?))
+    |> reject_error()
+    |> as_mat_type(type)
+  end
+
+  defp sort_values(m2d, _type, descending?) do
+    reject_error(Evision.sort(m2d, sort_flags(descending?)))
+  end
+
+  defp sort_indices(m2d, type, descending?) when type in @wide_int_types do
+    reject_error(Evision.Mat.argsort_rows(m2d, descending?))
+  end
+
+  # cv::sortIdx is stable ascending but not descending, so sort the order-reversing
+  # complement ascending to reproduce Nx's stable descending order.
+  defp sort_indices(m2d, type, descending?) do
+    work = if type in @half_types, do: as_mat_type(m2d, {:f, 32}), else: m2d
+    work = if descending?, do: complement(work), else: work
+    reject_error(Evision.sortIdx(work, 0))
+  end
+
+  # SORT_EVERY_ROW = 0, SORT_ASCENDING = 0, SORT_DESCENDING = 16.
+  defp sort_flags(true), do: 16
+  defp sort_flags(false), do: 0
+
+  defp complement(mat) do
+    case Evision.Mat.type(mat) do
+      {t, _} when t in [:f, :bf] -> reject_error(Evision.Mat.negate(mat))
+      {t, _} when t in [:s, :u] -> reject_error(Evision.Mat.bitwise_not(mat))
+    end
+  end
+
+  defp as_mat_type(mat, type), do: reject_error(Evision.Mat.as_type(mat, type))
+
+  # Reduce an n-d sort/argsort along `axis` to cv's 2D per-row form: move the
+  # target axis last, flatten to [n, axis_len], apply `fun`, then restore.
+  defp sort_along_axis(mat, shape, axis, fun) do
+    rank = tuple_size(shape)
+    identity = Enum.to_list(0..(rank - 1))
+    perm = (identity -- [axis]) ++ [axis]
+    axis_len = elem(shape, axis)
+    n = div(Nx.size(shape), max(axis_len, 1))
+    t_shape = perm |> Enum.map(&elem(shape, &1)) |> List.to_tuple()
+
+    transposed =
+      if perm == identity,
+        do: mat,
+        else: reject_error(Evision.Mat.transpose(mat, perm, as_shape: shape))
+
+    result_t =
+      transposed
+      |> Evision.Mat.reshape([n, axis_len])
+      |> reject_error()
+      |> fun.()
+      |> Evision.Mat.reshape(Tuple.to_list(t_shape))
+      |> reject_error()
+
+    if perm == identity,
+      do: result_t,
+      else: reject_error(Evision.Mat.transpose(result_t, inverse_perm(perm), as_shape: t_shape))
+  end
+
+  defp inverse_perm(perm) do
+    perm
+    |> Enum.with_index()
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(&elem(&1, 1))
+  end
+
   @doc false
   def from_nx(%T{data: %EB{ref: mat_ref}}), do: mat_ref
   def from_nx(%T{} = tensor) do

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1016,6 +1016,23 @@ defmodule Evision.Backend do
     mat |> Evision.Mat.sign() |> reject_error() |> Evision.Mat.abs() |> reject_error()
   end
 
+  @impl true
+  def select(%T{shape: shape, type: out_type} = out, pred, on_true, on_false) do
+    mask =
+      pred
+      |> Nx.broadcast(shape)
+      |> from_nx()
+      |> nonzero_mask()
+      |> as_mat_type({:u, 8})
+
+    t = on_true |> Nx.as_type(out_type) |> Nx.broadcast(shape) |> from_nx()
+    f = on_false |> Nx.as_type(out_type) |> Nx.broadcast(shape) |> from_nx()
+
+    Evision.Mat.select(mask, t, f)
+    |> reject_error()
+    |> to_nx(out)
+  end
+
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
   # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -108,6 +108,10 @@ defmodule Evision.Backend do
   end
 
   @impl true
+  @spec init(keyword()) :: keyword()
+  def init(opts), do: opts
+
+  @impl true
   @spec backend_copy(Nx.Tensor.t(), atom, any) :: Nx.Tensor.t()
   def backend_copy(tensor, Nx.Tensor, opts) do
     backend_copy(tensor, Nx.BinaryBackend, opts)

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1224,6 +1224,29 @@ defmodule Evision.Backend do
     |> elem(0)
   end
 
+  @impl true
+  def take_along_axis(%T{shape: out_shape} = out, %T{shape: shape} = tensor, indices, axis) do
+    idx = as_mat_type(from_nx(indices), {:s, 64})
+
+    Evision.Mat.take_along_axis(from_nx(tensor), idx, Tuple.to_list(shape), Tuple.to_list(out_shape), axis)
+    |> reject_error()
+    |> Evision.Mat.reshape(reduce_out_dims(out_shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
+  # top_k is optional (the fallback is shadowed by the catch-all), so it is built here
+  # from argsort + take_along_axis + slice along the last axis.
+  @impl true
+  def top_k(_out, tensor, opts) do
+    axis = Nx.rank(tensor) - 1
+    indices = Nx.argsort(tensor, axis: axis, direction: :desc)
+    values = Nx.take_along_axis(tensor, indices, axis: axis)
+    k = opts[:k]
+
+    {Nx.slice_along_axis(values, 0, k, axis: axis), Nx.slice_along_axis(indices, 0, k, axis: axis)}
+  end
+
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
   # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1591,6 +1591,44 @@ defmodule Evision.Backend do
   defp norm_list(v, rank) when is_nil(v), do: List.duplicate(1, rank)
   defp norm_list(v, _rank) when is_list(v), do: v
 
+  ## Convolution
+
+  # N-d cross-correlation. The input/kernel/output permutations and the float cast are done
+  # here (via the implemented transpose/as_type), so the NIF only does the canonical-layout
+  # correlation; the result is permuted back to the output layout. f16/bf16 widen to f32.
+  @impl true
+  def conv(%T{type: out_type, shape: out_shape} = out, %T{shape: in_shape} = tensor, kernel, opts) do
+    work_type = if out_type in @half_types, do: {:f, 32}, else: out_type
+    op = opts[:output_permutation]
+    d = tuple_size(in_shape) - 2
+
+    in_t = tensor |> Nx.transpose(axes: opts[:input_permutation]) |> Nx.as_type(work_type)
+    k_t = kernel |> Nx.transpose(axes: opts[:kernel_permutation]) |> Nx.as_type(work_type)
+    canon_shape = op |> Enum.map(&elem(out_shape, &1)) |> List.to_tuple()
+
+    Evision.Mat.conv(
+      from_nx(in_t),
+      from_nx(k_t),
+      Tuple.to_list(in_t.shape),
+      Tuple.to_list(k_t.shape),
+      Tuple.to_list(canon_shape),
+      norm_list(opts[:strides], d),
+      Enum.map(opts[:padding], &elem(&1, 0)),
+      norm_list(opts[:input_dilation], d),
+      norm_list(opts[:kernel_dilation], d),
+      opts[:feature_group_size],
+      opts[:batch_group_size]
+    )
+    |> reject_error()
+    |> Evision.Mat.reshape(Tuple.to_list(canon_shape))
+    |> reject_error()
+    |> to_nx(%{out | shape: canon_shape, type: work_type})
+    |> Nx.transpose(axes: inverse_perm(op))
+    |> Nx.as_type(out_type)
+    |> from_nx()
+    |> to_nx(out)
+  end
+
   # {product of leading dims, second-last dim, last dim} for a batched matrix shape.
   defp mat_dims(shape) do
     [n, m | lead] = shape |> Tuple.to_list() |> Enum.reverse()

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1152,6 +1152,50 @@ defmodule Evision.Backend do
     |> to_nx(out)
   end
 
+  ## Slicing
+
+  @impl true
+  def slice(%T{shape: out_shape} = out, %T{shape: shape} = tensor, start_indices, lengths, strides) do
+    starts = clamp_starts(start_indices, shape, lengths)
+
+    Evision.Mat.strided_copy(
+      from_nx(tensor),
+      Tuple.to_list(shape),
+      Tuple.to_list(out_shape),
+      starts,
+      strides
+    )
+    |> reject_error()
+    |> Evision.Mat.reshape(reduce_out_dims(out_shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
+  defp clamp_starts(start_indices, shape, lengths) do
+    [Tuple.to_list(shape), start_indices, lengths]
+    |> Enum.zip_with(fn [dim, idx, len] -> min(max(to_number(idx), 0), dim - len) end)
+  end
+
+  @impl true
+  def reverse(%T{shape: shape} = out, tensor, axes) do
+    dims = Tuple.to_list(shape)
+    axset = MapSet.new(axes)
+
+    {starts, strides} =
+      tuple_size(shape)
+      |> all_axes()
+      |> Enum.map(fn k ->
+        if MapSet.member?(axset, k), do: {elem(shape, k) - 1, -1}, else: {0, 1}
+      end)
+      |> Enum.unzip()
+
+    Evision.Mat.strided_copy(from_nx(tensor), dims, dims, starts, strides)
+    |> reject_error()
+    |> Evision.Mat.reshape(reduce_out_dims(shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
   # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1061,6 +1061,37 @@ defmodule Evision.Backend do
     |> to_nx(out)
   end
 
+  ## Bitwise
+
+  @bit_clz 0
+  @bit_popcount 1
+  @shift_left 0
+  @shift_right 1
+
+  @impl true
+  def count_leading_zeros(out, tensor), do: bit_unary(out, tensor, @bit_clz)
+
+  @impl true
+  def population_count(out, tensor), do: bit_unary(out, tensor, @bit_popcount)
+
+  defp bit_unary(out, tensor, op) do
+    Evision.Mat.bit_unary(from_nx(tensor), op) |> reject_error() |> to_nx(out)
+  end
+
+  @impl true
+  def left_shift(out, l, r), do: shift(out, l, r, @shift_left)
+
+  @impl true
+  def right_shift(out, l, r), do: shift(out, l, r, @shift_right)
+
+  # l and r are broadcast to the output shape and cast to the (integer) output type.
+  defp shift(%T{shape: shape, type: type} = out, l, r, op) do
+    {l, r} = enforce_same_shape(l, r, shape)
+    lm = as_mat_type(from_nx(l), type)
+    rm = as_mat_type(from_nx(r), type)
+    Evision.Mat.shift(lm, rm, op) |> reject_error() |> to_nx(out)
+  end
+
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
   # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -983,11 +983,38 @@ defmodule Evision.Backend do
 
   ## Reductions
 
-  @impl true
-  def sum(out, tensor, opts), do: reduce_aggregate(out, tensor, opts, 0)
+  @reduce_sum 0
+  @reduce_product 1
+  @reduce_max 2
+  @reduce_min 3
 
   @impl true
-  def product(out, tensor, opts), do: reduce_aggregate(out, tensor, opts, 1)
+  def sum(out, tensor, opts), do: reduce_aggregate(out, tensor, opts, @reduce_sum)
+
+  @impl true
+  def product(out, tensor, opts), do: reduce_aggregate(out, tensor, opts, @reduce_product)
+
+  @impl true
+  def reduce_max(out, tensor, opts), do: reduce_aggregate(out, tensor, opts, @reduce_max)
+
+  @impl true
+  def reduce_min(out, tensor, opts), do: reduce_aggregate(out, tensor, opts, @reduce_min)
+
+  @impl true
+  def all(out, tensor, opts), do: bool_reduce(out, tensor, opts, @reduce_min)
+
+  @impl true
+  def any(out, tensor, opts), do: bool_reduce(out, tensor, opts, @reduce_max)
+
+  # all = every element nonzero (min over the {0,1} nonzero mask); any = some nonzero (max).
+  defp bool_reduce(out, %T{} = tensor, opts, op) do
+    mask = tensor |> from_nx() |> nonzero_mask()
+    reduce_aggregate(out, to_nx(mask, tensor), opts, op)
+  end
+
+  defp nonzero_mask(mat) do
+    mat |> Evision.Mat.sign() |> reject_error() |> Evision.Mat.abs() |> reject_error()
+  end
 
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -888,6 +888,99 @@ defmodule Evision.Backend do
     reject_error(Evision.Mat.cumulative(m2d, op, reverse?))
   end
 
+  ## Elementwise unary math
+
+  @uop_sin 0
+  @uop_cos 1
+  @uop_tan 2
+  @uop_asin 3
+  @uop_acos 4
+  @uop_atan 5
+  @uop_sinh 6
+  @uop_cosh 7
+  @uop_tanh 8
+  @uop_asinh 9
+  @uop_acosh 10
+  @uop_atanh 11
+  @uop_erf 12
+  @uop_erfc 13
+  @uop_cbrt 14
+  @uop_log1p 15
+  @uop_rsqrt 16
+  @uop_sigmoid 17
+
+  # sqrt reuses cv::sqrt (the fast path, like exp/log); the rest have no cv
+  # primitive and go through the element-wise math NIF.
+  @impl true
+  def sqrt(out, tensor), do: unary_math(out, tensor, &Evision.sqrt/1)
+
+  @impl true
+  def sin(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_sin))
+
+  @impl true
+  def cos(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_cos))
+
+  @impl true
+  def tan(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_tan))
+
+  @impl true
+  def asin(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_asin))
+
+  @impl true
+  def acos(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_acos))
+
+  @impl true
+  def atan(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_atan))
+
+  @impl true
+  def sinh(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_sinh))
+
+  @impl true
+  def cosh(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_cosh))
+
+  @impl true
+  def tanh(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_tanh))
+
+  @impl true
+  def asinh(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_asinh))
+
+  @impl true
+  def acosh(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_acosh))
+
+  @impl true
+  def atanh(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_atanh))
+
+  @impl true
+  def erf(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_erf))
+
+  @impl true
+  def erfc(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_erfc))
+
+  @impl true
+  def cbrt(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_cbrt))
+
+  @impl true
+  def log1p(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_log1p))
+
+  @impl true
+  def rsqrt(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_rsqrt))
+
+  @impl true
+  def sigmoid(out, tensor), do: unary_math(out, tensor, &Evision.Mat.unary_math(&1, @uop_sigmoid))
+
+  # Cast the input to the (float) output type, widening f16/bf16 to f32 (the math
+  # NIF/cv::sqrt handle only f32/f64) and narrowing the result back.
+  defp unary_math(%T{type: out_type} = out, tensor, fun) do
+    work_type = if out_type in @half_types, do: {:f, 32}, else: out_type
+
+    from_nx(tensor)
+    |> as_mat_type(work_type)
+    |> fun.()
+    |> reject_error()
+    |> maybe_narrow(work_type, out_type)
+    |> to_nx(out)
+  end
+
   ## Reductions
 
   @impl true

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -700,6 +700,47 @@ defmodule Evision.Backend do
     |> to_nx(out)
   end
 
+  ## Aggregates
+
+  @impl true
+  def argmax(out, tensor, opts), do: arg_aggregate(:max, out, tensor, opts)
+
+  @impl true
+  def argmin(out, tensor, opts), do: arg_aggregate(:min, out, tensor, opts)
+
+  defp arg_aggregate(which, %T{type: out_type, shape: out_shape} = out, %T{shape: shape} = tensor, opts) do
+    last_index? = opts[:tie_break] == :high
+    mat = from_nx(tensor)
+
+    reduced =
+      if opts[:axis] == nil or Nx.rank(shape) <= 1 do
+        flat = reject_error(Evision.Mat.reshape(mat, [1, Nx.size(shape)]))
+        reduce_arg(flat, which, 1, last_index?)
+      else
+        reduce_arg(mat, which, opts[:axis], last_index?)
+      end
+
+    reshape_to =
+      case Tuple.to_list(out_shape) do
+        [] -> [1]
+        dims -> dims
+      end
+
+    reduced
+    |> reject_error()
+    |> Evision.Mat.as_type(out_type)
+    |> reject_error()
+    |> Evision.Mat.reshape(reshape_to)
+    |> reject_error()
+    |> to_nx(out)
+  end
+
+  defp reduce_arg(mat, :max, axis, last_index?),
+    do: Evision.reduceArgMax(mat, axis, lastIndex: last_index?)
+
+  defp reduce_arg(mat, :min, axis, last_index?),
+    do: Evision.reduceArgMin(mat, axis, lastIndex: last_index?)
+
   @doc false
   def from_nx(%T{data: %EB{ref: mat_ref}}), do: mat_ref
   def from_nx(%T{} = tensor) do

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1092,6 +1092,33 @@ defmodule Evision.Backend do
     Evision.Mat.shift(lm, rm, op) |> reject_error() |> to_nx(out)
   end
 
+  ## All-close
+
+  # Replicates Nx's vectorized_all_close out of already-implemented ops (the optional
+  # fallback is shadowed by the catch-all, so it must be built here). Scalars go second
+  # in multiply (Evision's scalar-first multiply path rejects constants), and the
+  # `select(nan, 1, inf)` over {0,1} masks is written as logical_or.
+  @impl true
+  def all_close(_out, a, b, opts) do
+    atol = opts[:atol]
+    rtol = opts[:rtol]
+    finite = Nx.less_equal(Nx.abs(Nx.subtract(a, b)), Nx.add(Nx.multiply(Nx.abs(b), rtol), atol))
+
+    if Nx.Type.integer?(a.type) and Nx.Type.integer?(b.type) do
+      Nx.all(finite)
+    else
+      inf_entries =
+        Nx.select(Nx.logical_or(Nx.is_infinity(a), Nx.is_infinity(b)), Nx.equal(a, b), finite)
+
+      if opts[:equal_nan] do
+        nan_entries = Nx.logical_and(Nx.is_nan(a), Nx.is_nan(b))
+        Nx.all(Nx.logical_or(nan_entries, inf_entries))
+      else
+        Nx.all(inf_entries)
+      end
+    end
+  end
+
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
   # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1501,6 +1501,96 @@ defmodule Evision.Backend do
     |> then(&stack_f64(out, &1))
   end
 
+  ## Windowed (pooling) ops
+
+  @window_sum 0
+  @window_product 1
+  @window_max 2
+  @window_min 3
+
+  @impl true
+  def window_sum(out, tensor, window_dims, opts),
+    do: window_reduce_op(out, tensor, window_dims, opts, @window_sum)
+
+  @impl true
+  def window_product(out, tensor, window_dims, opts),
+    do: window_reduce_op(out, tensor, window_dims, opts, @window_product)
+
+  @impl true
+  def window_max(out, tensor, window_dims, opts),
+    do: window_reduce_op(out, tensor, window_dims, opts, @window_max)
+
+  @impl true
+  def window_min(out, tensor, window_dims, opts),
+    do: window_reduce_op(out, tensor, window_dims, opts, @window_min)
+
+  # Sliding-window reduction; output keeps the input type (f16/bf16 widened to f32). `out`
+  # already carries the pooled shape; padding/strides/dilations come normalized from Nx.
+  defp window_reduce_op(%T{type: out_type, shape: out_shape} = out, %T{shape: in_shape} = tensor, window_dims, opts, op) do
+    rank = tuple_size(in_shape)
+    work_type = if out_type in @half_types, do: {:f, 32}, else: out_type
+    pad_lo = Enum.map(opts[:padding], &elem(&1, 0))
+
+    from_nx(tensor)
+    |> as_mat_type(work_type)
+    |> Evision.Mat.window_reduce(
+      Tuple.to_list(in_shape),
+      Tuple.to_list(out_shape),
+      Tuple.to_list(window_dims),
+      norm_list(opts[:strides], rank),
+      pad_lo,
+      norm_list(opts[:window_dilations], rank),
+      op
+    )
+    |> reject_error()
+    |> maybe_narrow(work_type, out_type)
+    |> Evision.Mat.reshape(reduce_out_dims(out_shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
+  @window_scatter_max 0
+  @window_scatter_min 1
+
+  @impl true
+  def window_scatter_max(out, tensor, source, init_value, window_dims, opts),
+    do: window_scatter(out, tensor, source, init_value, window_dims, opts, @window_scatter_max)
+
+  @impl true
+  def window_scatter_min(out, tensor, source, init_value, window_dims, opts),
+    do: window_scatter(out, tensor, source, init_value, window_dims, opts, @window_scatter_min)
+
+  # Select-and-scatter; input + source cast to the output type (f16/bf16 widened to f32). The
+  # source carries one value per window (its shape is the window grid).
+  defp window_scatter(%T{type: out_type, shape: in_shape} = out, tensor, %T{shape: grid} = source, init_value, window_dims, opts, op) do
+    rank = tuple_size(in_shape)
+    work_type = if out_type in @half_types, do: {:f, 32}, else: out_type
+    pad_lo = Enum.map(opts[:padding], &elem(&1, 0))
+    src = as_mat_type(from_nx(tensor), work_type)
+    vals = as_mat_type(from_nx(source), work_type)
+
+    Evision.Mat.window_scatter(
+      src,
+      vals,
+      to_number(init_value) * 1.0,
+      Tuple.to_list(in_shape),
+      Tuple.to_list(window_dims),
+      norm_list(opts[:strides], rank),
+      pad_lo,
+      Tuple.to_list(grid),
+      op
+    )
+    |> reject_error()
+    |> maybe_narrow(work_type, out_type)
+    |> Evision.Mat.reshape(reduce_out_dims(in_shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
+  defp norm_list(v, rank) when is_integer(v), do: List.duplicate(v, rank)
+  defp norm_list(v, rank) when is_nil(v), do: List.duplicate(1, rank)
+  defp norm_list(v, _rank) when is_list(v), do: v
+
   # {product of leading dims, second-last dim, last dim} for a batched matrix shape.
   defp mat_dims(shape) do
     [n, m | lead] = shape |> Tuple.to_list() |> Enum.reverse()

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1033,6 +1033,34 @@ defmodule Evision.Backend do
     |> to_nx(out)
   end
 
+  ## Predicates
+
+  @pred_is_nan 0
+  @pred_is_infinity 1
+  @pred_is_zero 2
+
+  @impl true
+  def is_nan(out, tensor), do: predicate(out, tensor, @pred_is_nan)
+
+  @impl true
+  def is_infinity(out, tensor), do: predicate(out, tensor, @pred_is_infinity)
+
+  @impl true
+  def logical_not(out, tensor), do: predicate(out, tensor, @pred_is_zero)
+
+  # Elementwise predicate -> u8. f16/bf16 widen to f32 (the NIF covers only real C types).
+  defp predicate(%T{shape: out_shape} = out, %T{type: type} = tensor, op) do
+    mat = from_nx(tensor)
+    mat = if type in @half_types, do: as_mat_type(mat, {:f, 32}), else: mat
+
+    mat
+    |> Evision.Mat.predicate(op)
+    |> reject_error()
+    |> Evision.Mat.reshape(reduce_out_dims(out_shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
   # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
   # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
   # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -847,6 +847,55 @@ defmodule Evision.Backend do
     |> Enum.map(&elem(&1, 1))
   end
 
+  ## Reductions
+
+  @impl true
+  def sum(out, tensor, opts), do: reduce_aggregate(out, tensor, opts, 0)
+
+  @impl true
+  def product(out, tensor, opts), do: reduce_aggregate(out, tensor, opts, 1)
+
+  # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
+  # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
+  # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.
+  defp reduce_aggregate(%T{type: out_type, shape: out_shape} = out, %T{shape: shape} = tensor, opts, op) do
+    rank = tuple_size(shape)
+    axes = all_axes(rank)
+    reduce_axes = Enum.sort(opts[:axes] || axes)
+    perm = (axes -- reduce_axes) ++ reduce_axes
+    keep_size = sizes_product(shape, axes -- reduce_axes)
+    reduce_size = sizes_product(shape, reduce_axes)
+
+    mat = as_mat_type(from_nx(tensor), accumulator_type(out_type))
+
+    transposed =
+      if perm == axes,
+        do: mat,
+        else: reject_error(Evision.Mat.transpose(mat, perm, as_shape: shape))
+
+    transposed
+    |> Evision.Mat.reshape([keep_size, reduce_size])
+    |> reject_error()
+    |> Evision.Mat.reduce_rows(op)
+    |> reject_error()
+    |> as_mat_type(out_type)
+    |> Evision.Mat.reshape(reduce_out_dims(out_shape))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
+  defp all_axes(0), do: []
+  defp all_axes(rank), do: Enum.to_list(0..(rank - 1))
+
+  defp sizes_product(shape, axes), do: Enum.reduce(axes, 1, &(elem(shape, &1) * &2))
+
+  defp accumulator_type({:u, _}), do: {:u, 64}
+  defp accumulator_type({:s, _}), do: {:s, 64}
+  defp accumulator_type(_float), do: {:f, 64}
+
+  defp reduce_out_dims({}), do: [1]
+  defp reduce_out_dims(shape), do: Tuple.to_list(shape)
+
   @doc false
   def from_nx(%T{data: %EB{ref: mat_ref}}), do: mat_ref
   def from_nx(%T{} = tensor) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1265,6 +1265,19 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Gather over leading axes (Nx.gather): each int64 coordinate row over `dims`
+  # selects one inner block; type-agnostic byte copy.
+  def gather(mat, indices, dims, inner) do
+    :evision_nif.mat_gather(
+      src: from_struct(mat),
+      indices: from_struct(indices),
+      dims: from_struct(dims),
+      inner: inner
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1242,6 +1242,16 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Row-wise reduction (op 0 = sum, 1 = product) of an accumulator-typed mat
+  # (f64/s64/u64), accumulating left-to-right; returns a [rows, 1] mat.
+  def reduce_rows(mat, op) do
+    mat = from_struct(mat)
+
+    :evision_nif.mat_reduce(src: mat, op: op)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1406,6 +1406,26 @@ defmodule Evision.Mat do
   end
 
   @doc false
+  # N-d cross-correlation (Nx.conv) on canonical-layout f32/f64 inputs. `input` is
+  # [N, Cin, *sp], `kernel` [O, Cin/G, *sp]; the result is the canonical [N/Bg, O, *sp].
+  def conv(input, kernel, in_shape, k_shape, out_shape, strides, pad_lo, input_dilation, kernel_dilation, feature_groups, batch_groups) do
+    :evision_nif.mat_conv(
+      input: from_struct(input),
+      kernel: from_struct(kernel),
+      in_shape: in_shape,
+      k_shape: k_shape,
+      out_shape: out_shape,
+      strides: strides,
+      pad_lo: pad_lo,
+      input_dilation: input_dilation,
+      kernel_dilation: kernel_dilation,
+      feature_groups: feature_groups,
+      batch_groups: batch_groups
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
   # Per-element bit op preserving the integer type (Nx.count_leading_zeros /
   # population_count): op 0 = clz, 1 = popcount.
   def bit_unary(mat, op) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1335,6 +1335,42 @@ defmodule Evision.Mat do
   end
 
   @doc false
+  # Cholesky-Banachiewicz lower factor (Nx.LinAlg.cholesky); `mat` is n*n f64.
+  def cholesky(mat, n) do
+    :evision_nif.mat_cholesky(a: from_struct(mat), n: n)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
+  # Partial-pivot LU returning {p, l, u} (Nx.LinAlg.lu); `mat` is n*n f64.
+  def lu(mat, n) do
+    :evision_nif.mat_lu(a: from_struct(mat), n: n)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
+  # Householder QR returning {q, r} (Nx.LinAlg.qr); `mat` is m*n f64, complete is 0/1.
+  def qr(mat, m, n, complete) do
+    :evision_nif.mat_qr(a: from_struct(mat), m: m, n: n, complete: complete)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
+  # Triangular system solve by substitution (Nx.LinAlg.triangular_solve); `a` is n*n f64,
+  # `b` a 2D f64 rhs, lower/left_side/transpose are 0/1.
+  def triangular_solve(a, b, n, lower, left_side, transpose) do
+    :evision_nif.mat_triangular_solve(
+      a: from_struct(a),
+      b: from_struct(b),
+      n: n,
+      lower: lower,
+      left_side: left_side,
+      transpose: transpose
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
   # Per-element bit op preserving the integer type (Nx.count_leading_zeros /
   # population_count): op 0 = clz, 1 = popcount.
   def bit_unary(mat, op) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1224,6 +1224,24 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Row-wise sort for wide-int depths (CV_32U/CV_64S/CV_64U) unsupported by cv::sort.
+  def sort_rows(mat, descending?) do
+    mat = from_struct(mat)
+
+    :evision_nif.mat_sort_rows(src: mat, descending: if(descending?, do: 1, else: 0))
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
+  # Row-wise stable argsort for wide-int depths unsupported by cv::sortIdx.
+  def argsort_rows(mat, descending?) do
+    mat = from_struct(mat)
+
+    :evision_nif.mat_argsort_rows(src: mat, descending: if(descending?, do: 1, else: 0))
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1350,6 +1350,14 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Elementwise binary op with no cv primitive (Nx.atan2/pow/quotient/remainder):
+  # op 0=atan2, 1=pow, 2=quotient, 3=remainder. `l` and `r` share the output type.
+  def binop(l, r, op) do
+    :evision_nif.mat_binop(l: from_struct(l), r: from_struct(r), op: op)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1252,6 +1252,19 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Gather along one axis (Nx.take): copies inner blocks selected by int64 indices.
+  def take(mat, indices, outer, axis_dim, inner) do
+    :evision_nif.mat_take(
+      src: from_struct(mat),
+      indices: from_struct(indices),
+      outer: outer,
+      axis_dim: axis_dim,
+      inner: inner
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1294,6 +1294,18 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Row-wise prefix scan (Nx.cumulative_*): op 0=sum 1=product 2=min 3=max,
+  # optionally reversed. `mat` is a 2D mat already cast to the output type.
+  def cumulative(mat, op, reverse?) do
+    :evision_nif.mat_cumulative(
+      src: from_struct(mat),
+      op: op,
+      reverse: if(reverse?, do: 1, else: 0)
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1371,6 +1371,41 @@ defmodule Evision.Mat do
   end
 
   @doc false
+  # Sliding-window reduction (Nx.window_sum/max/min/product): op 0=sum 1=product 2=max 3=min.
+  # All dimension/stride/padding/dilation args are flat int lists; result preserves `mat`'s type.
+  def window_reduce(mat, in_dims, out_dims, win_dims, strides, pad_lo, dilations, op) do
+    :evision_nif.mat_window_reduce(
+      src: from_struct(mat),
+      in_dims: in_dims,
+      out_dims: out_dims,
+      win_dims: win_dims,
+      strides: strides,
+      pad_lo: pad_lo,
+      dilations: dilations,
+      op: op
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
+  # Select-and-scatter (Nx.window_scatter_max/min): op 0=max 1=min. `source` carries the
+  # per-window values (output type), `init` the fill scalar; result has `mat`'s shape/type.
+  def window_scatter(mat, source, init, in_dims, win_dims, strides, pad_lo, grid, op) do
+    :evision_nif.mat_window_scatter(
+      src: from_struct(mat),
+      source: from_struct(source),
+      init: init,
+      in_dims: in_dims,
+      win_dims: win_dims,
+      strides: strides,
+      pad_lo: pad_lo,
+      grid: grid,
+      op: op
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
   # Per-element bit op preserving the integer type (Nx.count_leading_zeros /
   # population_count): op 0 = clz, 1 = popcount.
   def bit_unary(mat, op) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1278,6 +1278,22 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Scatter into a copy of `mat` (Nx.indexed_put / indexed_add): each int64
+  # coordinate row over `dims` selects one inner block to overwrite (op 0) or
+  # accumulate (op 1). `mat`/`updates` must already be the output type.
+  def indexed(mat, indices, updates, dims, inner, op) do
+    :evision_nif.mat_indexed(
+      src: from_struct(mat),
+      indices: from_struct(indices),
+      updates: from_struct(updates),
+      dims: from_struct(dims),
+      inner: inner,
+      op: op
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1314,6 +1314,18 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Elementwise select (Nx.select): mask ? on_true : on_false. All three are the
+  # same shape; `mask` is u8 and `on_true`/`on_false` already the output type.
+  def select(mask, on_true, on_false) do
+    :evision_nif.mat_select(
+      mask: from_struct(mask),
+      on_true: from_struct(on_true),
+      on_false: from_struct(on_false)
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1306,6 +1306,14 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Element-wise unary float math (Nx trig/hyperbolic/erf/cbrt/log1p/rsqrt/sigmoid):
+  # op codes match Evision.Backend's @uop_* constants. `mat` must already be f32/f64.
+  def unary_math(mat, op) do
+    :evision_nif.mat_unary_math(src: from_struct(mat), op: op)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1372,6 +1372,20 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Scatter a dense block into a copy of `base` (Nx.put_slice; also concatenate's
+  # building block): writes each `slice` element at (starts[k] + j_k). Same type.
+  def put_slice(base, slice, base_dims, slice_dims, starts) do
+    :evision_nif.mat_put_slice(
+      base: from_struct(base),
+      slice: from_struct(slice),
+      base_dims: base_dims,
+      slice_dims: slice_dims,
+      starts: starts
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1243,8 +1243,8 @@ defmodule Evision.Mat do
   end
 
   @doc false
-  # Row-wise reduction (op 0 = sum, 1 = product) of an accumulator-typed mat
-  # (f64/s64/u64), accumulating left-to-right; returns a [rows, 1] mat.
+  # Row-wise reduction (op 0=sum, 1=product, 2=max, 3=min) of an accumulator-typed
+  # mat (f64/s64/u64); returns a [rows, 1] mat.
   def reduce_rows(mat, op) do
     mat = from_struct(mat)
 

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1386,6 +1386,20 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Per-element gather along one axis (Nx.take_along_axis): out has the indices' shape;
+  # each output replaces the `axis` coordinate with the int64 index. Returns [1, n].
+  def take_along_axis(mat, indices, in_dims, out_dims, axis) do
+    :evision_nif.mat_take_along_axis(
+      src: from_struct(mat),
+      indices: from_struct(indices),
+      in_dims: in_dims,
+      out_dims: out_dims,
+      axis: axis
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1225,7 +1225,7 @@ defmodule Evision.Mat do
   end
 
   @doc false
-  # Row-wise sort for wide-int depths (CV_32U/CV_64S/CV_64U) unsupported by cv::sort.
+  # Row-wise sort for depths that need custom handling (wide ints, float NaN order).
   def sort_rows(mat, descending?) do
     mat = from_struct(mat)
 
@@ -1234,7 +1234,7 @@ defmodule Evision.Mat do
   end
 
   @doc false
-  # Row-wise stable argsort for wide-int depths unsupported by cv::sortIdx.
+  # Row-wise stable argsort for depths that need custom handling.
   def argsort_rows(mat, descending?) do
     mat = from_struct(mat)
 

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1358,6 +1358,20 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # General strided copy (Nx.slice / reverse): out[i] = src[starts[k] + i_k*strides[k]]
+  # per axis (strides may be negative). Lists are per-axis; returns a flat [1, n] mat.
+  def strided_copy(mat, in_dims, out_dims, starts, strides) do
+    :evision_nif.mat_strided_copy(
+      src: from_struct(mat),
+      in_dims: in_dims,
+      out_dims: out_dims,
+      starts: starts,
+      strides: strides
+    )
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1334,6 +1334,22 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Per-element bit op preserving the integer type (Nx.count_leading_zeros /
+  # population_count): op 0 = clz, 1 = popcount.
+  def bit_unary(mat, op) do
+    :evision_nif.mat_bit_unary(src: from_struct(mat), op: op)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
+  @doc false
+  # Elementwise integer shift (Nx.left_shift/right_shift): op 0 = left, 1 = right.
+  # `l` and `r` share the output type and shape.
+  def shift(l, r, op) do
+    :evision_nif.mat_shift(l: from_struct(l), r: from_struct(r), op: op)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1326,6 +1326,14 @@ defmodule Evision.Mat do
     |> Evision.Internal.Structurise.to_struct()
   end
 
+  @doc false
+  # Elementwise predicate -> u8 (Nx.is_nan/is_infinity/logical_not): op 0=is_nan,
+  # 1=is_infinity, 2=is_zero. `mat` must be a real C type (f16/bf16 widened first).
+  def predicate(mat, op) do
+    :evision_nif.mat_predicate(src: from_struct(mat), op: op)
+    |> Evision.Internal.Structurise.to_struct()
+  end
+
   @doc namespace: :"cv.Mat"
   @spec expm1(maybe_mat_in()) :: maybe_mat_out()
   def expm1(mat) do

--- a/src/evision.app.src
+++ b/src/evision.app.src
@@ -1,6 +1,6 @@
 {application, evision,
  [{description, "OpenCV BEAM binding."},
-  {vsn, "0.2.17"},
+  {vsn, "1.0.0-dev"},
   {registered, []},
   {applications,
    [kernel,

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -113,4 +113,21 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "take" do
+    test "matches Nx.BinaryBackend across axes, ranks, dtypes, and index shapes" do
+      tensors = [
+        Nx.tensor([10, 20, 30, 40]),
+        Nx.tensor([[1, 2, 3], [4, 5, 6]]),
+        Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], type: :s64),
+        Nx.tensor([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5]], type: :f32)
+      ]
+
+      index_sets = [Nx.tensor([1, 0, 1]), Nx.tensor([[0, 1], [1, 0]])]
+
+      for t <- tensors, axis <- 0..(Nx.rank(t) - 1), idx <- index_sets do
+        assert_same(Nx.take(ev(t), ev(idx), axis: axis), Nx.take(t, idx, axis: axis))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -684,4 +684,108 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "cholesky" do
+    test "lower factor matches reference and reconstructs A" do
+      tensors = [
+        Nx.tensor([[4.0, 0.0], [0.0, 9.0]], type: :f64),
+        Nx.tensor([[2.0, 1.0], [1.0, 2.0]], type: :f64),
+        Nx.tensor([[4.0, 2.0, -2.0], [2.0, 10.0, 2.0], [-2.0, 2.0, 5.0]], type: :f64)
+      ]
+
+      for a <- tensors do
+        l = Nx.LinAlg.cholesky(ev(a))
+        # the lower factor with positive diagonal is unique -> matches BinaryBackend
+        close_at(l, Nx.LinAlg.cholesky(a), 1.0e-4)
+        lb = b(l)
+        close_at(Nx.dot(lb, Nx.transpose(lb)), a, 1.0e-4)
+      end
+    end
+  end
+
+  describe "triangular_solve" do
+    test "matches Nx.BinaryBackend across lower/upper, vector/matrix rhs, and transpose" do
+      lower = Nx.tensor([[1.0, 0.0, 0.0], [2.0, 3.0, 0.0], [4.0, 5.0, 6.0]], type: :f64)
+      upper = Nx.tensor([[2.0, 1.0, 1.0], [0.0, 3.0, 2.0], [0.0, 0.0, 4.0]], type: :f64)
+      bvec = Nx.tensor([1.0, 2.0, 3.0], type: :f64)
+      bmat = Nx.tensor([[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]], type: :f64)
+
+      cases = [
+        {lower, bvec, []},
+        {lower, bmat, []},
+        {upper, bvec, [lower: false]},
+        {upper, bmat, [lower: false]},
+        {lower, bvec, [transform_a: :transpose]},
+        {upper, bmat, [lower: false, transform_a: :transpose]}
+      ]
+
+      for {aa, bb, opts} <- cases do
+        close_at(
+          Nx.LinAlg.triangular_solve(ev(aa), ev(bb), opts),
+          Nx.LinAlg.triangular_solve(aa, bb, opts),
+          1.0e-4
+        )
+      end
+    end
+
+    test "left_side: false solves X*A = B" do
+      a = Nx.tensor([[1.0, 0.0], [2.0, 3.0]], type: :f64)
+      bb = Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f64)
+      opts = [left_side: false]
+
+      close_at(
+        Nx.LinAlg.triangular_solve(ev(a), ev(bb), opts),
+        Nx.LinAlg.triangular_solve(a, bb, opts),
+        1.0e-4
+      )
+    end
+  end
+
+  describe "qr" do
+    test "reduced and complete reconstruct A with orthonormal Q" do
+      tensors = [
+        Nx.tensor([[12.0, -51.0, 4.0], [6.0, 167.0, -68.0], [-4.0, 24.0, -41.0]], type: :f64),
+        # tall 3x2
+        Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], type: :f64)
+      ]
+
+      for a <- tensors do
+        {m, n} = Nx.shape(a)
+
+        {q, r} = Nx.LinAlg.qr(ev(a), mode: :reduced)
+        assert {Nx.shape(q), Nx.shape(r)} == {{m, n}, {n, n}}
+        qb = b(q)
+        close_at(Nx.dot(qb, b(r)), a, 1.0e-4)
+        close_at(Nx.dot(Nx.transpose(qb), qb), Nx.eye(n, type: :f64), 1.0e-4)
+
+        {q, r} = Nx.LinAlg.qr(ev(a), mode: :complete)
+        assert {Nx.shape(q), Nx.shape(r)} == {{m, m}, {m, n}}
+        qb = b(q)
+        close_at(Nx.dot(qb, b(r)), a, 1.0e-4)
+        close_at(Nx.dot(Nx.transpose(qb), qb), Nx.eye(m, type: :f64), 1.0e-4)
+      end
+    end
+  end
+
+  describe "lu" do
+    test "P*L*U reconstructs A; P keeps the input dtype" do
+      tensors = [
+        Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 10.0]], type: :f64),
+        Nx.tensor([[2.0, 1.0], [1.0, 3.0]], type: :f64),
+        Nx.tensor([[4.0, 3.0], [6.0, 3.0]], type: :f64)
+      ]
+
+      for a <- tensors do
+        {p, l, u} = Nx.LinAlg.lu(ev(a))
+        close_at(Nx.dot(Nx.dot(b(p), b(l)), b(u)), a, 1.0e-4)
+      end
+
+      # integer input -> P keeps the input dtype (s64), L/U are float
+      ai = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+      {p, l, u} = Nx.LinAlg.lu(ev(ai))
+      assert Nx.type(p) == {:s, 64}
+      assert match?({:f, _}, Nx.type(l)) and match?({:f, _}, Nx.type(u))
+      close_at(Nx.dot(Nx.dot(b(p), b(l)), b(u)), Nx.as_type(ai, :f64), 1.0e-3)
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -467,4 +467,44 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "slice / reverse" do
+    test "slice matches across starts, lengths, strides, ranks, dtypes" do
+      t = Nx.tensor([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
+
+      cases = [
+        {[0, 0], [2, 2], [1, 1]},
+        {[1, 1], [2, 2], [1, 1]},
+        {[0, 0], [3, 2], [1, 2]},
+        {[0, 1], [2, 2], [2, 1]},
+        {[1, 0], [1, 4], [1, 1]},
+        {[5, 5], [2, 2], [1, 1]}
+      ]
+
+      for {s, l, st} <- cases do
+        assert_same(Nx.slice(ev(t), s, l, strides: st), Nx.slice(t, s, l, strides: st))
+      end
+
+      t3 = Nx.iota({2, 3, 4}, type: :f32)
+      assert_same(
+        Nx.slice(ev(t3), [0, 1, 0], [2, 2, 4], strides: [1, 1, 2]),
+        Nx.slice(t3, [0, 1, 0], [2, 2, 4], strides: [1, 1, 2])
+      )
+    end
+
+    test "reverse matches across axes, ranks, and dtypes" do
+      cases = [
+        {Nx.tensor([1, 2, 3, 4]), [0]},
+        {Nx.tensor([[1, 2, 3], [4, 5, 6]]), [0]},
+        {Nx.tensor([[1, 2, 3], [4, 5, 6]]), [1]},
+        {Nx.tensor([[1, 2, 3], [4, 5, 6]]), [0, 1]},
+        {Nx.iota({2, 2, 2}, type: :f32), [0, 2]},
+        {Nx.iota({2, 3, 4}, type: :s32), [1]}
+      ]
+
+      for {t, axes} <- cases do
+        assert_same(Nx.reverse(ev(t), axes: axes), Nx.reverse(t, axes: axes))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -581,4 +581,45 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "determinant" do
+    test "matches Nx.BinaryBackend across sizes, dtypes, and batches" do
+      tensors = [
+        Nx.tensor([[2.0, 1.0], [1.0, 3.0]], type: :f64),
+        Nx.tensor([[1.0, 2.0, 3.0], [0.0, 1.0, 4.0], [5.0, 6.0, 0.0]], type: :f64),
+        Nx.tensor([[4.0, 3.0], [6.0, 3.0]], type: :f32),
+        # integer input -> f32 output
+        Nx.tensor([[1, 2], [3, 4]]),
+        # batched {2, 2, 2}
+        Nx.tensor([[[2.0, 0.0], [0.0, 3.0]], [[1.0, 2.0], [3.0, 4.0]]], type: :f64)
+      ]
+
+      for t <- tensors do
+        assert_close(Nx.LinAlg.determinant(ev(t)), Nx.LinAlg.determinant(t))
+      end
+    end
+  end
+
+  describe "solve" do
+    test "matches Nx.BinaryBackend for vector/matrix rhs, dtypes, and batches" do
+      a = Nx.tensor([[1.0, 0.0, 1.0], [1.0, 1.0, 0.0], [1.0, 1.0, 1.0]], type: :f64)
+
+      cases = [
+        {a, Nx.tensor([0.0, 2.0, 1.0], type: :f64)},
+        {a, Nx.tensor([[2.0, 2.0, 3.0], [2.0, 2.0, 4.0], [2.0, 0.0, 1.0]], type: :f64)},
+        {Nx.tensor([[2.0, 1.0], [1.0, 3.0]], type: :f32), Nx.tensor([3.0, 5.0], type: :f32)},
+        # integer input -> f32 solution
+        {Nx.tensor([[3, 2], [1, 2]]), Nx.tensor([7, 5])}
+      ]
+
+      for {aa, bb} <- cases do
+        assert_close(Nx.LinAlg.solve(ev(aa), ev(bb)), Nx.LinAlg.solve(aa, bb))
+      end
+
+      # batched: a {2, 2, 2}, b {2, 2} (a per-batch vector rhs)
+      ab = Nx.tensor([[[14.0, 10.0], [9.0, 9.0]], [[4.0, 11.0], [2.0, 3.0]]], type: :f64)
+      bv = Nx.tensor([[2.0, 3.0], [1.0, -3.0]], type: :f64)
+      assert_close(Nx.LinAlg.solve(ev(ab), ev(bv)), Nx.LinAlg.solve(ab, bv))
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -357,4 +357,21 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "is_nan / is_infinity / logical_not" do
+    test "match Nx.BinaryBackend exactly across float (with nan/inf) and integer dtypes" do
+      tensors = [
+        Nx.tensor([1.0, 0.0, -2.5], type: :f32),
+        Nx.tensor([:nan, :infinity, :neg_infinity, 0.0, 3.0], type: :f32),
+        Nx.tensor([:nan, 1.0, :infinity], type: :f64),
+        Nx.tensor([0.0, :nan, 2.0], type: :f16),
+        Nx.tensor([0, 1, -2, 3]),
+        Nx.tensor([0, 5, 0], type: :u8)
+      ]
+
+      for op <- [:is_nan, :is_infinity, :logical_not], t <- tensors do
+        assert_same(apply(Nx, op, [ev(t)]), apply(Nx, op, [t]))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -507,4 +507,45 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "put_slice / concatenate" do
+    test "put_slice matches across positions, clamping, ranks, dtypes" do
+      t = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+      cases = [
+        {[0, 0], Nx.tensor([[10, 11], [12, 13]])},
+        {[1, 1], Nx.tensor([[0]])},
+        {[2, 2], Nx.tensor([[99, 99]])},
+        {[0, 0], Nx.tensor([[1, 1, 1]])}
+      ]
+
+      for {start, slice} <- cases do
+        assert_same(Nx.put_slice(ev(t), start, ev(slice)), Nx.put_slice(t, start, slice))
+      end
+
+      assert_same(
+        Nx.put_slice(ev(Nx.tensor([1.0, 2.0, 3.0, 4.0])), [1], ev(Nx.tensor([9.0, 9.0]))),
+        Nx.put_slice(Nx.tensor([1.0, 2.0, 3.0, 4.0]), [1], Nx.tensor([9.0, 9.0]))
+      )
+    end
+
+    test "concatenate matches across axes, arities, sizes, and dtypes" do
+      a = Nx.tensor([[1, 2], [3, 4]])
+      b = Nx.tensor([[5, 6], [7, 8]])
+      c = Nx.tensor([[9, 10], [11, 12]])
+
+      assert_same(Nx.concatenate([ev(a), ev(b)], axis: 0), Nx.concatenate([a, b], axis: 0))
+      assert_same(Nx.concatenate([ev(a), ev(b)], axis: 1), Nx.concatenate([a, b], axis: 1))
+      assert_same(Nx.concatenate([ev(a), ev(b), ev(c)], axis: 0), Nx.concatenate([a, b, c], axis: 0))
+
+      d = Nx.tensor([[1, 2, 3]])
+      e = Nx.tensor([[4, 5, 6], [7, 8, 9]])
+      assert_same(Nx.concatenate([ev(d), ev(e)], axis: 0), Nx.concatenate([d, e], axis: 0))
+
+      assert_same(
+        Nx.concatenate([ev(Nx.tensor([1, 2])), ev(Nx.tensor([3.0, 4.0]))]),
+        Nx.concatenate([Nx.tensor([1, 2]), Nx.tensor([3.0, 4.0])])
+      )
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -44,4 +44,33 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "sort/argsort" do
+    test "match Nx.BinaryBackend across axes, ranks, directions, ties, and dtypes" do
+      base = [
+        Nx.tensor([3, 1, 2, 1, 3]),
+        Nx.tensor([[3, 1, 2], [1, 3, 2]]),
+        Nx.tensor([[[2, 1], [1, 2]], [[3, 0], [0, 3]]]),
+        Nx.tensor([[5, 5, 5], [5, 5, 5]]),
+        Nx.tensor([[1.5, -2.0, 3.25], [3.25, 1.5, -2.0]], type: :f32)
+      ]
+
+      # exercise the wide-int custom NIF path (u32/s64/u64) and the half-float
+      # cast path (f16/bf16), with ties to pin stable ordering
+      typed = for ty <- [:u32, :s64, :u64, :f16, :bf16], do: Nx.tensor([[3, 1, 2, 1], [4, 0, 5, 0]], type: ty)
+
+      opts_list = [
+        [],
+        [direction: :desc],
+        [axis: 1],
+        [axis: 1, direction: :desc],
+        [axis: 2],
+        [axis: 2, direction: :desc]
+      ]
+
+      for t <- base ++ typed, fun <- [:sort, :argsort], opts <- opts_list, axis_in_rank?(t, opts) do
+        assert_same(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -788,4 +788,66 @@ defmodule Evision.Backend.Test do
       close_at(Nx.dot(Nx.dot(b(p), b(l)), b(u)), Nx.as_type(ai, :f64), 1.0e-3)
     end
   end
+
+  describe "window_sum / window_max / window_min / window_product" do
+    test "match Nx.BinaryBackend exactly across windows, strides, padding, dilations, dtypes" do
+      t3 = Nx.tensor([[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[10, 11, 12], [13, 14, 15], [16, 17, 18]]])
+      t2 = Nx.tensor([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]], type: :s32)
+      t1 = Nx.tensor([1, 2, 3, 4, 5], type: :u8)
+
+      cases = [
+        {t3, {1, 2, 1}, []},
+        {t3, {2, 2, 1}, [strides: [1, 2, 3], padding: [{0, 1}, {2, 0}, {1, 1}]]},
+        {t2, {2, 2}, [strides: [1, 2]]},
+        {t2, {2, 2}, [window_dilations: [1, 2]]},
+        {t2, {2, 3}, [padding: :same]},
+        {t1, {2}, []},
+        {t1, {2}, [strides: [2]]}
+      ]
+
+      for op <- [:window_sum, :window_max, :window_min, :window_product], {t, w, o} <- cases do
+        assert_same(apply(Nx, op, [ev(t), w, o]), apply(Nx, op, [t, w, o]))
+      end
+    end
+
+    test "match Nx.BinaryBackend approximately for floats" do
+      t = Nx.tensor([[1.5, -2.0, 3.25, 0.5], [4.0, -1.0, 2.0, 6.0], [0.0, 3.0, -4.0, 1.0]], type: :f32)
+
+      for op <- [:window_sum, :window_max, :window_min, :window_product],
+          o <- [[], [strides: [2, 1]], [padding: :same], [window_dilations: [1, 2]]] do
+        assert_close(apply(Nx, op, [ev(t), {2, 2}, o]), apply(Nx, op, [t, {2, 2}, o]))
+      end
+    end
+  end
+
+  describe "window_scatter_max / window_scatter_min" do
+    test "match Nx.BinaryBackend across windows, strides, and duplicate targets" do
+      t = Nx.tensor([[1, 3, 2, 7, 5, 4], [8, 6, 9, 2, 1, 0], [4, 5, 3, 1, 2, 6], [7, 0, 8, 3, 9, 2]])
+
+      cases = [
+        # non-overlapping {2,3} windows -> grid {2,2}
+        {t, {2, 3}, [strides: [2, 3]], Nx.tensor([[10, 20], [30, 40]])},
+        # overlapping (stride 1) -> grid {3,5}; exercises duplicate-target accumulation
+        {t, {2, 2}, [strides: [1, 1]], Nx.add(Nx.iota({3, 5}, type: :s64), 1)},
+        # stride {2,2} -> grid {2,3}
+        {t, {2, 2}, [strides: [2, 2]], Nx.tensor([[1, 2, 3], [4, 5, 6]])}
+      ]
+
+      for op <- [:window_scatter_max, :window_scatter_min], {tt, w, o, src} <- cases do
+        assert_same(apply(Nx, op, [ev(tt), ev(src), 0, w, o]), apply(Nx, op, [tt, src, 0, w, o]))
+      end
+    end
+
+    test "match Nx.BinaryBackend for floats" do
+      t = Nx.tensor([[1.0, 5.0, 2.0, 8.0], [3.0, 9.0, 4.0, 6.0], [7.0, 0.0, 5.0, 1.0]], type: :f32)
+      src = Nx.tensor([[10.0, 20.0]], type: :f32)
+
+      for op <- [:window_scatter_max, :window_scatter_min] do
+        assert_close(
+          apply(Nx, op, [ev(t), ev(src), 0.0, {3, 2}, [strides: [1, 2]]]),
+          apply(Nx, op, [t, src, 0.0, {3, 2}, [strides: [1, 2]]])
+        )
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -160,4 +160,46 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "indexed_add / indexed_put" do
+    test "match Nx.BinaryBackend across axes, ranks, dtypes (incl. wide ints), and duplicates" do
+      # Integer / same-type results -> exact. Covers default + explicit axes,
+      # scalar + block updates, and duplicate coordinates (add sums, put last-wins).
+      int_cases = [
+        {Nx.tensor([0, 0, 0]), Nx.tensor([[1], [2]]), Nx.tensor([2, 4]), []},
+        {Nx.tensor([1, 2, 3]), Nx.tensor([[0], [1], [2], [0]]), Nx.tensor([10, 20, 30, 40]), []},
+        {Nx.iota({1, 2, 3}), Nx.tensor([[0, 0, 0], [0, 1, 1], [0, 0, 2]]), Nx.tensor([1, 3, -2]), []},
+        {Nx.iota({1, 3, 2}), Nx.tensor([[0, 0], [0, 2]]), Nx.tensor([[0, 10], [40, 50]]), []},
+        {Nx.tensor([[1, 2, 3], [4, 5, 6]]), Nx.tensor([[0], [2], [2]]),
+         Nx.tensor([[7, 8], [9, 10], [11, 12]]), [axes: [1]]},
+        {Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[1, 0], [0, 1], [1, 0]]), Nx.tensor([5, 6, 7]), []}
+      ]
+
+      for op <- [:indexed_add, :indexed_put], {t, i, u, o} <- int_cases do
+        assert_same(apply(Nx, op, [ev(t), ev(i), ev(u), o]), apply(Nx, op, [t, i, u, o]))
+      end
+
+      # Wide-int dtypes cv::add/cv::reduce reject -> exercises the custom typed path.
+      for op <- [:indexed_add, :indexed_put], type <- [{:u, 32}, {:s, 64}, {:u, 64}] do
+        t = Nx.tensor([[10, 20, 30], [40, 50, 60]], type: type)
+        i = Nx.tensor([[0, 1], [1, 2], [0, 1]])
+        u = Nx.tensor([1, 2, 3], type: type)
+        assert_same(apply(Nx, op, [ev(t), ev(i), ev(u)]), apply(Nx, op, [t, i, u]))
+      end
+    end
+
+    test "match Nx.BinaryBackend approximately for float, half, and mixed dtypes" do
+      cases = [
+        {Nx.tensor([0.0, 0.0, 0.0]), Nx.tensor([[0], [1], [0]]), Nx.tensor([1.5, 2.5, 3.0]), []},
+        {Nx.tensor([1.0, 2.0, 3.0], type: :f16), Nx.tensor([[0], [2]]),
+         Nx.tensor([4.0, 5.0], type: :f16), []},
+        {Nx.tensor([1, 2, 3], type: :s32), Nx.tensor([[0], [1]]),
+         Nx.tensor([1.5, 2.5], type: :f32), []}
+      ]
+
+      for op <- [:indexed_add, :indexed_put], {t, i, u, o} <- cases do
+        assert_close(apply(Nx, op, [ev(t), ev(i), ev(u), o]), apply(Nx, op, [t, i, u, o]))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -426,4 +426,45 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "atan2 / pow / quotient / remainder" do
+    test "atan2 matches approximately (float out, incl. integer inputs)" do
+      for {l, r} <- [
+            {Nx.tensor([1.0, -1.0, 0.0, 2.5]), Nx.tensor([1.0, 1.0, -1.0, 0.5])},
+            {Nx.tensor([1, 2, 3]), Nx.tensor([4, 5, 6])}
+          ] do
+        assert_close(Nx.atan2(ev(l), ev(r)), Nx.atan2(l, r))
+      end
+    end
+
+    test "pow matches (integer modular, float approximate)" do
+      for {l, r} <- [
+            {Nx.tensor([2, 3, 4]), Nx.tensor([3, 2, 1])},
+            {Nx.tensor([2, 5], type: :u8), Nx.tensor([10, 2], type: :u8)},
+            {Nx.tensor([-2, 3], type: :s32), Nx.tensor([3, 3], type: :s32)}
+          ] do
+        assert_same(Nx.pow(ev(l), ev(r)), Nx.pow(l, r))
+      end
+
+      for {l, r} <- [{Nx.tensor([2.0, 9.0, 4.0]), Nx.tensor([0.5, 0.5, 2.0])}] do
+        assert_close(Nx.pow(ev(l), ev(r)), Nx.pow(l, r))
+      end
+    end
+
+    test "quotient/remainder match exactly across integer signs" do
+      for {l, r} <- [
+            {Nx.tensor([7, -7, 8, -8]), Nx.tensor([2, 2, 3, 3])},
+            {Nx.tensor([10, 20], type: :u8), Nx.tensor([3, 7], type: :u8)}
+          ] do
+        assert_same(Nx.quotient(ev(l), ev(r)), Nx.quotient(l, r))
+        assert_same(Nx.remainder(ev(l), ev(r)), Nx.remainder(l, r))
+      end
+    end
+
+    test "remainder matches approximately for floats" do
+      for {l, r} <- [{Nx.tensor([5.5, -5.5, 7.0]), Nx.tensor([2.0, 2.0, 3.0])}] do
+        assert_close(Nx.remainder(ev(l), ev(r)), Nx.remainder(l, r))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -850,4 +850,49 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "conv" do
+    test "matches Nx.BinaryBackend across strides, padding, dilations, groups, ranks" do
+      img = Nx.iota({1, 1, 4, 4}, type: :f32)
+      k11 = Nx.iota({1, 1, 2, 2}, type: :f32)
+      img2 = Nx.iota({2, 3, 5, 5}, type: :f32)
+      k2 = Nx.iota({4, 3, 2, 2}, type: :f32)
+      imgd = Nx.iota({1, 4, 5, 5}, type: :f32)
+      kd = Nx.iota({4, 1, 3, 3}, type: :f32)
+      img1 = Nx.iota({1, 2, 8}, type: :f32)
+      k1 = Nx.iota({3, 2, 3}, type: :f32)
+
+      cases = [
+        {img, k11, [strides: [1, 1]]},
+        {img, k11, [strides: [2, 2]]},
+        {img, k11, [padding: :same]},
+        {img, k11, [padding: [{1, 1}, {0, 1}]]},
+        {img, k11, [kernel_dilation: [2, 1]]},
+        {img, k11, [input_dilation: [2, 2]]},
+        {img2, k2, [strides: [2, 1]]},
+        {img2, k2, [padding: :same]},
+        # depthwise (feature groups)
+        {imgd, kd, [feature_group_size: 4]},
+        {img1, k1, [strides: [2]]},
+        {img1, k1, [padding: :same, kernel_dilation: [2]]}
+      ]
+
+      for {i, k, o} <- cases do
+        assert_close(Nx.conv(ev(i), ev(k), o), Nx.conv(i, k, o))
+      end
+    end
+
+    test "matches Nx.BinaryBackend with permutations and batch groups" do
+      # input given as NHWC, permuted to canonical NCHW
+      img = Nx.iota({1, 5, 5, 3}, type: :f32)
+      k = Nx.iota({4, 3, 2, 2}, type: :f32)
+      o = [input_permutation: [0, 3, 1, 2]]
+      assert_close(Nx.conv(ev(img), ev(k), o), Nx.conv(img, k, o))
+
+      bimg = Nx.iota({4, 2, 4, 4}, type: :f32)
+      bk = Nx.iota({2, 2, 2, 2}, type: :f32)
+      bo = [batch_group_size: 2]
+      assert_close(Nx.conv(ev(bimg), ev(bk), bo), Nx.conv(bimg, bk, bo))
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -30,6 +30,13 @@ defmodule Evision.Backend.Test do
     end
   end
 
+  defp axes_in_rank?(t, opts) do
+    case opts[:axes] do
+      nil -> true
+      axes -> Enum.all?(axes, &(&1 < Nx.rank(t)))
+    end
+  end
+
   describe "argmax/argmin (index family)" do
     test "match Nx.BinaryBackend across axes, ranks, tie-breaks, and dtypes" do
       tensors = [
@@ -283,6 +290,45 @@ defmodule Evision.Backend.Test do
       f16_t = Nx.tensor([0.5, 1.0, 2.0], type: :f16)
       assert_close(Nx.tanh(ev(f16_t)), Nx.tanh(f16_t))
       assert_close(Nx.sqrt(ev(f16_t)), Nx.sqrt(f16_t))
+    end
+  end
+
+  describe "reduce_max / reduce_min / all / any" do
+    test "reduce_max/min match Nx.BinaryBackend exactly across axes, keep_axes, and dtypes" do
+      tensors = [
+        Nx.tensor([3, 1, 2]),
+        Nx.tensor([[1, 5, 3], [9, 2, 8]]),
+        Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [0, 7]]]),
+        Nx.tensor([[1.5, -2.0, 3.25], [0.0, 4.0, -1.0]], type: :f32),
+        Nx.tensor([[10, 20, 30], [40, 50, 60]], type: :u64)
+      ]
+
+      opts_list = [
+        [],
+        [axes: [0]],
+        [axes: [1]],
+        [axes: [0], keep_axes: true],
+        [axes: [1], keep_axes: true]
+      ]
+
+      for op <- [:reduce_max, :reduce_min], t <- tensors, opts <- opts_list, axes_in_rank?(t, opts) do
+        assert_same(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
+      end
+    end
+
+    test "all/any match Nx.BinaryBackend exactly across axes, keep_axes, and dtypes" do
+      tensors = [
+        Nx.tensor([1, 0, 2]),
+        Nx.tensor([[1, 0, 3], [4, 5, 6]]),
+        Nx.tensor([[0.0, 1.0], [2.0, 3.0]], type: :f32),
+        Nx.tensor([[1, 1], [1, 0]], type: :u8)
+      ]
+
+      opts_list = [[], [axes: [0]], [axes: [1]], [axes: [1], keep_axes: true]]
+
+      for op <- [:all, :any], t <- tensors, opts <- opts_list, axes_in_rank?(t, opts) do
+        assert_same(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
+      end
     end
   end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -13,6 +13,16 @@ defmodule Evision.Backend.Test do
     assert got_list == Nx.to_flat_list(want)
   end
 
+  # For float results, reduction order is implementation-defined; compare approximately.
+  defp assert_close(got, want) do
+    assert Nx.type(got) == Nx.type(want)
+    assert Nx.shape(got) == Nx.shape(want)
+    got_b = Nx.backend_copy(got, Nx.BinaryBackend)
+
+    assert Nx.to_number(Nx.all_close(got_b, want, atol: 1.0e-5, rtol: 1.0e-5)) == 1,
+           "got #{inspect(Nx.to_flat_list(got_b))} vs #{inspect(Nx.to_flat_list(want))}"
+  end
+
   defp axis_in_rank?(t, opts) do
     case opts[:axis] do
       nil -> true
@@ -70,6 +80,36 @@ defmodule Evision.Backend.Test do
 
       for t <- base ++ typed, fun <- [:sort, :argsort], opts <- opts_list, axis_in_rank?(t, opts) do
         assert_same(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
+      end
+    end
+  end
+
+  describe "sum/product" do
+    test "match Nx.BinaryBackend exactly across axes, keep_axes, and integer dtypes" do
+      tensors = for ty <- [:s32, :u8, :s64, :u64, :u32], do: Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], type: ty)
+
+      opts_list = [
+        [],
+        [axes: [0]],
+        [axes: [1]],
+        [axes: [2]],
+        [axes: [0, 2]],
+        [axes: [1], keep_axes: true],
+        [axes: [0, 1, 2]]
+      ]
+
+      for t <- tensors, fun <- [:sum, :product], opts <- opts_list do
+        assert_same(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
+      end
+    end
+
+    test "match Nx.BinaryBackend approximately for floats" do
+      t32 = Nx.tensor([[1.5, -2.0, 3.25], [0.5, 4.0, -1.0]], type: :f32)
+
+      for t <- [t32, Nx.as_type(t32, :f64)],
+          fun <- [:sum, :product],
+          opts <- [[], [axes: [0]], [axes: [1]], [axes: [1], keep_axes: true]] do
+        assert_close(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
       end
     end
   end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -249,4 +249,40 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "elementwise unary math" do
+    test "match Nx.BinaryBackend approximately (in-domain real inputs)" do
+      general = Nx.tensor([0.2, 0.5, 0.9, 1.5, 2.0, 3.0], type: :f32)
+      unit = Nx.tensor([-0.9, -0.3, 0.0, 0.3, 0.9], type: :f32)
+      ge1 = Nx.tensor([1.0, 1.5, 2.0, 5.0], type: :f32)
+      pos = Nx.tensor([0.1, 0.5, 1.0, 2.0, 9.0], type: :f32)
+
+      cases = [
+        {:sin, general}, {:cos, general}, {:tan, general},
+        {:sinh, general}, {:cosh, general}, {:tanh, general},
+        {:asinh, general}, {:atan, general}, {:sigmoid, general},
+        {:erf, general}, {:erfc, general}, {:cbrt, general},
+        {:asin, unit}, {:acos, unit}, {:atanh, unit},
+        {:acosh, ge1},
+        {:sqrt, pos}, {:rsqrt, pos}, {:log1p, pos}
+      ]
+
+      for {op, t} <- cases do
+        assert_close(apply(Nx, op, [ev(t)]), apply(Nx, op, [t]))
+      end
+    end
+
+    test "cast integer input to float and handle f64/f16" do
+      int_t = Nx.tensor([1, 2, 3])
+      assert_close(Nx.sin(ev(int_t)), Nx.sin(int_t))
+
+      f64_t = Nx.tensor([0.5, 1.0, 2.0], type: :f64)
+      assert_close(Nx.cos(ev(f64_t)), Nx.cos(f64_t))
+      assert_close(Nx.sqrt(ev(f64_t)), Nx.sqrt(f64_t))
+
+      f16_t = Nx.tensor([0.5, 1.0, 2.0], type: :f16)
+      assert_close(Nx.tanh(ev(f16_t)), Nx.tanh(f16_t))
+      assert_close(Nx.sqrt(ev(f16_t)), Nx.sqrt(f16_t))
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -23,6 +23,22 @@ defmodule Evision.Backend.Test do
            "got #{inspect(Nx.to_flat_list(got_b))} vs #{inspect(Nx.to_flat_list(want))}"
   end
 
+  # Move a tensor onto BinaryBackend (factor reconstruction is done there, since
+  # Evision.Backend.multiply does matrix mult for two non-scalar operands).
+  defp b(t), do: Nx.backend_copy(t, Nx.BinaryBackend)
+
+  # Assert two tensors are close at a given tolerance (both moved to BinaryBackend first).
+  # Reconstruction of cv-exact factors uses a tight tol; comparing canonical values to Nx's
+  # iterative SVD/eigh reference uses a looser one (the reference is only ~1e-4 accurate).
+  defp close_at(x, y, tol) do
+    xb = b(x)
+    yb = b(y)
+    assert Nx.shape(xb) == Nx.shape(yb)
+
+    assert Nx.to_number(Nx.all_close(xb, yb, atol: tol, rtol: tol)) == 1,
+           "#{inspect(Nx.to_flat_list(xb))} vs #{inspect(Nx.to_flat_list(yb))}"
+  end
+
   defp axis_in_rank?(t, opts) do
     case opts[:axis] do
       nil -> true
@@ -620,6 +636,52 @@ defmodule Evision.Backend.Test do
       ab = Nx.tensor([[[14.0, 10.0], [9.0, 9.0]], [[4.0, 11.0], [2.0, 3.0]]], type: :f64)
       bv = Nx.tensor([[2.0, 3.0], [1.0, -3.0]], type: :f64)
       assert_close(Nx.LinAlg.solve(ev(ab), ev(bv)), Nx.LinAlg.solve(ab, bv))
+    end
+  end
+
+  describe "svd" do
+    test "reconstructs square A and matches singular values" do
+      a = Nx.tensor([[1.0, 2.0, 0.0], [2.0, 3.0, 1.0], [0.0, 1.0, 2.0]], type: :f64)
+      {u, s, vt} = Nx.LinAlg.svd(ev(a))
+      a_rec = Nx.dot(Nx.multiply(b(u), Nx.reshape(b(s), {1, 3})), b(vt))
+      close_at(a_rec, a, 1.0e-4)
+      close_at(s, elem(Nx.LinAlg.svd(a), 1), 1.0e-3)
+    end
+
+    test "rectangular full/reduced shapes and singular values" do
+      a = Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], type: :f64)
+
+      {uf, sf, vtf} = Nx.LinAlg.svd(ev(a), full_matrices?: true)
+      assert {Nx.shape(uf), Nx.shape(sf), Nx.shape(vtf)} == {{3, 3}, {2}, {2, 2}}
+
+      {ur, sr, vtr} = Nx.LinAlg.svd(ev(a), full_matrices?: false)
+      assert {Nx.shape(ur), Nx.shape(sr), Nx.shape(vtr)} == {{3, 2}, {2}, {2, 2}}
+
+      close_at(sf, elem(Nx.LinAlg.svd(a, full_matrices?: true), 1), 1.0e-3)
+      a_rec = Nx.dot(Nx.multiply(b(ur), Nx.reshape(b(sr), {1, 2})), b(vtr))
+      close_at(a_rec, a, 1.0e-4)
+    end
+  end
+
+  describe "eigh" do
+    test "reconstructs symmetric A and matches eigenvalues as a set" do
+      tensors = [
+        Nx.tensor([[2.0, 1.0], [1.0, 2.0]], type: :f64),
+        Nx.tensor([[2.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 5.0]], type: :f64),
+        Nx.tensor([[4.0, 1.0, -2.0], [1.0, 2.0, 0.0], [-2.0, 0.0, 3.0]], type: :f64)
+      ]
+
+      for a <- tensors do
+        n = elem(Nx.shape(a), 0)
+        {vals, vecs} = Nx.LinAlg.eigh(ev(a))
+        vb = b(vecs)
+        a_rec = Nx.dot(Nx.multiply(vb, Nx.reshape(b(vals), {1, n})), Nx.transpose(vb))
+        close_at(a_rec, a, 1.0e-4)
+
+        # order/sign conventions differ from Nx, so compare eigenvalues as a sorted set
+        {vals_ref, _} = Nx.LinAlg.eigh(a)
+        close_at(Nx.sort(vals), Nx.sort(vals_ref), 1.0e-3)
+      end
     end
   end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -216,4 +216,37 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "cumulative_sum / product / min / max" do
+    test "match Nx.BinaryBackend exactly for integer dtypes across axes and :reverse" do
+      tensors = [
+        Nx.tensor([1, 2, 3, 4]),
+        Nx.tensor([[1, 2, 3], [4, 5, 6]]),
+        Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]),
+        Nx.tensor([[3, 1, 2], [9, 8, 7]], type: :s32),
+        Nx.tensor([[10, 20], [30, 40]], type: :u64)
+      ]
+
+      opts_list = [[], [reverse: true], [axis: 0], [axis: 1, reverse: true]]
+
+      for op <- [:cumulative_sum, :cumulative_product, :cumulative_min, :cumulative_max],
+          t <- tensors, opts <- opts_list, axis_in_rank?(t, opts) do
+        assert_same(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
+      end
+    end
+
+    test "match Nx.BinaryBackend approximately for float and half dtypes" do
+      tensors = [
+        Nx.tensor([[1.5, -2.0, 3.25], [0.5, 4.0, -1.0]], type: :f32),
+        Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f16)
+      ]
+
+      opts_list = [[], [reverse: true], [axis: 0], [axis: 1, reverse: true]]
+
+      for op <- [:cumulative_sum, :cumulative_product, :cumulative_min, :cumulative_max],
+          t <- tensors, opts <- opts_list, axis_in_rank?(t, opts) do
+        assert_close(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -331,4 +331,30 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "select" do
+    test "match Nx.BinaryBackend exactly across shapes, broadcasting, and dtypes" do
+      cases = [
+        {Nx.tensor([1, 0, 1]), Nx.tensor([10, 20, 30]), Nx.tensor([-1, -2, -3])},
+        {Nx.tensor([[1, 0], [0, 1]]), Nx.tensor([[1, 2], [3, 4]]), Nx.tensor([[5, 6], [7, 8]])},
+        # scalar branches broadcast to the predicate shape
+        {Nx.tensor([1, 0, 2, 0]), Nx.tensor(7), Nx.tensor(9)},
+        # row broadcast of the branches
+        {Nx.tensor([[1, 0, 1], [0, 1, 0]]), Nx.tensor([[100, 200, 300]]), Nx.tensor([[1, 2, 3]])},
+        # float dtype
+        {Nx.tensor([1, 0, 1]), Nx.tensor([1.5, 2.5, 3.5], type: :f32),
+         Nx.tensor([0.0, 0.0, 0.0], type: :f32)},
+        # mixed dtype -> merged (f32) output
+        {Nx.tensor([0, 1, 0]), Nx.tensor([1, 2, 3], type: :s32),
+         Nx.tensor([1.5, 2.5, 3.5], type: :f32)},
+        # scalar predicate selects a whole branch
+        {Nx.tensor(1), Nx.tensor([1, 2, 3]), Nx.tensor([4, 5, 6])},
+        {Nx.tensor(0), Nx.tensor([1, 2, 3]), Nx.tensor([4, 5, 6])}
+      ]
+
+      for {p, a, b} <- cases do
+        assert_same(Nx.select(ev(p), ev(a), ev(b)), Nx.select(p, a, b))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -548,4 +548,37 @@ defmodule Evision.Backend.Test do
       )
     end
   end
+
+  describe "take_along_axis / top_k" do
+    test "take_along_axis matches across axes, ranks, dtypes" do
+      t = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+
+      cases = [
+        {t, Nx.tensor([[0, 1, 1], [1, 0, 0]]), 0},
+        {t, Nx.tensor([[0, 2, 1, 0], [2, 1, 2, 0]]), 1},
+        {Nx.tensor([10, 20, 30, 40]), Nx.tensor([3, 0, 0, 2, 1]), 0},
+        {Nx.iota({2, 3}, type: :f32), Nx.tensor([[0, 0, 0]]), 0}
+      ]
+
+      for {tt, idx, axis} <- cases do
+        assert_same(
+          Nx.take_along_axis(ev(tt), ev(idx), axis: axis),
+          Nx.take_along_axis(tt, idx, axis: axis)
+        )
+      end
+    end
+
+    test "top_k matches Nx.BinaryBackend (values and indices)" do
+      for {t, k} <- [
+            {Nx.tensor([3, 1, 2, 5]), 2},
+            {Nx.tensor([[3, 1, 2, 5], [9, 8, 7, 6]]), 2},
+            {Nx.tensor([[1.5, 4.5, 2.5, 0.5]], type: :f32), 3}
+          ] do
+        {gv, gi} = Nx.top_k(ev(t), k: k)
+        {wv, wi} = Nx.top_k(t, k: k)
+        assert_same(gv, wv)
+        assert_same(gi, wi)
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -403,4 +403,27 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "all_close" do
+    test "match Nx.BinaryBackend across dtypes, tolerances, and inf/nan" do
+      cases = [
+        {Nx.tensor([1.0, 2.0, 3.0]), Nx.tensor([1.0, 2.0, 3.0]), []},
+        {Nx.tensor([1.0, 2.0, 3.0]), Nx.tensor([1.0, 2.0, 3.001]), []},
+        {Nx.tensor([1.0, 2.0]), Nx.tensor([1.05, 2.0]), [atol: 0.1]},
+        {Nx.tensor([1.0, 2.0]), Nx.tensor([1.5, 2.0]), [atol: 0.1]},
+        {Nx.tensor([[1.0, 2.0], [3.0, 4.0]]), Nx.tensor([[1.0, 2.0], [3.0, 4.0]]), []},
+        {Nx.tensor([1, 2, 3]), Nx.tensor([1, 2, 3]), []},
+        {Nx.tensor([1, 2, 3]), Nx.tensor([1, 2, 4]), []},
+        {Nx.tensor([:infinity, 1.0]), Nx.tensor([:infinity, 1.0]), []},
+        {Nx.tensor([:infinity, 1.0]), Nx.tensor([:neg_infinity, 1.0]), []},
+        {Nx.tensor([:nan, 1.0]), Nx.tensor([:nan, 1.0]), []},
+        {Nx.tensor([:nan, 1.0]), Nx.tensor([:nan, 1.0]), [equal_nan: true]},
+        {Nx.tensor([1.0, 2.0]), Nx.tensor([1.0, 2.5]), [rtol: 0.0, atol: 0.0]}
+      ]
+
+      for {a, b, opts} <- cases do
+        assert_same(Nx.all_close(ev(a), ev(b), opts), Nx.all_close(a, b, opts))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -186,6 +186,12 @@ defmodule Evision.Backend.Test do
         u = Nx.tensor([1, 2, 3], type: type)
         assert_same(apply(Nx, op, [ev(t), ev(i), ev(u)]), apply(Nx, op, [t, i, u]))
       end
+
+      # Rank-1 index + scalar update shorthand (relies on scalar from_binary support).
+      assert_same(
+        Nx.indexed_put(ev(Nx.tensor([[1], [2]])), ev(Nx.tensor([1, 0])), ev(Nx.tensor(10))),
+        Nx.indexed_put(Nx.tensor([[1], [2]]), Nx.tensor([1, 0]), Nx.tensor(10))
+      )
     end
 
     test "match Nx.BinaryBackend approximately for float, half, and mixed dtypes" do
@@ -199,6 +205,14 @@ defmodule Evision.Backend.Test do
 
       for op <- [:indexed_add, :indexed_put], {t, i, u, o} <- cases do
         assert_close(apply(Nx, op, [ev(t), ev(i), ev(u), o]), apply(Nx, op, [t, i, u, o]))
+      end
+    end
+  end
+
+  describe "scalar (0-dim) tensors" do
+    test "round-trip through Evision.Backend.from_binary across dtypes" do
+      for t <- [Nx.tensor(10), Nx.tensor(-3, type: :s32), Nx.tensor(2.5, type: :f32), Nx.tensor(7, type: :u64)] do
+        assert_same(ev(t), t)
       end
     end
   end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -1,4 +1,47 @@
 defmodule Evision.Backend.Test do
   use ExUnit.Case
   doctest Evision.Backend
+
+  # Move a reference (BinaryBackend) tensor onto Evision.Backend.
+  defp ev(t), do: Nx.backend_copy(t, Evision.Backend)
+
+  # Assert an Evision.Backend result equals the BinaryBackend reference exactly.
+  defp assert_same(got, want) do
+    assert Nx.type(got) == Nx.type(want)
+    assert Nx.shape(got) == Nx.shape(want)
+    got_list = got |> Nx.backend_copy(Nx.BinaryBackend) |> Nx.to_flat_list()
+    assert got_list == Nx.to_flat_list(want)
+  end
+
+  defp axis_in_rank?(t, opts) do
+    case opts[:axis] do
+      nil -> true
+      axis -> axis < Nx.rank(t)
+    end
+  end
+
+  describe "argmax/argmin (index family)" do
+    test "match Nx.BinaryBackend across axes, ranks, tie-breaks, and dtypes" do
+      tensors = [
+        Nx.tensor([3, 1, 2]),
+        Nx.tensor([[1, 5, 3], [9, 2, 8]]),
+        Nx.tensor([[[1, 2], [3, 4]], [[5, 6], [0, 7]]]),
+        Nx.tensor([[1, 1, 1], [2, 2, 2]]),
+        Nx.tensor([[1.5, -2.0, 3.25], [0.0, 0.0, 0.0]], type: :f32)
+      ]
+
+      opts_list = [
+        [],
+        [tie_break: :high],
+        [axis: 0],
+        [axis: 1],
+        [axis: 0, keep_axis: true],
+        [axis: 1, tie_break: :high]
+      ]
+
+      for t <- tensors, fun <- [:argmax, :argmin], opts <- opts_list, axis_in_rank?(t, opts) do
+        assert_same(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -105,6 +105,18 @@ defmodule Evision.Backend.Test do
         assert_same(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
       end
     end
+
+    test "sort and argsort match Nx.BinaryBackend NaN ordering" do
+      for t <- [
+            Nx.tensor([1.0, :nan, 2.0, -1.0], type: :f32),
+            Nx.tensor([[1.0, :nan, 2.0], [:nan, -1.0, 0.0]], type: :f64),
+            Nx.tensor([1.0, :nan, 2.0, -1.0], type: :f16)
+          ],
+          fun <- [:sort, :argsort],
+          opts <- [[], [direction: :desc], [axis: max(Nx.rank(t) - 1, 0)]] do
+        assert_same(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
+      end
+    end
   end
 
   describe "sum/product" do
@@ -133,6 +145,14 @@ defmodule Evision.Backend.Test do
           fun <- [:sum, :product],
           opts <- [[], [axes: [0]], [axes: [1]], [axes: [1], keep_axes: true]] do
         assert_close(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
+      end
+    end
+
+    test "cumulative max/min propagate NaNs like Nx.BinaryBackend" do
+      t = Nx.tensor([1.0, :nan, 2.0], type: :f32)
+
+      for op <- [:cumulative_max, :cumulative_min], opts <- [[], [reverse: true]] do
+        assert_same(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
       end
     end
   end
@@ -343,6 +363,14 @@ defmodule Evision.Backend.Test do
       opts_list = [[], [axes: [0]], [axes: [1]], [axes: [1], keep_axes: true]]
 
       for op <- [:all, :any], t <- tensors, opts <- opts_list, axes_in_rank?(t, opts) do
+        assert_same(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
+      end
+    end
+
+    test "reduce_max/min propagate NaNs like Nx.BinaryBackend" do
+      t = Nx.tensor([[1.0, :nan, 2.0], [3.0, 4.0, 5.0]], type: :f32)
+
+      for op <- [:reduce_max, :reduce_min], opts <- [[], [axes: [1]], [axes: [1], keep_axes: true]] do
         assert_same(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
       end
     end
@@ -746,17 +774,20 @@ defmodule Evision.Backend.Test do
       tensors = [
         Nx.tensor([[12.0, -51.0, 4.0], [6.0, 167.0, -68.0], [-4.0, 24.0, -41.0]], type: :f64),
         # tall 3x2
-        Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], type: :f64)
+        Nx.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], type: :f64),
+        # wide 2x3
+        Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], type: :f64)
       ]
 
       for a <- tensors do
         {m, n} = Nx.shape(a)
+        k = min(m, n)
 
         {q, r} = Nx.LinAlg.qr(ev(a), mode: :reduced)
-        assert {Nx.shape(q), Nx.shape(r)} == {{m, n}, {n, n}}
+        assert {Nx.shape(q), Nx.shape(r)} == {{m, k}, {k, n}}
         qb = b(q)
         close_at(Nx.dot(qb, b(r)), a, 1.0e-4)
-        close_at(Nx.dot(Nx.transpose(qb), qb), Nx.eye(n, type: :f64), 1.0e-4)
+        close_at(Nx.dot(Nx.transpose(qb), qb), Nx.eye(k, type: :f64), 1.0e-4)
 
         {q, r} = Nx.LinAlg.qr(ev(a), mode: :complete)
         assert {Nx.shape(q), Nx.shape(r)} == {{m, m}, {m, n}}
@@ -816,6 +847,14 @@ defmodule Evision.Backend.Test do
       for op <- [:window_sum, :window_max, :window_min, :window_product],
           o <- [[], [strides: [2, 1]], [padding: :same], [window_dilations: [1, 2]]] do
         assert_close(apply(Nx, op, [ev(t), {2, 2}, o]), apply(Nx, op, [t, {2, 2}, o]))
+      end
+    end
+
+    test "window max/min propagate NaNs like Nx.BinaryBackend" do
+      t = Nx.tensor([1.0, :nan, 2.0], type: :f32)
+
+      for op <- [:window_max, :window_min] do
+        assert_same(apply(Nx, op, [ev(t), {2}]), apply(Nx, op, [t, {2}]))
       end
     end
   end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -130,4 +130,34 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "gather" do
+    test "matches Nx.BinaryBackend across axes, ranks, dtypes, and index shapes" do
+      t2 = Nx.tensor([[1, 2], [3, 4]])
+      t23 = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+      t3 = Nx.tensor([[[1, 2], [11, 12]], [[101, 102], [111, 112]]], type: :s64)
+      t23f = Nx.tensor([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5]], type: :f32)
+      iota = Nx.iota({2, 1, 3})
+
+      # {tensor, indices, opts} triples valid for Nx.gather (coords in bounds,
+      # indices last dim == length(axes)); covers default + explicit axes,
+      # contiguous + non-contiguous axes, scalar + subset gathers, int + float.
+      cases = [
+        {t2, Nx.tensor([[1, 1], [0, 1], [1, 0]]), []},
+        {t2, Nx.tensor([[[1, 1], [0, 0]], [[1, 0], [0, 1]]]), []},
+        {t3, Nx.tensor([[0, 0, 0], [0, 1, 1], [1, 1, 1]]), []},
+        {t23, Nx.tensor([[1], [0]]), []},
+        {t23, Nx.tensor([[1], [0], [2], [1]]), [axes: [1]]},
+        {iota, Nx.tensor([[[1], [0], [2]]]), [axes: [2]]},
+        {t23f, Nx.tensor([[0, 0], [1, 2], [0, 2]]), []},
+        {t23f, Nx.tensor([[0], [1]]), [axes: [0]]},
+        {t3, Nx.tensor([[0], [1]]), [axes: [0]]},
+        {t3, Nx.tensor([[0, 1], [1, 0]]), [axes: [0, 2]]}
+      ]
+
+      for {t, idx, opts} <- cases do
+        assert_same(Nx.gather(ev(t), ev(idx), opts), Nx.gather(t, idx, opts))
+      end
+    end
+  end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -374,4 +374,33 @@ defmodule Evision.Backend.Test do
       end
     end
   end
+
+  describe "count_leading_zeros / population_count / left_shift / right_shift" do
+    test "match Nx.BinaryBackend exactly across integer dtypes" do
+      unary_tensors = [
+        Nx.tensor([0, 1, 2, 255], type: :u8),
+        Nx.tensor([0, 1, -1, 127, -128], type: :s8),
+        Nx.tensor([1, 256, 65535], type: :u16),
+        Nx.tensor([0, 1, 2, 100], type: :s32),
+        Nx.tensor([1, 2, 3], type: :u64),
+        Nx.tensor([-1, -2], type: :s64)
+      ]
+
+      for op <- [:count_leading_zeros, :population_count], t <- unary_tensors do
+        assert_same(apply(Nx, op, [ev(t)]), apply(Nx, op, [t]))
+      end
+
+      shift_cases = [
+        {Nx.tensor([1, 2, 4], type: :u8), Nx.tensor([1, 2, 3], type: :u8)},
+        {Nx.tensor([255, 16, 1], type: :u8), Nx.tensor([1, 2, 4], type: :u8)},
+        {Nx.tensor([-8, -1, 16], type: :s32), Nx.tensor([1, 1, 2], type: :s32)},
+        {Nx.tensor([1, 2, 3], type: :s64), Nx.tensor([10, 20, 30], type: :s64)},
+        {Nx.tensor([100, 200], type: :u64), Nx.tensor([2, 3], type: :u64)}
+      ]
+
+      for op <- [:left_shift, :right_shift], {l, r} <- shift_cases do
+        assert_same(apply(Nx, op, [ev(l), ev(r)]), apply(Nx, op, [l, r]))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Implements 72 of the 85 missing `Nx.Backend` callbacks on `Evision.Backend`, so much more of the Nx API works directly on tensors backed by OpenCV `Mat`s. Every callback is verified against `Nx.BinaryBackend` in `test/evision_backend_test.exs`.

## Approach

Hybrid by operation and dtype: an OpenCV fast path where `cv::*` supports the op and dtype, and a custom C++ NIF (under `c_src/modules/evision_backend/`) where it does not. Wide integer dtypes (`u32`/`s64`/`u64`) and half floats (`f16`/`bf16`, widened to `f32`) are handled where OpenCV's algorithms reject them. Correctness is checked against `Nx.BinaryBackend`: exact for integer ops, approximate (`Nx.all_close`) for floats, and reconstruction-based for non-unique factorizations (QR, LU, SVD, eigh, Cholesky).

## Coverage

- Aggregates: argmax/argmin, sum/product, reduce_max/reduce_min, all/any, cumulative_{sum,product,min,max}
- Indexing: take, gather, take_along_axis, indexed_add/indexed_put, top_k
- Shape ops: slice, reverse, put_slice, concatenate
- Elementwise unary math: sin, cos, tan, asin, acos, atan, sinh..atanh, erf, erfc, cbrt, log1p, rsqrt, sigmoid, sqrt
- Elementwise binary: atan2, pow, quotient, remainder
- Predicates and bitwise: is_nan, is_infinity, logical_not, count_leading_zeros, population_count, left_shift, right_shift, all_close, select
- Linear algebra: determinant, solve (cv::solve), svd (cv::SVDecomp), eigh (cv::eigen); cholesky, lu, qr, triangular_solve (custom `linalg.h` NIFs)
- Windowed / pooling: window_sum/max/min/product, window_scatter_max/min (`window.h`)
- Convolution: conv, covering N-d, strides, padding, input/kernel dilation, feature and batch groups, and input/kernel/output permutations (`conv.h`)
- Plus `init/1` and a `from_binary` fix for 0-dim scalar tensors.

## Testing

- `mix test`: 163 tests, 0 failures (11 excluded; those require downloads/ffmpeg/CUDA/etc.)
- `mix compile --warnings-as-errors`: clean

## Deferred (13 callbacks, for follow-ups)

- `fft`, `fft2`, `ifft`, `ifft2` and the complex family (`conjugate`, `real`, `imag`, `phase`): these are inherently complex-valued, which needs complex (2-channel) `Mat` support that Evision does not have yet (`{:c, _}` is currently rejected). Planned as a dedicated follow-up.
- `window_reduce/6`, `reduce/5`, `map/4`: each takes an arbitrary BEAM reducer/mapper function, so there is no cv/NIF path. Candidates for an `Nx.BinaryBackend` delegation pattern.
- `erf_inv`: needs the `complex` library's approximation (not available in `<cmath>`).
- `optional/3`: inert (the `__unimplemented__` catch-all already covers it).
