### PR TITLE
Parallelize independent Evision backend loops

### DIFF
--- a/c_src/ArgInfo.hpp
+++ b/c_src/ArgInfo.hpp
@@ -18,12 +18,16 @@ public:
     bool pathlike;
     bool nd_mat;
     bool has_default; // <- added in evision
-    // Pure read-only input. Set only by generated bindings, where the source
-    // matrix is guaranteed to be handed to OpenCV as a const InputArray. It
-    // lets converters share the source buffer instead of deep-copying it.
-    // Hand-written modules leave this unset and keep the safe copying default.
+    // Pure read-only input. Set by generated bindings (const InputArray) and by
+    // hand-written modules that only read a source matrix (clone-then-work or
+    // write-a-fresh-dst). It lets converters share a cv-owned source buffer
+    // instead of deep-copying it; binary-backed sources still deep-copy (see the
+    // in_buf guard in evision_to), so sharing can never outlive an Erlang binary.
     bool input_only;  // <- added in evision
     // more fields may be added if necessary
+
+    // Flag value for hand-written modules: ArgInfo("src", ArgInfo::INPUT_ONLY).
+    static const uint32_t INPUT_ONLY = arg_input_only_flag;
 
     ArgInfo(const char* name_, uint32_t arg_) :
         name(name_),

--- a/c_src/modules/evision_backend/binop.h
+++ b/c_src/modules/evision_backend/binop.h
@@ -77,8 +77,8 @@ static ERL_NIF_TERM evision_cv_mat_binop(ErlNifEnv *env, int argc, const ERL_NIF
         Mat l, r;
         int op = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
             Mat lc = l.isContinuous() ? l : l.clone();
             Mat rc = r.isContinuous() ? r : r.clone();

--- a/c_src/modules/evision_backend/binop.h
+++ b/c_src/modules/evision_backend/binop.h
@@ -7,6 +7,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Elementwise binary ops without an OpenCV primitive (Nx.atan2 / pow / quotient /
 // remainder). op 0=atan2, 1=pow, 2=quotient, 3=remainder. l and r share the output
@@ -18,15 +19,17 @@ static void evision_binop_float(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst
     const T *rp = (const T *)r.data;
     T *dp = (T *)dst.data;
     size_t n = l.total();
-    for (size_t i = 0; i < n; i++) {
-        T a = lp[i], b = rp[i];
-        switch (op) {
-            case 0: dp[i] = std::atan2(a, b); break;
-            case 1: dp[i] = std::pow(a, b); break;
-            case 3: dp[i] = std::fmod(a, b); break;
-            default: dp[i] = (T)0; break;
+    evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
+            T a = lp[(size_t)i], b = rp[(size_t)i];
+            switch (op) {
+                case 0: dp[(size_t)i] = std::atan2(a, b); break;
+                case 1: dp[(size_t)i] = std::pow(a, b); break;
+                case 3: dp[(size_t)i] = std::fmod(a, b); break;
+                default: dp[(size_t)i] = (T)0; break;
+            }
         }
-    }
+    });
 }
 
 // Integer pow is exponentiation-by-squaring in the unsigned counterpart, so it
@@ -38,25 +41,27 @@ static void evision_binop_int(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst, 
     const T *rp = (const T *)r.data;
     T *dp = (T *)dst.data;
     size_t n = l.total();
-    for (size_t i = 0; i < n; i++) {
-        T a = lp[i], b = rp[i];
-        switch (op) {
-            case 1: {
-                Acc base = (Acc)a, result = 1;
-                T e = b;
-                while (e > 0) {
-                    if (e & 1) result = (Acc)(result * base);
-                    base = (Acc)(base * base);
-                    e >>= 1;
+    evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
+            T a = lp[(size_t)i], b = rp[(size_t)i];
+            switch (op) {
+                case 1: {
+                    Acc base = (Acc)a, result = 1;
+                    T e = b;
+                    while (e > 0) {
+                        if (e & 1) result = (Acc)(result * base);
+                        base = (Acc)(base * base);
+                        e >>= 1;
+                    }
+                    dp[(size_t)i] = (T)result;
+                    break;
                 }
-                dp[i] = (T)result;
-                break;
+                case 2: dp[(size_t)i] = (b == 0) ? (T)0 : (T)(a / b); break;
+                case 3: dp[(size_t)i] = (b == 0) ? (T)0 : (T)(a % b); break;
+                default: dp[(size_t)i] = (T)0; break;
             }
-            case 2: dp[i] = (b == 0) ? (T)0 : (T)(a / b); break;
-            case 3: dp[i] = (b == 0) ? (T)0 : (T)(a % b); break;
-            default: dp[i] = (T)0; break;
         }
-    }
+    });
 }
 
 // @evision c: mat_binop, evision_cv_mat_binop, 1

--- a/c_src/modules/evision_backend/conv.h
+++ b/c_src/modules/evision_backend/conv.h
@@ -1,7 +1,10 @@
 #ifndef EVISION_BACKEND_CONV_H
 #define EVISION_BACKEND_CONV_H
 
+#include <algorithm>
+#include <type_traits>
 #include <vector>
+#include <opencv2/core.hpp>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
@@ -93,6 +96,100 @@ static void conv_typed(const T *I, const T *K, T *Out, int d,
     });
 }
 
+// Fast path for 2D conv with no input dilation and a single batch group: turn the
+// correlation into one matrix multiply per feature group. im2row builds a patch matrix
+// whose rows are flattened receptive fields, so the GEMM is Col * Kg^T = [rows, O/G] --
+// the spatial axis is the GEMM's M dimension, which is where cv::gemm runs fastest
+// (channels as M is its slow regime). The result is scattered back into the canonical
+// channel-major [N, O, OH, OW] the caller expects. GEMM reassociates the sum, so floats
+// differ from conv_typed within tolerance.
+//
+// The output rows [0, N*OH*OW) are processed in tiles sized to a fixed memory budget, so
+// the im2row buffer never blows up on large inputs. A tile spans the batch freely (row r
+// -> n = r/OHW), keeping the GEMM's M (the tile height) large; typical convs fit one tile
+// and take the same path as no tiling at all.
+template <typename T>
+static void conv2d_im2row(const T *I, const T *K, T *Out,
+                          const std::vector<int> &in_shape, const std::vector<int> &k_shape,
+                          const std::vector<int> &out_shape, const std::vector<int> &stride,
+                          const std::vector<int> &pad_lo, const std::vector<int> &k_dil, int G,
+                          int64_t budget_bytes) {
+    int N = in_shape[0], Cin = in_shape[1], H = in_shape[2], W = in_shape[3];
+    int O = k_shape[0], Cin_pg = k_shape[1], KH = k_shape[2], KW = k_shape[3];
+    int OH = out_shape[2], OW = out_shape[3];
+    int O_pg = O / G;
+    int sh = stride[0], sw = stride[1];
+    int ph = pad_lo[0], pw = pad_lo[1];
+    int kdh = k_dil[0], kdw = k_dil[1];
+    int CKK = Cin_pg * KH * KW;
+    int OHW = OH * OW;
+    int cv_type = std::is_same<T, float>::value ? CV_32F : CV_64F;
+
+    int64_t in_cs = (int64_t)H * W;          // elements per input channel
+    int64_t in_ns = (int64_t)Cin * in_cs;    // elements per input batch
+    int64_t total_rows = (int64_t)N * OHW;
+    if (total_rows == 0) return;
+
+    // Bound the im2row + gemm-output buffers; the tile height is the GEMM's M, so keep it
+    // as large as the budget allows. Normal convs fit one tile (no tiling).
+    int64_t tile = budget_bytes / ((int64_t)(CKK + O_pg) * (int64_t)sizeof(T));
+    if (tile < 1) tile = 1;
+    if (tile > total_rows) tile = total_rows;
+
+    for (int g = 0; g < G; g++) {
+        int cbase = g * Cin_pg;
+        cv::Mat kg(O_pg, CKK, cv_type, (void *)(K + (int64_t)g * O_pg * CKK));
+        cv::Mat col((int)tile, CKK, cv_type);  // reused across tiles
+
+        for (int64_t r0 = 0; r0 < total_rows; r0 += tile) {
+            int rows = (int)std::min(tile, total_rows - r0);
+            cv::Mat colv = col.rowRange(0, rows);
+            T *colp = (T *)colv.data;
+
+            // im2row: row rr (global r0+rr) = (n*OH+oh)*OW+ow, col = (ic*KH+kh)*KW+kw.
+            evision_parallel_for(rows, (int64_t)rows * CKK, EVISION_PARALLEL_CONV_MIN_WORK, [&](int64_t rbegin, int64_t rend) {
+                for (int64_t rr = rbegin; rr < rend; rr++) {
+                    int64_t r = r0 + rr;
+                    int n = (int)(r / OHW);
+                    int rem = (int)(r % OHW);
+                    int oh = rem / OW;
+                    int ow = rem % OW;
+                    T *crow = colp + rr * CKK;
+                    int ci = 0;
+                    for (int ic = 0; ic < Cin_pg; ic++) {
+                        const T *inch = I + (int64_t)n * in_ns + (int64_t)(cbase + ic) * in_cs;
+                        for (int kh = 0; kh < KH; kh++) {
+                            int ih = oh * sh + kh * kdh - ph;
+                            bool h_ok = ih >= 0 && ih < H;
+                            const T *inrow = inch + (int64_t)ih * W;
+                            for (int kw = 0; kw < KW; kw++) {
+                                int iw = ow * sw + kw * kdw - pw;
+                                crow[ci++] = (h_ok && iw >= 0 && iw < W) ? inrow[iw] : (T)0;
+                            }
+                        }
+                    }
+                }
+            });
+
+            cv::Mat outg;
+            cv::gemm(colv, kg, 1.0, cv::noArray(), 0.0, outg, cv::GEMM_2_T);  // [rows, O_pg]
+            const T *ogp = (const T *)outg.data;
+
+            // Scatter into canonical Out[N, O, OH, OW]: Out[n, g*O_pg+o2, s] = outg[rr, o2].
+            evision_parallel_for(rows, (int64_t)rows * O_pg, EVISION_PARALLEL_CONV_MIN_WORK, [&](int64_t rbegin, int64_t rend) {
+                for (int64_t rr = rbegin; rr < rend; rr++) {
+                    int64_t r = r0 + rr;
+                    int n = (int)(r / OHW);
+                    int s = (int)(r % OHW);
+                    const T *orow = ogp + rr * O_pg;
+                    int64_t base = ((int64_t)n * O + g * O_pg) * OHW + s;
+                    for (int o2 = 0; o2 < O_pg; o2++) Out[base + (int64_t)o2 * OHW] = orow[o2];
+                }
+            });
+        }
+    }
+}
+
 // @evision c: mat_conv, evision_cv_mat_conv, 1
 // @evision nif: def mat_conv(_opts \\ []), do: :erlang.nif_error(:undefined)
 static ERL_NIF_TERM evision_cv_mat_conv(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -106,9 +203,10 @@ static ERL_NIF_TERM evision_cv_mat_conv(ErlNifEnv *env, int argc, const ERL_NIF_
         Mat input, kernel;
         std::vector<int> in_shape, k_shape, out_shape, stride, pad_lo, in_dil, k_dil;
         int feature_groups = 1, batch_groups = 1;
+        int im2row_budget = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "input"), input, ArgInfo("input", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "kernel"), kernel, ArgInfo("kernel", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "input"), input, ArgInfo("input", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "kernel"), kernel, ArgInfo("kernel", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "in_shape"), in_shape, ArgInfo("in_shape", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "k_shape"), k_shape, ArgInfo("k_shape", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "out_shape"), out_shape, ArgInfo("out_shape", 0)) &&
@@ -117,7 +215,8 @@ static ERL_NIF_TERM evision_cv_mat_conv(ErlNifEnv *env, int argc, const ERL_NIF_
             evision_to_safe(env, evision_get_kw(env, erl_terms, "input_dilation"), in_dil, ArgInfo("input_dilation", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "kernel_dilation"), k_dil, ArgInfo("kernel_dilation", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "feature_groups"), feature_groups, ArgInfo("feature_groups", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "batch_groups"), batch_groups, ArgInfo("batch_groups", 0))) {
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "batch_groups"), batch_groups, ArgInfo("batch_groups", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "im2row_budget"), im2row_budget, ArgInfo("im2row_budget", 0))) {
             int d = (int)in_shape.size() - 2;
             Mat in_c = input.isContinuous() ? input : input.clone();
             Mat k_c = kernel.isContinuous() ? kernel : kernel.clone();
@@ -126,19 +225,36 @@ static ERL_NIF_TERM evision_cv_mat_conv(ErlNifEnv *env, int argc, const ERL_NIF_
             for (size_t i = 0; i < out_shape.size(); i++) out_total *= out_shape[i];
             Mat dst(1, (int)(out_total > 0 ? out_total : 1), input.type());
 
-            switch (input.depth()) {
-                case CV_32F:
-                    conv_typed<float>((const float *)in_c.data, (const float *)k_c.data, (float *)dst.data,
-                                      d, in_shape, k_shape, out_shape, stride, pad_lo, in_dil, k_dil,
-                                      feature_groups, batch_groups);
-                    break;
-                case CV_64F:
-                    conv_typed<double>((const double *)in_c.data, (const double *)k_c.data, (double *)dst.data,
-                                       d, in_shape, k_shape, out_shape, stride, pad_lo, in_dil, k_dil,
-                                       feature_groups, batch_groups);
-                    break;
-                default:
-                    return evision::nif::error(env, "conv: unsupported depth (expected f32/f64)");
+            bool in_dil_one = std::all_of(in_dil.begin(), in_dil.end(), [](int x) { return x == 1; });
+            bool fast2d = d == 2 && batch_groups == 1 && in_dil_one &&
+                          (input.depth() == CV_32F || input.depth() == CV_64F);
+
+            // Caller may cap the im2row buffer (Application config / per-process override);
+            // 0 or unset means use the default.
+            int64_t budget = im2row_budget > 0 ? (int64_t)im2row_budget : (64LL << 20);
+
+            if (fast2d) {
+                if (input.depth() == CV_32F)
+                    conv2d_im2row<float>((const float *)in_c.data, (const float *)k_c.data, (float *)dst.data,
+                                         in_shape, k_shape, out_shape, stride, pad_lo, k_dil, feature_groups, budget);
+                else
+                    conv2d_im2row<double>((const double *)in_c.data, (const double *)k_c.data, (double *)dst.data,
+                                          in_shape, k_shape, out_shape, stride, pad_lo, k_dil, feature_groups, budget);
+            } else {
+                switch (input.depth()) {
+                    case CV_32F:
+                        conv_typed<float>((const float *)in_c.data, (const float *)k_c.data, (float *)dst.data,
+                                          d, in_shape, k_shape, out_shape, stride, pad_lo, in_dil, k_dil,
+                                          feature_groups, batch_groups);
+                        break;
+                    case CV_64F:
+                        conv_typed<double>((const double *)in_c.data, (const double *)k_c.data, (double *)dst.data,
+                                           d, in_shape, k_shape, out_shape, stride, pad_lo, in_dil, k_dil,
+                                           feature_groups, batch_groups);
+                        break;
+                    default:
+                        return evision::nif::error(env, "conv: unsupported depth (expected f32/f64)");
+                }
             }
             return evision_from(env, dst);
         }

--- a/c_src/modules/evision_backend/conv.h
+++ b/c_src/modules/evision_backend/conv.h
@@ -5,6 +5,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // N-d cross-correlation (Nx.conv) on already-permuted canonical layouts: input [N, Cin,
 // *spatial], kernel [O, Cin/G, *spatial], output [N/Bg, O, *spatial]. The caller does the
@@ -43,44 +44,53 @@ static void conv_typed(const T *I, const T *K, T *Out, int d,
     int64_t k_spatial = 1;
     for (int s = 0; s < d; s++) k_spatial *= k_shape[(size_t)(2 + s)];
 
-    std::vector<int> oidx((size_t)rank, 0), kp((size_t)d, 0);
-    for (int64_t flat = 0; flat < out_total; flat++) {
-        int bprime = oidx[0];
-        int o = oidx[1];
-        int fg = o / O_per_G;
-        int jchunk = o / O_per_Bg;
-        int n = bprime + jchunk * Nout;
-        int cbase = fg * Cin_pg;
-
-        T acc = (T)0;
-        for (int ic = 0; ic < Cin_pg; ic++) {
-            int64_t in_base = (int64_t)n * in_st[0] + (int64_t)(cbase + ic) * in_st[1];
-            int64_t k_base = (int64_t)o * k_st[0] + (int64_t)ic * k_st[1];
-            std::fill(kp.begin(), kp.end(), 0);
-
-            for (int64_t kq = 0; kq < k_spatial; kq++) {
-                bool valid = true;
-                int64_t in_off = in_base;
-                for (int s = 0; s < d; s++) {
-                    int64_t cd = (int64_t)oidx[(size_t)(2 + s)] * stride[(size_t)s] +
-                                 (int64_t)kp[(size_t)s] * k_dil[(size_t)s] - pad_lo[(size_t)s];
-                    if (cd < 0 || cd >= dilated_in[(size_t)s]) { valid = false; break; }
-                    if (in_dil[(size_t)s] != 1 && (cd % in_dil[(size_t)s]) != 0) { valid = false; break; }
-                    int64_t orig = (in_dil[(size_t)s] == 1) ? cd : cd / in_dil[(size_t)s];
-                    in_off += orig * in_st[(size_t)(2 + s)];
-                }
-                if (valid) {
-                    int64_t k_off = k_base;
-                    for (int s = 0; s < d; s++) k_off += (int64_t)kp[(size_t)s] * k_st[(size_t)(2 + s)];
-                    acc += I[in_off] * K[k_off];
-                }
-                for (int s = d - 1; s >= 0; s--) { if (++kp[(size_t)s] < k_shape[(size_t)(2 + s)]) break; kp[(size_t)s] = 0; }
-            }
+    int64_t work = out_total * Cin_pg * (k_spatial > 0 ? k_spatial : 1);
+    evision_parallel_for(out_total, work, EVISION_PARALLEL_CONV_MIN_WORK, [&](int64_t begin, int64_t end) {
+        std::vector<int> oidx((size_t)rank, 0), kp((size_t)d, 0);
+        int64_t q = begin;
+        for (int s = rank - 1; s >= 0; s--) {
+            oidx[(size_t)s] = (int)(q % out_shape[(size_t)s]);
+            q /= out_shape[(size_t)s];
         }
 
-        Out[flat] = acc;
-        for (int s = rank - 1; s >= 0; s--) { if (++oidx[(size_t)s] < out_shape[(size_t)s]) break; oidx[(size_t)s] = 0; }
-    }
+        for (int64_t flat = begin; flat < end; flat++) {
+            int bprime = oidx[0];
+            int o = oidx[1];
+            int fg = o / O_per_G;
+            int jchunk = o / O_per_Bg;
+            int n = bprime + jchunk * Nout;
+            int cbase = fg * Cin_pg;
+
+            T acc = (T)0;
+            for (int ic = 0; ic < Cin_pg; ic++) {
+                int64_t in_base = (int64_t)n * in_st[0] + (int64_t)(cbase + ic) * in_st[1];
+                int64_t k_base = (int64_t)o * k_st[0] + (int64_t)ic * k_st[1];
+                std::fill(kp.begin(), kp.end(), 0);
+
+                for (int64_t kq = 0; kq < k_spatial; kq++) {
+                    bool valid = true;
+                    int64_t in_off = in_base;
+                    for (int s = 0; s < d; s++) {
+                        int64_t cd = (int64_t)oidx[(size_t)(2 + s)] * stride[(size_t)s] +
+                                     (int64_t)kp[(size_t)s] * k_dil[(size_t)s] - pad_lo[(size_t)s];
+                        if (cd < 0 || cd >= dilated_in[(size_t)s]) { valid = false; break; }
+                        if (in_dil[(size_t)s] != 1 && (cd % in_dil[(size_t)s]) != 0) { valid = false; break; }
+                        int64_t orig = (in_dil[(size_t)s] == 1) ? cd : cd / in_dil[(size_t)s];
+                        in_off += orig * in_st[(size_t)(2 + s)];
+                    }
+                    if (valid) {
+                        int64_t k_off = k_base;
+                        for (int s = 0; s < d; s++) k_off += (int64_t)kp[(size_t)s] * k_st[(size_t)(2 + s)];
+                        acc += I[in_off] * K[k_off];
+                    }
+                    for (int s = d - 1; s >= 0; s--) { if (++kp[(size_t)s] < k_shape[(size_t)(2 + s)]) break; kp[(size_t)s] = 0; }
+                }
+            }
+
+            Out[flat] = acc;
+            for (int s = rank - 1; s >= 0; s--) { if (++oidx[(size_t)s] < out_shape[(size_t)s]) break; oidx[(size_t)s] = 0; }
+        }
+    });
 }
 
 // @evision c: mat_conv, evision_cv_mat_conv, 1

--- a/c_src/modules/evision_backend/cumulative.h
+++ b/c_src/modules/evision_backend/cumulative.h
@@ -69,7 +69,7 @@ static ERL_NIF_TERM evision_cv_mat_cumulative(ErlNifEnv *env, int argc, const ER
         Mat src;
         int op = 0, reverse = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "reverse"), reverse, ArgInfo("reverse", 0))) {
             Mat dst(src.rows, src.cols, src.type());

--- a/c_src/modules/evision_backend/cumulative.h
+++ b/c_src/modules/evision_backend/cumulative.h
@@ -6,6 +6,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Row-wise prefix scan (Nx.cumulative_*): op 0=sum, 1=product, 2=min, 3=max,
 // accumulating left-to-right (or right-to-left when reverse). Output has the same
@@ -31,26 +32,28 @@ static inline T evision_scan_max(T acc, T v) {
 template <typename T, typename Acc>
 static void evision_scan_rows(const cv::Mat &src, cv::Mat &dst, int op, bool reverse) {
     int cols = src.cols;
-    for (int r = 0; r < src.rows; r++) {
-        const T *sp = src.ptr<T>(r);
-        T *dp = dst.ptr<T>(r);
-        if (cols == 0) continue;
-        int start = reverse ? cols - 1 : 0;
-        int step = reverse ? -1 : 1;
-        T running = sp[start];
-        dp[start] = running;
-        for (int k = 1; k < cols; k++) {
-            int c = start + step * k;
-            T v = sp[c];
-            switch (op) {
-                case 0: running = (T)((Acc)running + (Acc)v); break;
-                case 1: running = (T)((Acc)running * (Acc)v); break;
-                case 2: running = evision_scan_min(running, v); break;
-                case 3: running = evision_scan_max(running, v); break;
+    evision_parallel_for(src.rows, (int64_t)src.rows * cols, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t row = begin; row < end; row++) {
+            const T *sp = src.ptr<T>((int)row);
+            T *dp = dst.ptr<T>((int)row);
+            if (cols == 0) continue;
+            int start = reverse ? cols - 1 : 0;
+            int step = reverse ? -1 : 1;
+            T running = sp[start];
+            dp[start] = running;
+            for (int k = 1; k < cols; k++) {
+                int c = start + step * k;
+                T v = sp[c];
+                switch (op) {
+                    case 0: running = (T)((Acc)running + (Acc)v); break;
+                    case 1: running = (T)((Acc)running * (Acc)v); break;
+                    case 2: running = evision_scan_min(running, v); break;
+                    case 3: running = evision_scan_max(running, v); break;
+                }
+                dp[c] = running;
             }
-            dp[c] = running;
         }
-    }
+    });
 }
 
 // @evision c: mat_cumulative, evision_cv_mat_cumulative, 1

--- a/c_src/modules/evision_backend/gather.h
+++ b/c_src/modules/evision_backend/gather.h
@@ -1,11 +1,13 @@
 #ifndef EVISION_BACKEND_GATHER_H
 #define EVISION_BACKEND_GATHER_H
 
+#include <atomic>
 #include <cstring>
 #include <vector>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Gather over the leading axes (Nx.gather). The tensor is pre-transposed so the
 // indexed axes lead; each consecutive `depth`-tuple in `indices` is a coordinate
@@ -56,18 +58,29 @@ static ERL_NIF_TERM evision_cv_mat_gather(ErlNifEnv *env, int argc, const ERL_NI
             Mat dst(1, (int)(num_gathers * inner), src.type());
             uchar *dp = dst.data;
 
-            for (int64_t g = 0; g < num_gathers; g++) {
-                int64_t offset = 0;
-                for (int64_t k = 0; k < depth; k++) {
-                    int64_t c = ip[g * depth + k];
-                    if (c < 0 || c >= dimp[(size_t)k])
-                        return evision::nif::error(env, "gather: index out of bounds");
-                    offset += c * mult[(size_t)k];
+            std::atomic<bool> bad_index(false);
+            int64_t work = num_gathers * (inner > 0 ? inner : 1);
+            evision_parallel_for(num_gathers, work, [&](int64_t begin, int64_t end) {
+                for (int64_t g = begin; g < end; g++) {
+                    int64_t offset = 0;
+                    for (int64_t k = 0; k < depth; k++) {
+                        int64_t c = ip[g * depth + k];
+                        if (c < 0 || c >= dimp[(size_t)k]) {
+                            bad_index.store(true, std::memory_order_relaxed);
+                            offset = -1;
+                            break;
+                        }
+                        offset += c * mult[(size_t)k];
+                    }
+                    if (offset >= 0) {
+                        std::memcpy(dp + (size_t)g * inner_bytes,
+                                    sp + (size_t)offset * elem_size,
+                                    inner_bytes);
+                    }
                 }
-                std::memcpy(dp + (size_t)g * inner_bytes,
-                            sp + (size_t)offset * elem_size,
-                            inner_bytes);
-            }
+            });
+            if (bad_index.load(std::memory_order_relaxed))
+                return evision::nif::error(env, "gather: index out of bounds");
             return evision_from(env, dst);
         }
     }

--- a/c_src/modules/evision_backend/gather.h
+++ b/c_src/modules/evision_backend/gather.h
@@ -27,9 +27,9 @@ static ERL_NIF_TERM evision_cv_mat_gather(ErlNifEnv *env, int argc, const ERL_NI
         Mat src, indices, dims;
         int inner = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "dims"), dims, ArgInfo("dims", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "dims"), dims, ArgInfo("dims", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "inner"), inner, ArgInfo("inner", 0))) {
             Mat src_c = src.isContinuous() ? src : src.clone();
             Mat idx_c = indices.isContinuous() ? indices : indices.clone();

--- a/c_src/modules/evision_backend/parallel.h
+++ b/c_src/modules/evision_backend/parallel.h
@@ -1,17 +1,42 @@
 #ifndef EVISION_BACKEND_PARALLEL_H
 #define EVISION_BACKEND_PARALLEL_H
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <opencv2/core/utility.hpp>
 
+// Minimum total scalar work before a loop is handed to cv::parallel_for_. The
+// fixed cost of waking the thread pool is on the order of ~10us, so the floor is
+// set where the serial run clears that by a wide margin while still keeping
+// small tensors single-threaded. The tiers scale with the per-element cost:
+// MIN/SIMPLE cover flat elementwise and row-wise passes, NESTED/CONV cover the
+// kernels whose inner loop also does per-output index math.
 static constexpr int64_t EVISION_PARALLEL_MIN_WORK = 32768;
-static constexpr int64_t EVISION_PARALLEL_SIMPLE_MIN_WORK = 1048576;
-static constexpr int64_t EVISION_PARALLEL_NESTED_MIN_WORK = 4194304;
-static constexpr int64_t EVISION_PARALLEL_CONV_MIN_WORK = 16777216;
+static constexpr int64_t EVISION_PARALLEL_SIMPLE_MIN_WORK = 65536;
+static constexpr int64_t EVISION_PARALLEL_NESTED_MIN_WORK = 262144;
+static constexpr int64_t EVISION_PARALLEL_CONV_MIN_WORK = 262144;
+
+// Target scalar work per stripe. cv::parallel_for_ defaults nstripes to the full
+// range length (modules/core/src/parallel.cpp), which on the GCD backend
+// dispatches one block per index -- tens of ns of dispatch overhead per element,
+// which dwarfs a cheap body. We instead size the stripe count to the thread pool
+// so each worker processes a few large contiguous chunks.
+static constexpr int64_t EVISION_PARALLEL_STRIPE_WORK = 16384;
 
 static inline bool evision_should_parallelize(int64_t total, int64_t work, int64_t min_work) {
     return total > 0 && work >= min_work && total <= (int64_t)std::numeric_limits<int>::max();
+}
+
+// Stripe count: at least one per thread (so the pool is saturated), at most four
+// per thread (headroom for load balancing), scaled down when there is too little
+// work to keep a stripe busy, and never more than the range itself.
+static inline double evision_nstripes(int64_t total, int64_t work) {
+    int64_t threads = (int64_t)std::max(1, cv::getNumThreads());
+    int64_t target = work / EVISION_PARALLEL_STRIPE_WORK;
+    target = std::min(std::max(target, threads), threads * 4);
+    target = std::min(target, total);
+    return (double)std::max<int64_t>(target, 1);
 }
 
 template <typename Body>
@@ -24,7 +49,7 @@ static inline void evision_parallel_for(int64_t total, int64_t work, int64_t min
 
     cv::parallel_for_(cv::Range(0, (int)total), [&](const cv::Range &range) {
         body((int64_t)range.start, (int64_t)range.end);
-    });
+    }, evision_nstripes(total, work));
 }
 
 template <typename Body>

--- a/c_src/modules/evision_backend/parallel.h
+++ b/c_src/modules/evision_backend/parallel.h
@@ -1,0 +1,35 @@
+#ifndef EVISION_BACKEND_PARALLEL_H
+#define EVISION_BACKEND_PARALLEL_H
+
+#include <cstdint>
+#include <limits>
+#include <opencv2/core/utility.hpp>
+
+static constexpr int64_t EVISION_PARALLEL_MIN_WORK = 32768;
+static constexpr int64_t EVISION_PARALLEL_SIMPLE_MIN_WORK = 1048576;
+static constexpr int64_t EVISION_PARALLEL_NESTED_MIN_WORK = 4194304;
+static constexpr int64_t EVISION_PARALLEL_CONV_MIN_WORK = 16777216;
+
+static inline bool evision_should_parallelize(int64_t total, int64_t work, int64_t min_work) {
+    return total > 0 && work >= min_work && total <= (int64_t)std::numeric_limits<int>::max();
+}
+
+template <typename Body>
+static inline void evision_parallel_for(int64_t total, int64_t work, int64_t min_work, const Body &body) {
+    if (total <= 0) return;
+    if (!evision_should_parallelize(total, work, min_work)) {
+        body(0, total);
+        return;
+    }
+
+    cv::parallel_for_(cv::Range(0, (int)total), [&](const cv::Range &range) {
+        body((int64_t)range.start, (int64_t)range.end);
+    });
+}
+
+template <typename Body>
+static inline void evision_parallel_for(int64_t total, int64_t work, const Body &body) {
+    evision_parallel_for(total, work, EVISION_PARALLEL_MIN_WORK, body);
+}
+
+#endif // EVISION_BACKEND_PARALLEL_H

--- a/c_src/modules/evision_backend/predicate.h
+++ b/c_src/modules/evision_backend/predicate.h
@@ -5,6 +5,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Elementwise predicate -> u8 {0,1} (Nx.is_nan / is_infinity / logical_not).
 // op 0 = is_nan, 1 = is_infinity, 2 = is_zero (logical_not). The nan/inf checks go
@@ -16,17 +17,19 @@ static void evision_predicate(const cv::Mat &src, cv::Mat &dst, int op) {
     const T *sp = (const T *)src.data;
     unsigned char *dp = dst.data;
     size_t n = src.total();
-    for (size_t i = 0; i < n; i++) {
-        T x = sp[i];
-        unsigned char r = 0;
-        switch (op) {
-            case 0: r = std::isnan((double)x) ? 1 : 0; break;
-            case 1: r = std::isinf((double)x) ? 1 : 0; break;
-            case 2: r = (x == (T)0) ? 1 : 0; break;
-            default: break;
+    evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
+            T x = sp[(size_t)i];
+            unsigned char r = 0;
+            switch (op) {
+                case 0: r = std::isnan((double)x) ? 1 : 0; break;
+                case 1: r = std::isinf((double)x) ? 1 : 0; break;
+                case 2: r = (x == (T)0) ? 1 : 0; break;
+                default: break;
+            }
+            dp[(size_t)i] = r;
         }
-        dp[i] = r;
-    }
+    });
 }
 
 // @evision c: mat_predicate, evision_cv_mat_predicate, 1

--- a/c_src/modules/evision_backend/predicate.h
+++ b/c_src/modules/evision_backend/predicate.h
@@ -45,7 +45,7 @@ static ERL_NIF_TERM evision_cv_mat_predicate(ErlNifEnv *env, int argc, const ERL
         Mat src;
         int op = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
             Mat src_c = src.isContinuous() ? src : src.clone();
             Mat dst(1, (int)src_c.total(), CV_8U);

--- a/c_src/modules/evision_backend/reduce.h
+++ b/c_src/modules/evision_backend/reduce.h
@@ -2,17 +2,23 @@
 #define EVISION_BACKEND_REDUCE_H
 
 #include <cmath>
+#include <cstdint>
 #include <type_traits>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
 #include "parallel.h"
 
-// Row-wise reduction: sum (op 0) / product (op 1) accumulate left-to-right, max
-// (op 2) / min (op 3) seed from the first element. Input is a 2D single-channel
-// Mat already cast to the accumulator type (CV_64F / CV_64S / CV_64U) by the
-// caller, so integer promotion (s64/u64, modular) and f64 accumulation match Nx;
-// output is [rows, 1] of the same type.
+// Reduction of a 2D single-channel mat: sum (op 0) / product (op 1) accumulate
+// left-to-right, max (op 2) / min (op 3) seed from the first element. axis 1
+// reduces each row (trailing axis) into a [rows, 1] result; axis 0 reduces each
+// column (leading axis) into a [1, cols] result -- the caller picks axis 0 when
+// the reduced axes are leading so no transpose is needed.
+//
+// The input keeps its native dtype: sum/product promote each element to the wide
+// accumulator (f64 for floats, s64/u64 for ints, matching Nx integer promotion
+// and f64 float accumulation) in-register, so there is no separate cast pass and
+// only the native bytes are streamed. max/min do not promote (Nx keeps the type).
 
 template <typename T>
 static inline T evision_reduce_max(T acc, T v) {
@@ -30,30 +36,81 @@ static inline T evision_reduce_min(T acc, T v) {
     return (v < acc) ? v : acc;
 }
 
-template <typename T>
+// Wide accumulator for sum/product: floats accumulate in f64, signed ints in
+// s64, unsigned ints in u64 (unsigned wraparound is well-defined and matches
+// Nx's modular integer semantics).
+template <typename T> struct evision_reduce_acc { using type = T; };
+template <> struct evision_reduce_acc<float>    { using type = double; };
+template <> struct evision_reduce_acc<int8_t>   { using type = int64_t; };
+template <> struct evision_reduce_acc<int16_t>  { using type = int64_t; };
+template <> struct evision_reduce_acc<int32_t>  { using type = int64_t; };
+template <> struct evision_reduce_acc<uint8_t>  { using type = uint64_t; };
+template <> struct evision_reduce_acc<uint16_t> { using type = uint64_t; };
+template <> struct evision_reduce_acc<uint32_t> { using type = uint64_t; };
+
+template <typename Tin, typename Tacc>
 static void evision_reduce_rows(const cv::Mat &src, cv::Mat &dst, int op) {
-    evision_parallel_for(src.rows, (int64_t)src.rows * src.cols, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+    int cols = src.cols;
+    evision_parallel_for(src.rows, (int64_t)src.rows * cols, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
         for (int64_t row = begin; row < end; row++) {
-            const T *sp = src.ptr<T>((int)row);
-            T acc;
-            switch (op) {
-                case 1: acc = (T)1; break;
-                case 2: case 3: acc = sp[0]; break;
-                default: acc = (T)0; break;
-            }
+            const Tin *sp = src.ptr<Tin>((int)row);
+            Tacc acc = (op == 1) ? (Tacc)1 : (op == 2 || op == 3) ? (Tacc)sp[0] : (Tacc)0;
             int start = (op == 2 || op == 3) ? 1 : 0;
-            for (int c = start; c < src.cols; c++) {
-                T v = sp[c];
-                switch (op) {
-                    case 0: acc = (T)(acc + v); break;
-                    case 1: acc = (T)(acc * v); break;
-                    case 2: acc = evision_reduce_max(acc, v); break;
-                    case 3: acc = evision_reduce_min(acc, v); break;
-                }
+            switch (op) {
+                case 0: for (int c = start; c < cols; c++) acc = (Tacc)(acc + (Tacc)sp[c]); break;
+                case 1: for (int c = start; c < cols; c++) acc = (Tacc)(acc * (Tacc)sp[c]); break;
+                case 2: for (int c = start; c < cols; c++) acc = evision_reduce_max(acc, (Tacc)sp[c]); break;
+                case 3: for (int c = start; c < cols; c++) acc = evision_reduce_min(acc, (Tacc)sp[c]); break;
             }
-            dst.ptr<T>((int)row)[0] = acc;
+            dst.ptr<Tacc>((int)row)[0] = acc;
         }
     });
+}
+
+template <typename Tin, typename Tacc>
+static void evision_reduce_cols(const cv::Mat &src, cv::Mat &dst, int op) {
+    int rows = src.rows, cols = src.cols;
+    const Tin *sp = (const Tin *)src.data;
+    Tacc *dp = (Tacc *)dst.data;
+    evision_parallel_for(cols, (int64_t)rows * cols, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t cb, int64_t ce) {
+        switch (op) {
+            case 1: for (int64_t c = cb; c < ce; c++) dp[c] = (Tacc)1; break;
+            case 2: case 3: for (int64_t c = cb; c < ce; c++) dp[c] = (Tacc)sp[c]; break;
+            default: for (int64_t c = cb; c < ce; c++) dp[c] = (Tacc)0; break;
+        }
+        int rstart = (op == 2 || op == 3) ? 1 : 0;
+        for (int r = rstart; r < rows; r++) {
+            const Tin *row = sp + (int64_t)r * cols;
+            switch (op) {
+                case 0: for (int64_t c = cb; c < ce; c++) dp[c] = (Tacc)(dp[c] + (Tacc)row[c]); break;
+                case 1: for (int64_t c = cb; c < ce; c++) dp[c] = (Tacc)(dp[c] * (Tacc)row[c]); break;
+                case 2: for (int64_t c = cb; c < ce; c++) dp[c] = evision_reduce_max(dp[c], (Tacc)row[c]); break;
+                case 3: for (int64_t c = cb; c < ce; c++) dp[c] = evision_reduce_min(dp[c], (Tacc)row[c]); break;
+            }
+        }
+    });
+}
+
+template <typename Tin>
+static void evision_reduce_typed(const cv::Mat &src, cv::Mat &dst, int op, bool leading) {
+    if (op == 2 || op == 3) {
+        if (leading) evision_reduce_cols<Tin, Tin>(src, dst, op);
+        else evision_reduce_rows<Tin, Tin>(src, dst, op);
+    } else {
+        using Tacc = typename evision_reduce_acc<Tin>::type;
+        if (leading) evision_reduce_cols<Tin, Tacc>(src, dst, op);
+        else evision_reduce_rows<Tin, Tacc>(src, dst, op);
+    }
+}
+
+// Output depth: sum/product promote to the wide type; max/min keep the input type.
+static inline int evision_reduce_out_depth(int in_depth, int op) {
+    if (op == 2 || op == 3) return in_depth;
+    switch (in_depth) {
+        case CV_32F: case CV_64F: return CV_64F;
+        case CV_8U: case CV_16U: case CV_32U: case CV_64U: return CV_64U;
+        default: return CV_64S;
+    }
 }
 
 // @evision c: mat_reduce, evision_cv_mat_reduce, 1
@@ -67,15 +124,27 @@ static ERL_NIF_TERM evision_cv_mat_reduce(ErlNifEnv *env, int argc, const ERL_NI
 
     {
         Mat src;
-        int op = 0;
+        int op = 0, axis = 1;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
-            Mat dst(src.rows, 1, src.type());
-            switch (src.depth()) {
-                case CV_64F: evision_reduce_rows<double>(src, dst, op); break;
-                case CV_64S: evision_reduce_rows<int64_t>(src, dst, op); break;
-                case CV_64U: evision_reduce_rows<uint64_t>(src, dst, op); break;
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "axis"), axis, ArgInfo("axis", 0))) {
+            Mat src_c = src.isContinuous() ? src : src.clone();
+            bool leading = (axis == 0);
+            int out_depth = evision_reduce_out_depth(src_c.depth(), op);
+            Mat dst = leading ? Mat(1, src_c.cols, out_depth) : Mat(src_c.rows, 1, out_depth);
+
+            switch (src_c.depth()) {
+                case CV_8U:  evision_reduce_typed<uint8_t>(src_c, dst, op, leading); break;
+                case CV_8S:  evision_reduce_typed<int8_t>(src_c, dst, op, leading); break;
+                case CV_16U: evision_reduce_typed<uint16_t>(src_c, dst, op, leading); break;
+                case CV_16S: evision_reduce_typed<int16_t>(src_c, dst, op, leading); break;
+                case CV_32S: evision_reduce_typed<int32_t>(src_c, dst, op, leading); break;
+                case CV_32U: evision_reduce_typed<uint32_t>(src_c, dst, op, leading); break;
+                case CV_64S: evision_reduce_typed<int64_t>(src_c, dst, op, leading); break;
+                case CV_64U: evision_reduce_typed<uint64_t>(src_c, dst, op, leading); break;
+                case CV_32F: evision_reduce_typed<float>(src_c, dst, op, leading); break;
+                case CV_64F: evision_reduce_typed<double>(src_c, dst, op, leading); break;
                 default: return evision::nif::error(env, "mat_reduce: unsupported depth");
             }
             return evision_from(env, dst);

--- a/c_src/modules/evision_backend/reduce.h
+++ b/c_src/modules/evision_backend/reduce.h
@@ -6,6 +6,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Row-wise reduction: sum (op 0) / product (op 1) accumulate left-to-right, max
 // (op 2) / min (op 3) seed from the first element. Input is a 2D single-channel
@@ -31,26 +32,28 @@ static inline T evision_reduce_min(T acc, T v) {
 
 template <typename T>
 static void evision_reduce_rows(const cv::Mat &src, cv::Mat &dst, int op) {
-    for (int r = 0; r < src.rows; r++) {
-        const T *sp = src.ptr<T>(r);
-        T acc;
-        switch (op) {
-            case 1: acc = (T)1; break;
-            case 2: case 3: acc = sp[0]; break;
-            default: acc = (T)0; break;
-        }
-        int start = (op == 2 || op == 3) ? 1 : 0;
-        for (int c = start; c < src.cols; c++) {
-            T v = sp[c];
+    evision_parallel_for(src.rows, (int64_t)src.rows * src.cols, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t row = begin; row < end; row++) {
+            const T *sp = src.ptr<T>((int)row);
+            T acc;
             switch (op) {
-                case 0: acc = (T)(acc + v); break;
-                case 1: acc = (T)(acc * v); break;
-                case 2: acc = evision_reduce_max(acc, v); break;
-                case 3: acc = evision_reduce_min(acc, v); break;
+                case 1: acc = (T)1; break;
+                case 2: case 3: acc = sp[0]; break;
+                default: acc = (T)0; break;
             }
+            int start = (op == 2 || op == 3) ? 1 : 0;
+            for (int c = start; c < src.cols; c++) {
+                T v = sp[c];
+                switch (op) {
+                    case 0: acc = (T)(acc + v); break;
+                    case 1: acc = (T)(acc * v); break;
+                    case 2: acc = evision_reduce_max(acc, v); break;
+                    case 3: acc = evision_reduce_min(acc, v); break;
+                }
+            }
+            dst.ptr<T>((int)row)[0] = acc;
         }
-        dst.ptr<T>(r)[0] = acc;
-    }
+    });
 }
 
 // @evision c: mat_reduce, evision_cv_mat_reduce, 1

--- a/c_src/modules/evision_backend/reshape.h
+++ b/c_src/modules/evision_backend/reshape.h
@@ -17,7 +17,7 @@ static ERL_NIF_TERM evision_cv_mat_reshape(ErlNifEnv *env, int argc, const ERL_N
         Mat mat;
         std::vector<int> shape;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "mat"), mat, ArgInfo("mat", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "mat"), mat, ArgInfo("mat", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "shape"), shape, ArgInfo("shape", 0))) {
             Mat ret;
 

--- a/c_src/modules/evision_backend/select.h
+++ b/c_src/modules/evision_backend/select.h
@@ -5,6 +5,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Elementwise select (Nx.select): result = mask ? on_true : on_false. All three
 // have the same shape (broadcast by the caller); on_true/on_false are already the
@@ -34,10 +35,12 @@ static ERL_NIF_TERM evision_cv_mat_select(ErlNifEnv *env, int argc, const ERL_NI
             unsigned char *dp = dst.data;
             size_t elem_size = dst.elemSize();
             size_t n = dst.total();
-            for (size_t i = 0; i < n; i++) {
-                if (mp[i] == 0)
-                    std::memcpy(dp + i * elem_size, fp + i * elem_size, elem_size);
-            }
+            evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+                for (int64_t i = begin; i < end; i++) {
+                    if (mp[(size_t)i] == 0)
+                        std::memcpy(dp + (size_t)i * elem_size, fp + (size_t)i * elem_size, elem_size);
+                }
+            });
             return evision_from(env, dst);
         }
     }

--- a/c_src/modules/evision_backend/select.h
+++ b/c_src/modules/evision_backend/select.h
@@ -23,9 +23,9 @@ static ERL_NIF_TERM evision_cv_mat_select(ErlNifEnv *env, int argc, const ERL_NI
     {
         Mat mask, on_true, on_false;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "mask"), mask, ArgInfo("mask", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "on_true"), on_true, ArgInfo("on_true", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "on_false"), on_false, ArgInfo("on_false", 0))) {
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "mask"), mask, ArgInfo("mask", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "on_true"), on_true, ArgInfo("on_true", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "on_false"), on_false, ArgInfo("on_false", ArgInfo::INPUT_ONLY))) {
             Mat mc = mask.isContinuous() ? mask : mask.clone();
             Mat fc = on_false.isContinuous() ? on_false : on_false.clone();
             Mat dst = on_true.clone();

--- a/c_src/modules/evision_backend/shift.h
+++ b/c_src/modules/evision_backend/shift.h
@@ -50,8 +50,8 @@ static ERL_NIF_TERM evision_cv_mat_shift(ErlNifEnv *env, int argc, const ERL_NIF
         Mat l, r;
         int op = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "l"), l, ArgInfo("l", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "r"), r, ArgInfo("r", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
             Mat lc = l.isContinuous() ? l : l.clone();
             Mat rc = r.isContinuous() ? r : r.clone();

--- a/c_src/modules/evision_backend/shift.h
+++ b/c_src/modules/evision_backend/shift.h
@@ -6,6 +6,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Elementwise integer shift (Nx.left_shift / right_shift). `l` and `r` share the
 // output type and shape. op 0 = left (<<), 1 = right (>>). Left shifts compute in
@@ -21,17 +22,19 @@ static void evision_shift(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst, int 
     T *dp = (T *)dst.data;
     size_t n = l.total();
     uint64_t width = (uint64_t)(sizeof(T) * 8);
-    for (size_t i = 0; i < n; i++) {
-        T a = lp[i];
-        T b = rp[i];
-        if (op == 0) {
-            dp[i] = ((uint64_t)b >= width) ? (T)0 : (T)((U)a << b);
-        } else if ((uint64_t)b >= width) {
-            dp[i] = (std::is_signed<T>::value && a < 0) ? (T)(-1) : (T)0;
-        } else {
-            dp[i] = (T)(a >> b);
+    evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
+            T a = lp[(size_t)i];
+            T b = rp[(size_t)i];
+            if (op == 0) {
+                dp[(size_t)i] = ((uint64_t)b >= width) ? (T)0 : (T)((U)a << b);
+            } else if ((uint64_t)b >= width) {
+                dp[(size_t)i] = (std::is_signed<T>::value && a < 0) ? (T)(-1) : (T)0;
+            } else {
+                dp[(size_t)i] = (T)(a >> b);
+            }
         }
-    }
+    });
 }
 
 // @evision c: mat_shift, evision_cv_mat_shift, 1

--- a/c_src/modules/evision_backend/sort.h
+++ b/c_src/modules/evision_backend/sort.h
@@ -67,7 +67,7 @@ static ERL_NIF_TERM evision_cv_mat_sort_rows(ErlNifEnv *env, int argc, const ERL
         Mat src;
         int descending = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "descending"), descending, ArgInfo("descending", 0))) {
             Mat dst(src.rows, src.cols, src.type());
             switch (src.depth()) {
@@ -98,7 +98,7 @@ static ERL_NIF_TERM evision_cv_mat_argsort_rows(ErlNifEnv *env, int argc, const 
         Mat src;
         int descending = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "descending"), descending, ArgInfo("descending", 0))) {
             Mat dst(src.rows, src.cols, CV_32S);
             switch (src.depth()) {

--- a/c_src/modules/evision_backend/sort.h
+++ b/c_src/modules/evision_backend/sort.h
@@ -8,6 +8,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Row-wise sort/argsort for depths that need custom handling. Floats use Nx's
 // NaN order: ascending puts NaNs last, descending puts them first.
@@ -27,26 +28,30 @@ static inline bool evision_sort_before(T a, T b, bool descending) {
 
 template <typename T>
 static void evision_sort_rows(const cv::Mat &src, cv::Mat &dst, bool descending) {
-    for (int r = 0; r < src.rows; r++) {
-        const T *sp = src.ptr<T>(r);
-        T *dp = dst.ptr<T>(r);
-        std::copy(sp, sp + src.cols, dp);
-        std::sort(dp, dp + src.cols, [descending](T a, T b) {
-            return evision_sort_before(a, b, descending);
-        });
-    }
+    evision_parallel_for(src.rows, (int64_t)src.rows * src.cols, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t row = begin; row < end; row++) {
+            const T *sp = src.ptr<T>((int)row);
+            T *dp = dst.ptr<T>((int)row);
+            std::copy(sp, sp + src.cols, dp);
+            std::sort(dp, dp + src.cols, [descending](T a, T b) {
+                return evision_sort_before(a, b, descending);
+            });
+        }
+    });
 }
 
 template <typename T>
 static void evision_argsort_rows(const cv::Mat &src, cv::Mat &dst, bool descending) {
-    for (int r = 0; r < src.rows; r++) {
-        const T *sp = src.ptr<T>(r);
-        int32_t *dp = dst.ptr<int32_t>(r);
-        std::iota(dp, dp + src.cols, 0);
-        std::stable_sort(dp, dp + src.cols, [sp, descending](int32_t a, int32_t b) {
-            return evision_sort_before(sp[a], sp[b], descending);
-        });
-    }
+    evision_parallel_for(src.rows, (int64_t)src.rows * src.cols, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t row = begin; row < end; row++) {
+            const T *sp = src.ptr<T>((int)row);
+            int32_t *dp = dst.ptr<int32_t>((int)row);
+            std::iota(dp, dp + src.cols, 0);
+            std::stable_sort(dp, dp + src.cols, [sp, descending](int32_t a, int32_t b) {
+                return evision_sort_before(sp[a], sp[b], descending);
+            });
+        }
+    });
 }
 
 // @evision c: mat_sort_rows, evision_cv_mat_sort_rows, 1

--- a/c_src/modules/evision_backend/take.h
+++ b/c_src/modules/evision_backend/take.h
@@ -24,8 +24,8 @@ static ERL_NIF_TERM evision_cv_mat_take(ErlNifEnv *env, int argc, const ERL_NIF_
         Mat src, indices;
         int outer = 0, axis_dim = 0, inner = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "outer"), outer, ArgInfo("outer", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "axis_dim"), axis_dim, ArgInfo("axis_dim", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "inner"), inner, ArgInfo("inner", 0))) {
@@ -41,7 +41,10 @@ static ERL_NIF_TERM evision_cv_mat_take(ErlNifEnv *env, int argc, const ERL_NIF_
 
             int64_t copies = (int64_t)outer * num_idx;
             int64_t work = copies * (inner > 0 ? inner : 1);
-            if (!evision_should_parallelize(copies, work, EVISION_PARALLEL_SIMPLE_MIN_WORK)) {
+            // take is a scattered gather of `inner`-sized blocks; threading random
+            // reads only pays off once the blocks (or their count) are large, so it
+            // takes a higher bar than the contiguous elementwise kernels.
+            if (!evision_should_parallelize(copies, work, EVISION_PARALLEL_NESTED_MIN_WORK)) {
                 for (int64_t o = 0; o < outer; o++) {
                     for (int64_t i = 0; i < num_idx; i++) {
                         int64_t idx = ip[i];

--- a/c_src/modules/evision_backend/take.h
+++ b/c_src/modules/evision_backend/take.h
@@ -1,10 +1,12 @@
 #ifndef EVISION_BACKEND_TAKE_H
 #define EVISION_BACKEND_TAKE_H
 
+#include <atomic>
 #include <cstring>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Gather along one axis (Nx.take). Type-agnostic byte copy:
 // out[o, i, inner-block] = src[o, indices[i], inner-block], where o in [0,outer),
@@ -37,16 +39,43 @@ static ERL_NIF_TERM evision_cv_mat_take(ErlNifEnv *env, int argc, const ERL_NIF_
             Mat dst(1, (int)((int64_t)outer * num_idx * inner), src.type());
             uchar *dp = dst.data;
 
-            for (int64_t o = 0; o < outer; o++) {
-                for (int64_t i = 0; i < num_idx; i++) {
+            int64_t copies = (int64_t)outer * num_idx;
+            int64_t work = copies * (inner > 0 ? inner : 1);
+            if (!evision_should_parallelize(copies, work, EVISION_PARALLEL_SIMPLE_MIN_WORK)) {
+                for (int64_t o = 0; o < outer; o++) {
+                    for (int64_t i = 0; i < num_idx; i++) {
+                        int64_t idx = ip[i];
+                        if (idx < 0 || idx >= axis_dim)
+                            return evision::nif::error(env, "take: index out of bounds");
+                        std::memcpy(dp + (size_t)(o * num_idx + i) * inner_bytes,
+                                    sp + (size_t)(o * axis_dim + idx) * inner_bytes,
+                                    inner_bytes);
+                    }
+                }
+                return evision_from(env, dst);
+            }
+
+            std::atomic<bool> bad_index(false);
+            evision_parallel_for(num_idx, num_idx, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+                for (int64_t i = begin; i < end; i++) {
                     int64_t idx = ip[i];
                     if (idx < 0 || idx >= axis_dim)
-                        return evision::nif::error(env, "take: index out of bounds");
-                    std::memcpy(dp + (size_t)(o * num_idx + i) * inner_bytes,
+                        bad_index.store(true, std::memory_order_relaxed);
+                }
+            });
+            if (bad_index.load(std::memory_order_relaxed))
+                return evision::nif::error(env, "take: index out of bounds");
+
+            evision_parallel_for(copies, work, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+                for (int64_t p = begin; p < end; p++) {
+                    int64_t o = p / num_idx;
+                    int64_t i = p - o * num_idx;
+                    int64_t idx = ip[i];
+                    std::memcpy(dp + (size_t)p * inner_bytes,
                                 sp + (size_t)(o * axis_dim + idx) * inner_bytes,
                                 inner_bytes);
                 }
-            }
+            });
             return evision_from(env, dst);
         }
     }

--- a/c_src/modules/evision_backend/take_along_axis.h
+++ b/c_src/modules/evision_backend/take_along_axis.h
@@ -27,8 +27,8 @@ static ERL_NIF_TERM evision_cv_mat_take_along_axis(ErlNifEnv *env, int argc, con
         std::vector<int> in_dims, out_dims;
         int axis = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "indices"), indices, ArgInfo("indices", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "in_dims"), in_dims, ArgInfo("in_dims", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "out_dims"), out_dims, ArgInfo("out_dims", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "axis"), axis, ArgInfo("axis", 0))) {

--- a/c_src/modules/evision_backend/take_along_axis.h
+++ b/c_src/modules/evision_backend/take_along_axis.h
@@ -1,16 +1,18 @@
 #ifndef EVISION_BACKEND_TAKE_ALONG_AXIS_H
 #define EVISION_BACKEND_TAKE_ALONG_AXIS_H
 
+#include <atomic>
 #include <cstring>
 #include <vector>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Per-element gather along one axis (Nx.take_along_axis). out has the indices' shape;
 // out[j_0..j_{r-1}] = src[j with the `axis` coord replaced by indices[j]]. The non-axis
-// part of the input offset is tracked by an odometer (the axis stride is skipped), and
-// each element adds indices[p] * axis_stride. int64 indices, bounds-checked.
+// part of the input offset skips the axis stride, and each element adds
+// indices[p] * axis_stride. int64 indices, bounds-checked.
 // @evision c: mat_take_along_axis, evision_cv_mat_take_along_axis, 1
 // @evision nif: def mat_take_along_axis(_opts \\ []), do: :erlang.nif_error(:undefined)
 static ERL_NIF_TERM evision_cv_mat_take_along_axis(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
@@ -52,21 +54,27 @@ static ERL_NIF_TERM evision_cv_mat_take_along_axis(ErlNifEnv *env, int argc, con
             uchar *dp = dst.data;
 
             if (out_total > 0) {
-                std::vector<int64_t> idx((size_t)(r > 0 ? r : 1), 0);
-                int64_t base = 0;
-                for (int64_t p = 0; p < out_total; p++) {
-                    int64_t iv = ip[p];
-                    if (iv < 0 || iv >= axis_dim)
-                        return evision::nif::error(env, "take_along_axis: index out of bounds");
-                    std::memcpy(dp + (size_t)p * elem, sp + (size_t)(base + iv * axis_stride) * elem, elem);
-                    for (int k = r - 1; k >= 0; k--) {
-                        idx[(size_t)k]++;
-                        if (k != axis) base += in_stride[(size_t)k];
-                        if (idx[(size_t)k] < out_dims[(size_t)k]) break;
-                        idx[(size_t)k] = 0;
-                        if (k != axis) base -= (int64_t)out_dims[(size_t)k] * in_stride[(size_t)k];
+                std::atomic<bool> bad_index(false);
+                evision_parallel_for(out_total, out_total, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+                    for (int64_t p = begin; p < end; p++) {
+                        int64_t q = p;
+                        int64_t base = 0;
+                        for (int k = r - 1; k >= 0; k--) {
+                            int64_t coord = q % out_dims[(size_t)k];
+                            q /= out_dims[(size_t)k];
+                            if (k != axis) base += coord * in_stride[(size_t)k];
+                        }
+
+                        int64_t iv = ip[p];
+                        if (iv < 0 || iv >= axis_dim) {
+                            bad_index.store(true, std::memory_order_relaxed);
+                        } else {
+                            std::memcpy(dp + (size_t)p * elem, sp + (size_t)(base + iv * axis_stride) * elem, elem);
+                        }
                     }
-                }
+                });
+                if (bad_index.load(std::memory_order_relaxed))
+                    return evision::nif::error(env, "take_along_axis: index out of bounds");
             }
             return evision_from(env, dst);
         }

--- a/c_src/modules/evision_backend/unary_math.h
+++ b/c_src/modules/evision_backend/unary_math.h
@@ -5,6 +5,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Element-wise unary float math (Nx trig / hyperbolic / erf / etc.) that OpenCV
 // has no primitive for. The caller passes a single-channel f32/f64 mat already
@@ -14,30 +15,32 @@ template <typename T>
 static void evision_unary_math(cv::Mat &m, int op) {
     T *p = (T *)m.data;
     size_t n = m.total();
-    for (size_t i = 0; i < n; i++) {
-        T x = p[i];
-        switch (op) {
-            case 0:  p[i] = std::sin(x); break;
-            case 1:  p[i] = std::cos(x); break;
-            case 2:  p[i] = std::tan(x); break;
-            case 3:  p[i] = std::asin(x); break;
-            case 4:  p[i] = std::acos(x); break;
-            case 5:  p[i] = std::atan(x); break;
-            case 6:  p[i] = std::sinh(x); break;
-            case 7:  p[i] = std::cosh(x); break;
-            case 8:  p[i] = std::tanh(x); break;
-            case 9:  p[i] = std::asinh(x); break;
-            case 10: p[i] = std::acosh(x); break;
-            case 11: p[i] = std::atanh(x); break;
-            case 12: p[i] = std::erf(x); break;
-            case 13: p[i] = std::erfc(x); break;
-            case 14: p[i] = std::cbrt(x); break;
-            case 15: p[i] = std::log1p(x); break;
-            case 16: p[i] = (T)1 / std::sqrt(x); break;
-            case 17: p[i] = (T)1 / ((T)1 + std::exp(-x)); break;
-            default: break;
+    evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) {
+            T x = p[(size_t)i];
+            switch (op) {
+                case 0:  p[(size_t)i] = std::sin(x); break;
+                case 1:  p[(size_t)i] = std::cos(x); break;
+                case 2:  p[(size_t)i] = std::tan(x); break;
+                case 3:  p[(size_t)i] = std::asin(x); break;
+                case 4:  p[(size_t)i] = std::acos(x); break;
+                case 5:  p[(size_t)i] = std::atan(x); break;
+                case 6:  p[(size_t)i] = std::sinh(x); break;
+                case 7:  p[(size_t)i] = std::cosh(x); break;
+                case 8:  p[(size_t)i] = std::tanh(x); break;
+                case 9:  p[(size_t)i] = std::asinh(x); break;
+                case 10: p[(size_t)i] = std::acosh(x); break;
+                case 11: p[(size_t)i] = std::atanh(x); break;
+                case 12: p[(size_t)i] = std::erf(x); break;
+                case 13: p[(size_t)i] = std::erfc(x); break;
+                case 14: p[(size_t)i] = std::cbrt(x); break;
+                case 15: p[(size_t)i] = std::log1p(x); break;
+                case 16: p[(size_t)i] = (T)1 / std::sqrt(x); break;
+                case 17: p[(size_t)i] = (T)1 / ((T)1 + std::exp(-x)); break;
+                default: break;
+            }
         }
-    }
+    });
 }
 
 // @evision c: mat_unary_math, evision_cv_mat_unary_math, 1

--- a/c_src/modules/evision_backend/unary_math.h
+++ b/c_src/modules/evision_backend/unary_math.h
@@ -56,7 +56,7 @@ static ERL_NIF_TERM evision_cv_mat_unary_math(ErlNifEnv *env, int argc, const ER
         Mat src;
         int op = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
             Mat dst = src.clone();
             switch (dst.depth()) {

--- a/c_src/modules/evision_backend/window.h
+++ b/c_src/modules/evision_backend/window.h
@@ -9,6 +9,7 @@
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 #include "../evision_mat_utils.hpp"
+#include "parallel.h"
 
 // Sliding-window ops (Nx.window_*). Windows preserve the input dtype (no accumulator
 // upcast, unlike reduce), so everything is templated over the element type T; f16/bf16 are
@@ -59,36 +60,78 @@ static void window_reduce_typed(const T *sp, T *dp, int r,
     for (int k = 0; k < r; k++) { out_total *= out_dims[(size_t)k]; win_total *= win_dims[(size_t)k]; }
 
     T init = window_identity<T>(op);
-    std::vector<int> op_idx((size_t)r, 0), w_idx((size_t)r, 0);
+    int64_t work = out_total * (win_total > 0 ? win_total : 1);
 
-    for (int64_t p = 0; p < out_total; p++) {
-        T av = init;
-        std::fill(w_idx.begin(), w_idx.end(), 0);
+    if (!evision_should_parallelize(out_total, work, EVISION_PARALLEL_NESTED_MIN_WORK)) {
+        std::vector<int> op_idx((size_t)r, 0), w_idx((size_t)r, 0);
+        for (int64_t p = 0; p < out_total; p++) {
+            T av = init;
+            std::fill(w_idx.begin(), w_idx.end(), 0);
 
-        for (int64_t wq = 0; wq < win_total; wq++) {
-            bool inrange = true;
-            int64_t soff = 0;
-            for (int k = 0; k < r; k++) {
-                int64_t s = (int64_t)op_idx[(size_t)k] * strides[(size_t)k] +
-                            (int64_t)w_idx[(size_t)k] * dil[(size_t)k] - pad_lo[(size_t)k];
-                if (s < 0 || s >= in_dims[(size_t)k]) { inrange = false; break; }
-                soff += s * in_stride[(size_t)k];
-            }
-            if (inrange) {
-                T x = sp[soff];
-                switch (op) {
-                    case 0: av = (T)(av + x); break;
-                    case 1: av = (T)(av * x); break;
-                    case 2: av = window_max_value(av, x); break;
-                    case 3: av = window_min_value(av, x); break;
+            for (int64_t wq = 0; wq < win_total; wq++) {
+                bool inrange = true;
+                int64_t soff = 0;
+                for (int k = 0; k < r; k++) {
+                    int64_t s = (int64_t)op_idx[(size_t)k] * strides[(size_t)k] +
+                                (int64_t)w_idx[(size_t)k] * dil[(size_t)k] - pad_lo[(size_t)k];
+                    if (s < 0 || s >= in_dims[(size_t)k]) { inrange = false; break; }
+                    soff += s * in_stride[(size_t)k];
                 }
+                if (inrange) {
+                    T x = sp[soff];
+                    switch (op) {
+                        case 0: av = (T)(av + x); break;
+                        case 1: av = (T)(av * x); break;
+                        case 2: av = window_max_value(av, x); break;
+                        case 3: av = window_min_value(av, x); break;
+                    }
+                }
+                for (int k = r - 1; k >= 0; k--) { if (++w_idx[(size_t)k] < win_dims[(size_t)k]) break; w_idx[(size_t)k] = 0; }
             }
-            for (int k = r - 1; k >= 0; k--) { if (++w_idx[(size_t)k] < win_dims[(size_t)k]) break; w_idx[(size_t)k] = 0; }
+
+            dp[p] = av;
+            for (int k = r - 1; k >= 0; k--) { if (++op_idx[(size_t)k] < out_dims[(size_t)k]) break; op_idx[(size_t)k] = 0; }
+        }
+        return;
+    }
+
+    evision_parallel_for(out_total, work, EVISION_PARALLEL_NESTED_MIN_WORK, [&](int64_t begin, int64_t end) {
+        std::vector<int> op_idx((size_t)r, 0), w_idx((size_t)r, 0);
+        int64_t q = begin;
+        for (int k = r - 1; k >= 0; k--) {
+            op_idx[(size_t)k] = (int)(q % out_dims[(size_t)k]);
+            q /= out_dims[(size_t)k];
         }
 
-        dp[p] = av;
-        for (int k = r - 1; k >= 0; k--) { if (++op_idx[(size_t)k] < out_dims[(size_t)k]) break; op_idx[(size_t)k] = 0; }
-    }
+        for (int64_t p = begin; p < end; p++) {
+            T av = init;
+            std::fill(w_idx.begin(), w_idx.end(), 0);
+
+            for (int64_t wq = 0; wq < win_total; wq++) {
+                bool inrange = true;
+                int64_t soff = 0;
+                for (int k = 0; k < r; k++) {
+                    int64_t s = (int64_t)op_idx[(size_t)k] * strides[(size_t)k] +
+                                (int64_t)w_idx[(size_t)k] * dil[(size_t)k] - pad_lo[(size_t)k];
+                    if (s < 0 || s >= in_dims[(size_t)k]) { inrange = false; break; }
+                    soff += s * in_stride[(size_t)k];
+                }
+                if (inrange) {
+                    T x = sp[soff];
+                    switch (op) {
+                        case 0: av = (T)(av + x); break;
+                        case 1: av = (T)(av * x); break;
+                        case 2: av = window_max_value(av, x); break;
+                        case 3: av = window_min_value(av, x); break;
+                    }
+                }
+                for (int k = r - 1; k >= 0; k--) { if (++w_idx[(size_t)k] < win_dims[(size_t)k]) break; w_idx[(size_t)k] = 0; }
+            }
+
+            dp[p] = av;
+            for (int k = r - 1; k >= 0; k--) { if (++op_idx[(size_t)k] < out_dims[(size_t)k]) break; op_idx[(size_t)k] = 0; }
+        }
+    });
 }
 
 #define EVISION_WINDOW_DISPATCH(FN, SRC, DST, ...)                              \
@@ -163,7 +206,9 @@ static void window_scatter_typed(const T *sp, const T *srcvals, T *dp, int r,
         grid_total *= grid[(size_t)k];
         win_total *= win_dims[(size_t)k];
     }
-    for (int64_t i = 0; i < in_total; i++) dp[i] = init;
+    evision_parallel_for(in_total, in_total, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; i++) dp[i] = init;
+    });
 
     std::vector<int> g_idx((size_t)r, 0), w_idx((size_t)r, 0);
     for (int64_t p = 0; p < grid_total; p++) {

--- a/c_src/modules/evision_backend/window.h
+++ b/c_src/modules/evision_backend/window.h
@@ -163,7 +163,7 @@ static ERL_NIF_TERM evision_cv_mat_window_reduce(ErlNifEnv *env, int argc, const
         std::vector<int> in_dims, out_dims, win_dims, strides, pad_lo, dil;
         int op = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "in_dims"), in_dims, ArgInfo("in_dims", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "out_dims"), out_dims, ArgInfo("out_dims", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "win_dims"), win_dims, ArgInfo("win_dims", 0)) &&
@@ -257,8 +257,8 @@ static ERL_NIF_TERM evision_cv_mat_window_scatter(ErlNifEnv *env, int argc, cons
         double init = 0.0;
         int op = 0;
 
-        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", 0)) &&
-            evision_to_safe(env, evision_get_kw(env, erl_terms, "source"), source, ArgInfo("source", 0)) &&
+        if (evision_to_safe(env, evision_get_kw(env, erl_terms, "src"), src, ArgInfo("src", ArgInfo::INPUT_ONLY)) &&
+            evision_to_safe(env, evision_get_kw(env, erl_terms, "source"), source, ArgInfo("source", ArgInfo::INPUT_ONLY)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "init"), init, ArgInfo("init", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "in_dims"), in_dims, ArgInfo("in_dims", 0)) &&
             evision_to_safe(env, evision_get_kw(env, erl_terms, "win_dims"), win_dims, ArgInfo("win_dims", 0)) &&

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -1278,28 +1278,44 @@ defmodule Evision.Backend do
     {Nx.slice_along_axis(values, 0, k, axis: axis), Nx.slice_along_axis(indices, 0, k, axis: axis)}
   end
 
-  # Reduce `op` (0 sum, 1 product) over `opts[:axes]` (nil = all axes). Cast to the
-  # accumulator type so integer promotion (s64/u64) and f64 float accumulation match
-  # Nx, move the reduced axes to the end, flatten to [keep, reduce], reduce per row.
+  # Reduce `op` (0 sum, 1 product, 2 max, 3 min) over `opts[:axes]` (nil = all axes).
+  # The reduce NIF reads the native dtype and promotes per element (sum/product use a
+  # s64/u64/f64 accumulator to match Nx), so no input cast is needed. The reduced axes
+  # are flattened against the kept axes: trailing -> reduce each row, leading -> reduce
+  # each column (no transpose), interleaved -> transpose them last then reduce per row.
   defp reduce_aggregate(%T{type: out_type, shape: out_shape} = out, %T{shape: shape} = tensor, opts, op) do
     rank = tuple_size(shape)
     axes = all_axes(rank)
     reduce_axes = Enum.sort(opts[:axes] || axes)
-    perm = (axes -- reduce_axes) ++ reduce_axes
-    keep_size = sizes_product(shape, axes -- reduce_axes)
+    keep_axes = axes -- reduce_axes
+    keep_size = sizes_product(shape, keep_axes)
     reduce_size = sizes_product(shape, reduce_axes)
+    mat = from_nx(tensor)
 
-    mat = as_mat_type(from_nx(tensor), accumulator_type(out_type))
+    reduced =
+      cond do
+        keep_axes ++ reduce_axes == axes ->
+          mat
+          |> Evision.Mat.reshape([keep_size, reduce_size])
+          |> reject_error()
+          |> Evision.Mat.reduce_rows(op)
 
-    transposed =
-      if perm == axes,
-        do: mat,
-        else: reject_error(Evision.Mat.transpose(mat, perm, as_shape: shape))
+        reduce_axes ++ keep_axes == axes ->
+          mat
+          |> Evision.Mat.reshape([reduce_size, keep_size])
+          |> reject_error()
+          |> Evision.Mat.reduce_cols(op)
 
-    transposed
-    |> Evision.Mat.reshape([keep_size, reduce_size])
-    |> reject_error()
-    |> Evision.Mat.reduce_rows(op)
+        true ->
+          mat
+          |> Evision.Mat.transpose(keep_axes ++ reduce_axes, as_shape: shape)
+          |> reject_error()
+          |> Evision.Mat.reshape([keep_size, reduce_size])
+          |> reject_error()
+          |> Evision.Mat.reduce_rows(op)
+      end
+
+    reduced
     |> reject_error()
     |> as_mat_type(out_type)
     |> Evision.Mat.reshape(reduce_out_dims(out_shape))
@@ -1311,10 +1327,6 @@ defmodule Evision.Backend do
   defp all_axes(rank), do: Enum.to_list(0..(rank - 1))
 
   defp sizes_product(shape, axes), do: Enum.reduce(axes, 1, &(elem(shape, &1) * &2))
-
-  defp accumulator_type({:u, _}), do: {:u, 64}
-  defp accumulator_type({:s, _}), do: {:s, 64}
-  defp accumulator_type(_float), do: {:f, 64}
 
   defp reduce_out_dims({}), do: [1]
   defp reduce_out_dims(shape), do: Tuple.to_list(shape)
@@ -1640,7 +1652,8 @@ defmodule Evision.Backend do
       norm_list(opts[:input_dilation], d),
       norm_list(opts[:kernel_dilation], d),
       opts[:feature_group_size],
-      opts[:batch_group_size]
+      opts[:batch_group_size],
+      conv_im2row_budget()
     )
     |> reject_error()
     |> Evision.Mat.reshape(Tuple.to_list(canon_shape))
@@ -1650,6 +1663,14 @@ defmodule Evision.Backend do
     |> Nx.as_type(out_type)
     |> from_nx()
     |> to_nx(out)
+  end
+
+  # Memory budget (bytes) for the conv im2row fast-path buffers; 0 = NIF default. The
+  # process-local override is set per-test (each ExUnit test runs in its own process, so
+  # it never leaks across parallel tests); the application config is the global knob.
+  defp conv_im2row_budget do
+    Process.get(:evision_conv_im2row_budget_bytes) ||
+      Application.get_env(:evision, :conv_im2row_budget_bytes, 0)
   end
 
   # {product of leading dims, second-last dim, last dim} for a batched matrix shape.

--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -1243,12 +1243,19 @@ defmodule Evision.Mat do
   end
 
   @doc false
-  # Row-wise reduction (op 0=sum, 1=product, 2=max, 3=min) of an accumulator-typed
-  # mat (f64/s64/u64); returns a [rows, 1] mat.
+  # Reduction (op 0=sum, 1=product, 2=max, 3=min) of a native-dtype 2D mat over the
+  # trailing axis; returns a [rows, 1] mat. sum/product promote to the wide type
+  # (f64/s64/u64), max/min keep the input type.
   def reduce_rows(mat, op) do
-    mat = from_struct(mat)
+    :evision_nif.mat_reduce(src: from_struct(mat), op: op, axis: 1)
+    |> Evision.Internal.Structurise.to_struct()
+  end
 
-    :evision_nif.mat_reduce(src: mat, op: op)
+  @doc false
+  # Same as reduce_rows but over the leading axis; returns a [1, cols] mat. Lets the
+  # caller reduce leading axes without first transposing them to the end.
+  def reduce_cols(mat, op) do
+    :evision_nif.mat_reduce(src: from_struct(mat), op: op, axis: 0)
     |> Evision.Internal.Structurise.to_struct()
   end
 
@@ -1408,7 +1415,7 @@ defmodule Evision.Mat do
   @doc false
   # N-d cross-correlation (Nx.conv) on canonical-layout f32/f64 inputs. `input` is
   # [N, Cin, *sp], `kernel` [O, Cin/G, *sp]; the result is the canonical [N/Bg, O, *sp].
-  def conv(input, kernel, in_shape, k_shape, out_shape, strides, pad_lo, input_dilation, kernel_dilation, feature_groups, batch_groups) do
+  def conv(input, kernel, in_shape, k_shape, out_shape, strides, pad_lo, input_dilation, kernel_dilation, feature_groups, batch_groups, im2row_budget \\ 0) do
     :evision_nif.mat_conv(
       input: from_struct(input),
       kernel: from_struct(kernel),
@@ -1420,7 +1427,8 @@ defmodule Evision.Mat do
       input_dilation: input_dilation,
       kernel_dilation: kernel_dilation,
       feature_groups: feature_groups,
-      batch_groups: batch_groups
+      batch_groups: batch_groups,
+      im2row_budget: im2row_budget
     )
     |> Evision.Internal.Structurise.to_struct()
   end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -117,6 +117,18 @@ defmodule Evision.Backend.Test do
         assert_same(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
       end
     end
+
+    test "match Nx.BinaryBackend for larger row-wise inputs" do
+      t =
+        Nx.iota({96, 512}, type: :s64)
+        |> Nx.multiply(17)
+        |> Nx.remainder(1009)
+        |> Nx.as_type(:f32)
+
+      for fun <- [:sort, :argsort], opts <- [[axis: 1], [axis: 1, direction: :desc]] do
+        assert_same(apply(Nx, fun, [ev(t), opts]), apply(Nx, fun, [t, opts]))
+      end
+    end
   end
 
   describe "sum/product" do
@@ -148,6 +160,16 @@ defmodule Evision.Backend.Test do
       end
     end
 
+    test "sum matches Nx.BinaryBackend for larger row-wise inputs" do
+      t =
+        Nx.iota({96, 512}, type: :f32)
+        |> Nx.multiply(0.25)
+        |> Nx.subtract(64.0)
+
+      close_at(Nx.sum(ev(t), axes: [1]), Nx.sum(t, axes: [1]), 1.0e-4)
+      close_at(Nx.sum(ev(t), axes: [0]), Nx.sum(t, axes: [0]), 1.0e-4)
+    end
+
     test "cumulative max/min propagate NaNs like Nx.BinaryBackend" do
       t = Nx.tensor([1.0, :nan, 2.0], type: :f32)
 
@@ -170,6 +192,22 @@ defmodule Evision.Backend.Test do
 
       for t <- tensors, axis <- 0..(Nx.rank(t) - 1), idx <- index_sets do
         assert_same(Nx.take(ev(t), ev(idx), axis: axis), Nx.take(t, idx, axis: axis))
+      end
+    end
+
+    test "matches Nx.BinaryBackend for larger copied blocks" do
+      t = Nx.iota({32, 64, 8}, type: :s32)
+      idx = Nx.remainder(Nx.iota({512}, type: :s64), 64)
+
+      assert_same(Nx.take(ev(t), ev(idx), axis: 1), Nx.take(t, idx, axis: 1))
+    end
+
+    test "raises on out-of-bounds indices" do
+      t = Nx.tensor([10, 20, 30])
+      idx = Nx.tensor([0, 3])
+
+      assert_raise RuntimeError, ~r/take: index out of bounds/, fn ->
+        Nx.take(ev(t), ev(idx), axis: 0)
       end
     end
   end
@@ -200,6 +238,23 @@ defmodule Evision.Backend.Test do
 
       for {t, idx, opts} <- cases do
         assert_same(Nx.gather(ev(t), ev(idx), opts), Nx.gather(t, idx, opts))
+      end
+    end
+
+    test "matches Nx.BinaryBackend for larger leading-axis gathers" do
+      t = Nx.iota({32, 32, 4}, type: :s32)
+      g = Nx.iota({8192}, type: :s64)
+      idx = Nx.stack([Nx.remainder(g, 32), Nx.remainder(Nx.quotient(g, 32), 32)], axis: 1)
+
+      assert_same(Nx.gather(ev(t), ev(idx), axes: [0, 1]), Nx.gather(t, idx, axes: [0, 1]))
+    end
+
+    test "raises on out-of-bounds coordinates" do
+      t = Nx.tensor([[1, 2], [3, 4]])
+      idx = Nx.tensor([[0, 0], [2, 1]])
+
+      assert_raise RuntimeError, ~r/gather: index out of bounds/, fn ->
+        Nx.gather(ev(t), ev(idx))
       end
     end
   end
@@ -291,6 +346,21 @@ defmodule Evision.Backend.Test do
         assert_close(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
       end
     end
+
+    test "match Nx.BinaryBackend for larger row-wise scans" do
+      t =
+        Nx.iota({96, 512}, type: :f32)
+        |> Nx.multiply(0.25)
+        |> Nx.subtract(64.0)
+
+      close_at(Nx.cumulative_sum(ev(t), axis: 1), Nx.cumulative_sum(t, axis: 1), 1.0e-3)
+
+      close_at(
+        Nx.cumulative_max(ev(t), axis: 0, reverse: true),
+        Nx.cumulative_max(t, axis: 0, reverse: true),
+        1.0e-5
+      )
+    end
   end
 
   describe "elementwise unary math" do
@@ -326,6 +396,14 @@ defmodule Evision.Backend.Test do
       f16_t = Nx.tensor([0.5, 1.0, 2.0], type: :f16)
       assert_close(Nx.tanh(ev(f16_t)), Nx.tanh(f16_t))
       assert_close(Nx.sqrt(ev(f16_t)), Nx.sqrt(f16_t))
+    end
+
+    test "match Nx.BinaryBackend for larger elementwise inputs" do
+      t =
+        Nx.iota({256, 256}, type: :f32)
+        |> Nx.divide(100.0)
+
+      assert_close(Nx.sin(ev(t)), Nx.sin(t))
     end
   end
 
@@ -371,6 +449,17 @@ defmodule Evision.Backend.Test do
       t = Nx.tensor([[1.0, :nan, 2.0], [3.0, 4.0, 5.0]], type: :f32)
 
       for op <- [:reduce_max, :reduce_min], opts <- [[], [axes: [1]], [axes: [1], keep_axes: true]] do
+        assert_same(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
+      end
+    end
+
+    test "reduce_max/min match Nx.BinaryBackend for larger row-wise inputs" do
+      t =
+        Nx.iota({96, 512}, type: :f32)
+        |> Nx.multiply(-3.0)
+        |> Nx.add(7.0)
+
+      for op <- [:reduce_max, :reduce_min], opts <- [[axes: [1]], [axes: [0]]] do
         assert_same(apply(Nx, op, [ev(t), opts]), apply(Nx, op, [t, opts]))
       end
     end
@@ -609,6 +698,31 @@ defmodule Evision.Backend.Test do
           Nx.take_along_axis(ev(tt), ev(idx), axis: axis),
           Nx.take_along_axis(tt, idx, axis: axis)
         )
+      end
+    end
+
+    test "take_along_axis matches Nx.BinaryBackend for larger axis choices" do
+      t = Nx.iota({64, 512}, type: :s32)
+      axis0_idx = Nx.remainder(Nx.iota({64, 512}, type: :s64), 64)
+      axis1_idx = Nx.remainder(Nx.iota({64, 512}, type: :s64), 512)
+
+      assert_same(
+        Nx.take_along_axis(ev(t), ev(axis0_idx), axis: 0),
+        Nx.take_along_axis(t, axis0_idx, axis: 0)
+      )
+
+      assert_same(
+        Nx.take_along_axis(ev(t), ev(axis1_idx), axis: 1),
+        Nx.take_along_axis(t, axis1_idx, axis: 1)
+      )
+    end
+
+    test "take_along_axis raises on out-of-bounds indices" do
+      t = Nx.tensor([[1, 2, 3], [4, 5, 6]])
+      idx = Nx.tensor([[0, 3, 1], [1, 0, 2]])
+
+      assert_raise RuntimeError, ~r/take_along_axis: index out of bounds/, fn ->
+        Nx.take_along_axis(ev(t), ev(idx), axis: 1)
       end
     end
 
@@ -857,6 +971,17 @@ defmodule Evision.Backend.Test do
         assert_same(apply(Nx, op, [ev(t), {2}]), apply(Nx, op, [t, {2}]))
       end
     end
+
+    test "match Nx.BinaryBackend for larger padded windows" do
+      t =
+        Nx.iota({64, 64}, type: :f32)
+        |> Nx.divide(10.0)
+
+      opts = [padding: :same, window_dilations: [1, 2]]
+
+      close_at(Nx.window_sum(ev(t), {3, 3}, opts), Nx.window_sum(t, {3, 3}, opts), 1.0e-4)
+      assert_same(Nx.window_max(ev(t), {3, 3}, opts), Nx.window_max(t, {3, 3}, opts))
+    end
   end
 
   describe "window_scatter_max / window_scatter_min" do
@@ -932,6 +1057,20 @@ defmodule Evision.Backend.Test do
       bk = Nx.iota({2, 2, 2, 2}, type: :f32)
       bo = [batch_group_size: 2]
       assert_close(Nx.conv(ev(bimg), ev(bk), bo), Nx.conv(bimg, bk, bo))
+    end
+
+    test "matches Nx.BinaryBackend for larger grouped convolution" do
+      img =
+        Nx.iota({2, 4, 16, 16}, type: :f32)
+        |> Nx.divide(100.0)
+
+      kernel =
+        Nx.iota({4, 2, 3, 3}, type: :f32)
+        |> Nx.divide(50.0)
+
+      opts = [feature_group_size: 2, padding: :same, strides: [1, 2], kernel_dilation: [1, 2]]
+
+      assert_close(Nx.conv(ev(img), ev(kernel), opts), Nx.conv(img, kernel, opts))
     end
   end
 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -53,6 +53,56 @@ defmodule Evision.Backend.Test do
     end
   end
 
+  describe "input immutability (shared-buffer safety)" do
+    # Read-only NIFs share a cv-owned source buffer instead of deep-copying it, so a
+    # reshape (or any internal pipeline that reshapes) can alias its input. These
+    # assert that operating on a derived tensor never writes back into the original.
+    for type <- [:f32, :s32] do
+      test "ops on a reshape do not mutate the original (#{type})" do
+        a = Nx.iota({32, 32}, type: unquote(type)) |> Nx.add(1) |> ev()
+        a0 = Nx.to_binary(a)
+
+        b = Nx.reshape(a, {1024})
+        b0 = Nx.to_binary(b)
+
+        _ = Nx.add(b, 7)
+        _ = Nx.negate(b)
+        _ = Nx.sum(b)
+        _ = Nx.sort(Nx.reshape(b, {32, 32}), axis: 1)
+
+        assert Nx.to_binary(a) == a0
+        assert Nx.to_binary(b) == b0
+      end
+
+      test "reduction/scan/sort pipelines leave their input intact (#{type})" do
+        a = Nx.iota({24, 48}, type: unquote(type)) |> Nx.add(1) |> ev()
+        a0 = Nx.to_binary(a)
+
+        _ = Nx.sum(a, axes: [1])
+        _ = Nx.reduce_max(a, axes: [0])
+        _ = Nx.cumulative_sum(a, axis: 1)
+        _ = Nx.sort(a, axis: 1)
+
+        assert Nx.to_binary(a) == a0
+      end
+    end
+
+    test "multiple live aliases stay independent under GC" do
+      a = Nx.iota({64, 64}, type: :f32) |> Nx.add(1.0) |> ev()
+      a0 = Nx.to_binary(a)
+
+      Enum.each(1..100, fn i ->
+        view = Nx.reshape(a, {4096})
+        _ = Nx.add(view, i * 1.0)
+        _ = Nx.sum(view)
+        if rem(i, 10) == 0, do: :erlang.garbage_collect()
+      end)
+
+      :erlang.garbage_collect()
+      assert Nx.to_binary(a) == a0
+    end
+  end
+
   describe "argmax/argmin (index family)" do
     test "match Nx.BinaryBackend across axes, ranks, tie-breaks, and dtypes" do
       tensors = [
@@ -1071,6 +1121,33 @@ defmodule Evision.Backend.Test do
       opts = [feature_group_size: 2, padding: :same, strides: [1, 2], kernel_dilation: [1, 2]]
 
       assert_close(Nx.conv(ev(img), ev(kernel), opts), Nx.conv(img, kernel, opts))
+    end
+
+    test "im2row fast path tiles correctly across tile and batch boundaries" do
+      # A tiny memory budget forces the im2row path into many tiles (here ~1-4 output
+      # rows each), so tiles split mid-batch and the last tile is partial -- exercising
+      # the boundary arithmetic that a single-tile conv never hits. The override is
+      # process-local, so it never leaks into other (parallel) tests.
+      Process.put(:evision_conv_im2row_budget_bytes, 256)
+
+      img2 = Nx.iota({2, 3, 5, 5}, type: :f32)
+      k2 = Nx.iota({4, 3, 2, 2}, type: :f32)
+      imgd = Nx.iota({1, 4, 5, 5}, type: :f32)
+      kd = Nx.iota({4, 1, 3, 3}, type: :f32)
+      fimg = Nx.iota({2, 4, 16, 16}, type: :f32) |> Nx.divide(100.0)
+      fk = Nx.iota({4, 2, 3, 3}, type: :f32) |> Nx.divide(50.0)
+
+      cases = [
+        {img2, k2, [strides: [2, 1]]},
+        {img2, k2, [padding: :same]},
+        {img2, k2, [padding: :same, kernel_dilation: [2, 1]]},
+        {imgd, kd, [feature_group_size: 4]},
+        {fimg, fk, [feature_group_size: 2, padding: :same, strides: [1, 2], kernel_dilation: [1, 2]]}
+      ]
+
+      for {i, k, o} <- cases do
+        assert_close(Nx.conv(ev(i), ev(k), o), Nx.conv(i, k, o))
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a small `cv::parallel_for_` helper with workload thresholds for backend NIF loops
- parallelize independent output ranges while keeping sequential fast paths for smaller memory-bound workloads
- collect bounds-check failures safely for parallel gather/take-style loops
- add larger-shape and out-of-bounds tests for the affected backend paths