### PR TITLE
Fix scalar arithmetic + N-d broadcasting in Evision.Backend (correctness + perf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ erl_crash.dump
 *.beam
 /config/*.secret.exs
 .elixir_ls/
+compile_commands.json
 /c_src/evision_generated_*
 /c_src/evision_signatures.json
 /c_src/evision_custom_headers.h

--- a/c_src/modules/evision_backend/binop.h
+++ b/c_src/modules/evision_backend/binop.h
@@ -11,17 +11,19 @@
 
 // Elementwise binary ops without an OpenCV primitive (Nx.atan2 / pow / quotient /
 // remainder). op 0=atan2, 1=pow, 2=quotient, 3=remainder. l and r share the output
-// type and shape (broadcast + cast by the caller; f16/bf16 widened to f32).
+// type (cast by the caller; f16/bf16 widened to f32) and either the same shape or
+// one is a 1-element scalar, which is broadcast (stride 0) over the other.
 
 template <typename T>
 static void evision_binop_float(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst, int op) {
     const T *lp = (const T *)l.data;
     const T *rp = (const T *)r.data;
     T *dp = (T *)dst.data;
-    size_t n = l.total();
+    size_t n = dst.total();
+    size_t ls = (l.total() == 1) ? 0 : 1, rs = (r.total() == 1) ? 0 : 1;
     evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
         for (int64_t i = begin; i < end; i++) {
-            T a = lp[(size_t)i], b = rp[(size_t)i];
+            T a = lp[(size_t)i * ls], b = rp[(size_t)i * rs];
             switch (op) {
                 case 0: dp[(size_t)i] = std::atan2(a, b); break;
                 case 1: dp[(size_t)i] = std::pow(a, b); break;
@@ -40,10 +42,11 @@ static void evision_binop_int(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst, 
     const T *lp = (const T *)l.data;
     const T *rp = (const T *)r.data;
     T *dp = (T *)dst.data;
-    size_t n = l.total();
+    size_t n = dst.total();
+    size_t ls = (l.total() == 1) ? 0 : 1, rs = (r.total() == 1) ? 0 : 1;
     evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
         for (int64_t i = begin; i < end; i++) {
-            T a = lp[(size_t)i], b = rp[(size_t)i];
+            T a = lp[(size_t)i * ls], b = rp[(size_t)i * rs];
             switch (op) {
                 case 1: {
                     Acc base = (Acc)a, result = 1;
@@ -82,7 +85,7 @@ static ERL_NIF_TERM evision_cv_mat_binop(ErlNifEnv *env, int argc, const ERL_NIF
             evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
             Mat lc = l.isContinuous() ? l : l.clone();
             Mat rc = r.isContinuous() ? r : r.clone();
-            Mat dst = lc.clone();
+            Mat dst = (rc.total() > lc.total() ? rc : lc).clone();
             switch (dst.depth()) {
                 case CV_8U:  evision_binop_int<uint8_t, uint8_t>(lc, rc, dst, op); break;
                 case CV_8S:  evision_binop_int<int8_t, uint8_t>(lc, rc, dst, op); break;

--- a/c_src/modules/evision_backend/broadcast.h
+++ b/c_src/modules/evision_backend/broadcast.h
@@ -1,59 +1,70 @@
 #ifndef EVISION_BACKEND_BROADCAST_H
 #define EVISION_BACKEND_BROADCAST_H
 
+#include <cstring>
+#include <vector>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
 
+// Replicate img (interpreted as src_shape, already left-aligned with 1s to
+// to_shape's rank) into dst_data shaped as to_shape, following NumPy/Nx
+// broadcasting: a source dim of size 1 is stretched to the target size. Source
+// dims map to output coordinates with stride 0 where stretched; the contiguous
+// trailing run is copied as a block.
 static void broadcast(
-    Mat &img,
-    void *& dst_data,
-    void *& tmp_data,
-    std::vector<int>& src_shape,
-    std::vector<int>& to_shape,
+    const cv::Mat &img,
+    void *dst_data,
+    const std::vector<int>& src_shape,
+    const std::vector<int>& to_shape,
     size_t elem_size
 )
 {
-    size_t ndims = src_shape.size();
-    size_t subgroup_bytes = src_shape[ndims - 1] * elem_size;
-    size_t num_subgroups = 1;
-    for (size_t i = 0; i < ndims - 1; ++i) {
-        num_subgroups *= src_shape[i];
+    const size_t ndims = to_shape.size();
+
+    const uint8_t *src = (const uint8_t *)img.data;
+    cv::Mat tmp;
+    if (!img.isContinuous()) {
+        tmp = img.clone();
+        src = (const uint8_t *)tmp.data;
     }
 
-    if (img.isContinuous()) {
-        memcpy(dst_data, img.data, num_subgroups * subgroup_bytes);
-    } else {
-        Mat tmp = img.clone();
-        memcpy(dst_data, tmp.data, num_subgroups * subgroup_bytes);
+    uint8_t *dst = (uint8_t *)dst_data;
+
+    if (ndims == 0) {
+        memcpy(dst, src, elem_size);
+        return;
     }
 
-    for (int64_t dim = ndims - 1; dim >= 0; --dim) {
-        size_t elem_per_subgroup = src_shape[dim];
-        size_t elem_per_group = to_shape[dim];
-        size_t num_groups = num_subgroups / elem_per_subgroup;
-        if (num_subgroups == 1) {
-            num_groups = 1;
+    // Row-major source strides (in elements); stretched dims get stride 0.
+    std::vector<size_t> src_strides(ndims, 0);
+    size_t stride = 1;
+    for (int64_t d = (int64_t)ndims - 1; d >= 0; --d) {
+        src_strides[d] = (src_shape[d] == 1) ? 0 : stride;
+        stride *= (size_t)src_shape[d];
+    }
+
+    const size_t last = (size_t)to_shape[ndims - 1];
+    const bool last_is_broadcast = src_shape[ndims - 1] == 1;
+    size_t outer = 1;
+    for (size_t d = 0; d + 1 < ndims; ++d) outer *= (size_t)to_shape[d];
+
+    std::vector<int> idx(ndims - 1, 0);
+    for (size_t o = 0; o < outer; ++o) {
+        size_t base = 0;
+        for (size_t d = 0; d + 1 < ndims; ++d) base += (size_t)idx[d] * src_strides[d];
+
+        uint8_t *drow = dst + o * last * elem_size;
+        if (!last_is_broadcast) {
+            memcpy(drow, src + base * elem_size, last * elem_size);
+        } else {
+            const uint8_t *s = src + base * elem_size;
+            for (size_t i = 0; i < last; ++i) memcpy(drow + i * elem_size, s, elem_size);
         }
-        size_t group_bytes = subgroup_bytes * num_subgroups / elem_per_group;
 
-        if (elem_per_subgroup == 1) {
-            size_t copy_times = elem_per_group;
-            group_bytes = subgroup_bytes * num_subgroups * copy_times / num_groups;
-
-            for (size_t subgroup = 0; subgroup < num_subgroups; ++subgroup) {
-                void * subgroup_start = (void *)((uint64_t)(uint64_t *)dst_data + subgroup_bytes * subgroup);
-                for (size_t i = 0; i < copy_times; ++i) {
-                    void * tmp_data_start = (void *)((uint64_t)(uint64_t *)tmp_data + subgroup_bytes * i + group_bytes * subgroup);
-                    memcpy(tmp_data_start, subgroup_start, subgroup_bytes);
-                }
-            }
-            std::swap(tmp_data, dst_data);
-            subgroup_bytes = group_bytes;
-        } else if (elem_per_subgroup == elem_per_group) {
-            subgroup_bytes = subgroup_bytes * num_subgroups / num_groups;
+        for (int64_t d = (int64_t)ndims - 2; d >= 0; --d) {
+            if (++idx[d] < to_shape[d]) break;
+            idx[d] = 0;
         }
-
-        num_subgroups = num_groups;
     }
 }
 
@@ -116,21 +127,14 @@ static ERL_NIF_TERM evision_cv_mat_broadcast_to(ErlNifEnv *env, int argc, const 
             if (dst_data == nullptr) {
                 return evision::nif::error(env, "cannot broadcast to specified shape, out of memory");
             }
-            void * tmp_data = (void *)enif_alloc(elem_size * count_new_elem);
-            if (tmp_data == nullptr) {
-                enif_free((void *)dst_data);
-                dst_data = nullptr;
-                return evision::nif::error(env, "cannot broadcast to specified shape, out of memory");
-            }
 
             // broadcast
-            broadcast(img, dst_data, tmp_data, src_shape, to_shape, elem_size);
+            broadcast(img, dst_data, src_shape, to_shape, elem_size);
 
             int type = img.type() & CV_MAT_DEPTH_MASK;
             Mat result = Mat((int)ndims, to_shape.data(), type, dst_data);
             result = result.clone();
             enif_free((void *)dst_data);
-            enif_free((void *)tmp_data);
             return evision_from(env, result);
         }
     }

--- a/c_src/modules/evision_backend/broadcast.h
+++ b/c_src/modules/evision_backend/broadcast.h
@@ -1,10 +1,23 @@
 #ifndef EVISION_BACKEND_BROADCAST_H
 #define EVISION_BACKEND_BROADCAST_H
 
+#include <algorithm>
 #include <cstring>
 #include <vector>
 #include <erl_nif.h>
 #include "../../ArgInfo.hpp"
+
+static void repeat_bytes(uint8_t *dst, const uint8_t *src, size_t elem_size, size_t count)
+{
+    if (count == 0) return;
+    memcpy(dst, src, elem_size);
+    size_t copied = 1;
+    while (copied < count) {
+        size_t chunk = std::min(copied, count - copied);
+        memcpy(dst + copied * elem_size, dst, chunk * elem_size);
+        copied += chunk;
+    }
+}
 
 // Replicate img (interpreted as src_shape, already left-aligned with 1s to
 // to_shape's rank) into dst_data shaped as to_shape, following NumPy/Nx
@@ -35,6 +48,13 @@ static void broadcast(
         return;
     }
 
+    if (img.total() == 1) {
+        size_t count = 1;
+        for (size_t d = 0; d < ndims; ++d) count *= (size_t)to_shape[d];
+        repeat_bytes(dst, src, elem_size, count);
+        return;
+    }
+
     // Row-major source strides (in elements); stretched dims get stride 0.
     std::vector<size_t> src_strides(ndims, 0);
     size_t stride = 1;
@@ -57,8 +77,7 @@ static void broadcast(
         if (!last_is_broadcast) {
             memcpy(drow, src + base * elem_size, last * elem_size);
         } else {
-            const uint8_t *s = src + base * elem_size;
-            for (size_t i = 0; i < last; ++i) memcpy(drow + i * elem_size, s, elem_size);
+            repeat_bytes(drow, src + base * elem_size, elem_size, last);
         }
 
         for (int64_t d = (int64_t)ndims - 2; d >= 0; --d) {
@@ -115,26 +134,14 @@ static ERL_NIF_TERM evision_cv_mat_broadcast_to(ErlNifEnv *env, int argc, const 
                 }
             }
 
-            // calculate number of elements in the new shape
             const size_t elem_size = img.elemSize();
-            size_t count_new_elem = 1;
-            for (int64_t i = 0; i < ndims; i++) {
-                count_new_elem *= to_shape[i];
-            }
-
-            // allocate memory
-            void * dst_data = (void *)enif_alloc(elem_size * count_new_elem);
-            if (dst_data == nullptr) {
+            int type = img.type();
+            Mat result((int)ndims, to_shape.data(), type);
+            if (result.data == nullptr) {
                 return evision::nif::error(env, "cannot broadcast to specified shape, out of memory");
             }
 
-            // broadcast
-            broadcast(img, dst_data, src_shape, to_shape, elem_size);
-
-            int type = img.type() & CV_MAT_DEPTH_MASK;
-            Mat result = Mat((int)ndims, to_shape.data(), type, dst_data);
-            result = result.clone();
-            enif_free((void *)dst_data);
+            broadcast(img, result.data, src_shape, to_shape, elem_size);
             return evision_from(env, result);
         }
     }

--- a/c_src/modules/evision_backend/shift.h
+++ b/c_src/modules/evision_backend/shift.h
@@ -9,7 +9,8 @@
 #include "parallel.h"
 
 // Elementwise integer shift (Nx.left_shift / right_shift). `l` and `r` share the
-// output type and shape. op 0 = left (<<), 1 = right (>>). Left shifts compute in
+// output type and either the same shape or one is a 1-element scalar, broadcast
+// (stride 0) over the other. op 0 = left (<<), 1 = right (>>). Left shifts compute in
 // the unsigned counterpart (modular, no signed-overflow UB); right shifts use the
 // native >> (arithmetic for signed, logical for unsigned). A shift >= bit width
 // yields 0, except a right shift of a negative signed value yields -1 -- matching
@@ -20,12 +21,13 @@ static void evision_shift(const cv::Mat &l, const cv::Mat &r, cv::Mat &dst, int 
     const T *lp = (const T *)l.data;
     const T *rp = (const T *)r.data;
     T *dp = (T *)dst.data;
-    size_t n = l.total();
+    size_t n = dst.total();
+    size_t ls = (l.total() == 1) ? 0 : 1, rs = (r.total() == 1) ? 0 : 1;
     uint64_t width = (uint64_t)(sizeof(T) * 8);
     evision_parallel_for((int64_t)n, (int64_t)n, EVISION_PARALLEL_SIMPLE_MIN_WORK, [&](int64_t begin, int64_t end) {
         for (int64_t i = begin; i < end; i++) {
-            T a = lp[(size_t)i];
-            T b = rp[(size_t)i];
+            T a = lp[(size_t)i * ls];
+            T b = rp[(size_t)i * rs];
             if (op == 0) {
                 dp[(size_t)i] = ((uint64_t)b >= width) ? (T)0 : (T)((U)a << b);
             } else if ((uint64_t)b >= width) {
@@ -55,7 +57,7 @@ static ERL_NIF_TERM evision_cv_mat_shift(ErlNifEnv *env, int argc, const ERL_NIF
             evision_to_safe(env, evision_get_kw(env, erl_terms, "op"), op, ArgInfo("op", 0))) {
             Mat lc = l.isContinuous() ? l : l.clone();
             Mat rc = r.isContinuous() ? r : r.clone();
-            Mat dst = lc.clone();
+            Mat dst = (rc.total() > lc.total() ? rc : lc).clone();
             switch (dst.depth()) {
                 case CV_8U:  evision_shift<uint8_t>(lc, rc, dst, op); break;
                 case CV_8S:  evision_shift<int8_t>(lc, rc, dst, op); break;

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -223,43 +223,20 @@ defmodule Evision.Backend do
 
   @impl true
   @spec broadcast(Nx.Tensor.t(), Nx.Tensor.t(), tuple, any) :: Nx.Tensor.t()
-  def broadcast(out, %T{} = t, shape, axes) do
-    {tensor, reshape} = maybe_reshape(t, shape, axes)
-    Evision.Mat.broadcast_to(tensor |> from_nx(), shape, reshape)
+  def broadcast(out, %T{shape: src_shape} = t, to_shape, axes) do
+    Evision.Mat.broadcast_to(from_nx(t), to_shape, force_src_shape(src_shape, to_shape, axes))
     |> reject_error()
     |> to_nx(out)
   end
 
-  defp maybe_reshape(%T{shape: {n}} = t, {n, _}, [0]) do
-    {Nx.reshape(t, {n, 1}), {n, 1}}
-  end
+  # Place each source dim onto the target axis Nx assigns it (other axes are 1),
+  # so the NIF stretches the size-1 axes. This mirrors Nx broadcasting for both
+  # the default right-aligned case and explicit `:axes`.
+  defp force_src_shape(src_shape, to_shape, axes) do
+    placed = Map.new(Enum.zip(Tuple.to_list(src_shape), axes), fn {dim, axis} -> {axis, dim} end)
 
-  defp maybe_reshape(%T{shape: shape} = t, to_shape, _axes) do
-    l_shape = Tuple.to_list(shape)
-    l_to_shape = Tuple.to_list(to_shape)
-
-    if length(l_shape) != length(l_to_shape) do
-      src_shape_axis = length(l_shape) - 1
-      {_src_shape_axis, force_shape} =
-        for axis <- Enum.to_list(length(l_to_shape)-1..0), reduce: {src_shape_axis, []} do
-          {src_shape_axis, acc} ->
-            if src_shape_axis == -1 do
-              {src_shape_axis, [1 | acc]}
-            else
-              case {elem(shape, src_shape_axis), elem(to_shape, axis)} do
-                {1, _d} ->
-                  {src_shape_axis - 1, [1 | acc]}
-                {d, d} ->
-                  {src_shape_axis - 1, [d | acc]}
-              end
-            end
-        end
-      force_shape = List.to_tuple(force_shape)
-
-      {Nx.reshape(t, force_shape), force_shape}
-    else
-      {t, shape}
-    end
+    for(axis <- 0..(tuple_size(to_shape) - 1)//1, do: Map.get(placed, axis, 1))
+    |> List.to_tuple()
   end
 
   @impl true

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -366,24 +366,29 @@ defmodule Evision.Backend do
     Evision.Mat.as_type(from_nx(tensor), {:f, 64})
   end
 
-  @impl true
-  def min(%T{shape: out_shape}=out, l, r) do
-    shape =
-      case out_shape do
-        {} -> {1}
-        _ -> out_shape
-      end
-    l = Nx.broadcast(l, shape)
-    r = Nx.broadcast(r, shape)
-    {l, r} = enforce_same_type(l, r)
-    l = Evision.Mat.reshape(from_nx(l), shape)
-    r = Evision.Mat.reshape(from_nx(r), shape)
-    ret = Evision.min(l, r)
-    to_nx(ret, %T{out | type: Evision.Mat.type(ret)})
-  end
+  defp cast_mat(%T{type: type} = t, type), do: from_nx(t)
+  defp cast_mat(%T{} = t, type), do: Evision.Mat.as_type(from_nx(t), type)
 
   @impl true
-  def max(%T{shape: out_shape}=out, l, r) do
+  def min(%T{type: out_type}=out, %T{shape: {}}=l, r), do: min_max_scalar(out, out_type, r, l, &Evision.min/2)
+  def min(%T{type: out_type}=out, l, %T{shape: {}}=r), do: min_max_scalar(out, out_type, l, r, &Evision.min/2)
+  def min(%T{shape: out_shape}=out, l, r), do: min_max(out, out_shape, l, r, &Evision.min/2)
+
+  @impl true
+  def max(%T{type: out_type}=out, %T{shape: {}}=l, r), do: min_max_scalar(out, out_type, r, l, &Evision.max/2)
+  def max(%T{type: out_type}=out, l, %T{shape: {}}=r), do: min_max_scalar(out, out_type, l, r, &Evision.max/2)
+  def max(%T{shape: out_shape}=out, l, r), do: min_max(out, out_shape, l, r, &Evision.max/2)
+
+  # cv::min/max keep the array's dtype, so cast the array to the (already
+  # promoted) output type and feed the scalar through the cv::min(Mat, double)
+  # overload -- only the array's single pass, no full broadcast of the scalar.
+  defp min_max_scalar(out, out_type, array, scalar, fun) do
+    fun.(cast_mat(array, out_type), to_number(scalar))
+    |> reject_error()
+    |> to_nx(out)
+  end
+
+  defp min_max(out, out_shape, l, r, fun) do
     shape =
       case out_shape do
         {} -> {1}
@@ -394,8 +399,8 @@ defmodule Evision.Backend do
     {l, r} = enforce_same_type(l, r)
     l = Evision.Mat.reshape(from_nx(l), shape)
     r = Evision.Mat.reshape(from_nx(r), shape)
-    ret = Evision.max(l, r)
-    to_nx(ret, %T{out | type: Evision.Mat.type(ret)})
+    ret = fun.(l, r)
+    to_nx(ret, %{out | type: Evision.Mat.type(ret)})
   end
 
   defp enforce_same_type(%T{type: type}=a, %T{type: type}=b), do: {a, b}
@@ -516,64 +521,44 @@ defmodule Evision.Backend do
 
   @impl true
   @spec equal(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
-  def equal(%T{shape: out_shape} = out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
-    {l, r} = enforce_same_type(l, r)
-    from_nx(l)
-    |> Evision.Mat.cmp(from_nx(r), :eq)
-    |> reject_error()
-    |> to_nx(out)
-  end
+  def equal(%T{shape: out_shape} = out, l, r), do: cmp(out, out_shape, l, r, :eq)
 
   @impl true
   @spec not_equal(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
-  def not_equal(%T{shape: out_shape} = out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
-    {l, r} = enforce_same_type(l, r)
-    from_nx(l)
-    |> Evision.Mat.cmp(from_nx(r), :ne)
-    |> reject_error()
-    |> to_nx(out)
-  end
+  def not_equal(%T{shape: out_shape} = out, l, r), do: cmp(out, out_shape, l, r, :ne)
 
   @impl true
-  def greater(%T{shape: out_shape} = out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
-    {l, r} = enforce_same_type(l, r)
-    from_nx(l)
-    |> Evision.Mat.cmp(from_nx(r), :gt)
-    |> reject_error()
-    |> to_nx(out)
-  end
+  def greater(%T{shape: out_shape} = out, l, r), do: cmp(out, out_shape, l, r, :gt)
 
   @impl true
   @spec less(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
-  def less(%T{shape: out_shape} = out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
-    {l, r} = enforce_same_type(l, r)
-    from_nx(l)
-    |> Evision.Mat.cmp(from_nx(r), :lt)
-    |> reject_error()
-    |> to_nx(out)
-  end
+  def less(%T{shape: out_shape} = out, l, r), do: cmp(out, out_shape, l, r, :lt)
 
   @impl true
   @spec greater_equal(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
-  def greater_equal(%T{shape: out_shape} = out, l, r) do
+  def greater_equal(%T{shape: out_shape} = out, l, r), do: cmp(out, out_shape, l, r, :ge)
+
+  @impl true
+  def less_equal(%T{shape: out_shape} = out, l, r), do: cmp(out, out_shape, l, r, :le)
+
+  # cv::compare broadcasts a 1x1 mat on either side, so a 0-d operand is cast to
+  # the merged comparison type (a single element) and compared in place, in the
+  # original operand order, instead of being broadcast to a full array. The merged
+  # type is what Nx compares in, which keeps fractional-scalar results correct.
+  defp cmp(out, _out_shape, %T{shape: {}} = l, r, op), do: cmp_scalar(out, l, r, op)
+  defp cmp(out, _out_shape, l, %T{shape: {}} = r, op), do: cmp_scalar(out, l, r, op)
+  defp cmp(out, out_shape, l, r, op) do
     {l, r} = enforce_same_shape(l, r, out_shape)
     {l, r} = enforce_same_type(l, r)
-    from_nx(l)
-    |> Evision.Mat.cmp(from_nx(r), :ge)
+    Evision.Mat.cmp(from_nx(l), from_nx(r), op)
     |> reject_error()
     |> to_nx(out)
   end
 
-  @impl true
-  def less_equal(%T{shape: out_shape} = out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
-    {l, r} = enforce_same_type(l, r)
-    from_nx(l)
-    |> Evision.Mat.cmp(from_nx(r), :le)
+  defp cmp_scalar(out, %T{type: lt} = l, %T{type: rt} = r, op) do
+    merged = Nx.Type.merge(lt, rt)
+    Evision.Mat.cmp(cast_mat(l, merged), cast_mat(r, merged), op)
+    |> reject_error()
     |> to_nx(out)
   end
 

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -359,6 +359,13 @@ defmodule Evision.Backend do
   defp align_operands(l, %T{shape: {}} = r, _out_shape), do: {l, float_scalar(r)}
   defp align_operands(l, r, out_shape), do: enforce_same_shape(l, r, out_shape)
 
+  # For NIFs that broadcast a 1-element operand themselves (mat_binop, mat_shift),
+  # a 0-d operand is left untouched; two different non-scalar shapes still need a
+  # materialized broadcast.
+  defp same_shape_unless_scalar(%T{shape: {}} = l, r, _shape), do: {l, r}
+  defp same_shape_unless_scalar(l, %T{shape: {}} = r, _shape), do: {l, r}
+  defp same_shape_unless_scalar(l, r, shape), do: enforce_same_shape(l, r, shape)
+
   defp maybe_cast_type_for_matrix_mul_div(%T{type: {:f, _}}=tensor) do
     from_nx(tensor)
   end
@@ -569,38 +576,21 @@ defmodule Evision.Backend do
     {to_nx(l_mat, %T{l | shape: out_shape}), to_nx(b_mat, %T{r | shape: out_shape})}
   end
 
+  # Nx logical ops are truthiness-based: reduce each operand to a 0/1 mask, then
+  # combine elementwise (min=and, max=or, not_equal=xor). Building on the masked
+  # ops keeps the result correct for any dtype (cv's bitwise `&`/`^` over the raw
+  # values are wrong, e.g. `2 and 1`) and inherits their broadcast + scalar paths.
   @impl true
   @spec logical_and(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
-  def logical_and(%T{shape: out_shape} = out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
-    {l, r} = enforce_same_type(l, r)
-    Evision.Mat.logical_and(from_nx(l), from_nx(r))
-    |> reject_error()
-    |> to_nx(out)
-    |> Nx.not_equal(0)
-  end
+  def logical_and(_out, l, r), do: Nx.min(Nx.not_equal(l, 0), Nx.not_equal(r, 0))
 
   @impl true
   @spec logical_or(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
-  def logical_or(%T{shape: out_shape} = out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
-    {l, r} = enforce_same_type(l, r)
-    Evision.Mat.logical_or(from_nx(l), from_nx(r))
-    |> reject_error()
-    |> to_nx(out)
-    |> Nx.not_equal(0)
-  end
+  def logical_or(_out, l, r), do: Nx.max(Nx.not_equal(l, 0), Nx.not_equal(r, 0))
 
   @impl true
   @spec logical_xor(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
-  def logical_xor(%T{shape: out_shape} =out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
-    {l, r} = enforce_same_type(l, r)
-    Evision.Mat.logical_xor(from_nx(l), from_nx(r))
-    |> reject_error()
-    |> to_nx(out)
-    |> Nx.not_equal(0)
-  end
+  def logical_xor(_out, l, r), do: Nx.not_equal(Nx.not_equal(l, 0), Nx.not_equal(r, 0))
 
   @impl true
   @spec abs(Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
@@ -1089,7 +1079,7 @@ defmodule Evision.Backend do
 
   # l and r are broadcast to the output shape and cast to the (integer) output type.
   defp shift(%T{shape: shape, type: type} = out, l, r, op) do
-    {l, r} = enforce_same_shape(l, r, shape)
+    {l, r} = same_shape_unless_scalar(l, r, shape)
     lm = as_mat_type(from_nx(l), type)
     rm = as_mat_type(from_nx(r), type)
     Evision.Mat.shift(lm, rm, op) |> reject_error() |> to_nx(out)
@@ -1144,7 +1134,7 @@ defmodule Evision.Backend do
   # widened to f32 since the NIF covers only real C types), then narrow the result back.
   defp binary_math(%T{type: out_type, shape: shape} = out, l, r, op) do
     work_type = if out_type in @half_types, do: {:f, 32}, else: out_type
-    {l, r} = enforce_same_shape(l, r, shape)
+    {l, r} = same_shape_unless_scalar(l, r, shape)
     lm = as_mat_type(from_nx(l), work_type)
     rm = as_mat_type(from_nx(r), work_type)
 

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -327,7 +327,7 @@ defmodule Evision.Backend do
   def multiply(%T{type: type}=out, %T{}=l, %T{}=r) do
     case check_mul_div_kind(l, r) do
       :per_element ->
-        Evision.Mat.multiply(from_nx(l), from_nx(r), type)
+        Evision.Mat.multiply(from_nx(float_scalar(l)), from_nx(float_scalar(r)), type)
 
       :matrix ->
         l = maybe_cast_type_for_matrix_mul_div(l)
@@ -335,6 +335,7 @@ defmodule Evision.Backend do
         Evision.Mat.matrix_multiply(l, r)
         |> Evision.Mat.as_type(type)
     end
+    |> reject_error()
     |> to_nx(out)
   end
 
@@ -342,7 +343,7 @@ defmodule Evision.Backend do
   def divide(%T{type: type, shape: shape}=out, l, r) do
     case check_mul_div_kind(l, r) do
       :per_element ->
-        Evision.Mat.divide(from_nx(l), from_nx(r), type)
+        Evision.Mat.divide(from_nx(float_scalar(l)), from_nx(float_scalar(r)), type)
 
       :matrix ->
         l = Nx.broadcast(l, shape)
@@ -351,6 +352,7 @@ defmodule Evision.Backend do
         r = maybe_cast_type_for_matrix_mul_div(r)
         Evision.Mat.divide(l, r, type)
     end
+    |> reject_error()
     |> to_nx(out)
   end
 
@@ -363,6 +365,13 @@ defmodule Evision.Backend do
   defp check_mul_div_kind(_l, _r) do
     :matrix
   end
+
+  # OpenCV's arithmetic only treats a 1x1 operand as a scalar when it is f64 (an
+  # integer or f32 scalar is rejected, especially as the left operand), so cast a
+  # 0-d operand to f64 -- a single element -- instead of broadcasting it to a full
+  # array. Widening a float scalar is lossless and the other operand is untouched.
+  defp float_scalar(%T{shape: {}} = scalar), do: Nx.as_type(scalar, {:f, 64})
+  defp float_scalar(scalar), do: scalar
 
   defp maybe_cast_type_for_matrix_mul_div(%T{type: {:f, _}}=tensor) do
     from_nx(tensor)

--- a/lib/evision/backend.ex
+++ b/lib/evision/backend.ex
@@ -285,7 +285,7 @@ defmodule Evision.Backend do
   @impl true
   @spec add(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
   def add(%T{type: type, shape: out_shape}=out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
+    {l, r} = align_operands(l, r, out_shape)
     Evision.Mat.add(from_nx(l), from_nx(r), type)
     |> reject_error()
     |> to_nx(out)
@@ -294,7 +294,7 @@ defmodule Evision.Backend do
   @impl true
   @spec subtract(Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()) :: Nx.Tensor.t()
   def subtract(%T{type: type, shape: out_shape}=out, l, r) do
-    {l, r} = enforce_same_shape(l, r, out_shape)
+    {l, r} = align_operands(l, r, out_shape)
     Evision.Mat.subtract(from_nx(l), from_nx(r), type)
     |> reject_error()
     |> to_nx(out)
@@ -349,6 +349,15 @@ defmodule Evision.Backend do
   # array. Widening a float scalar is lossless and the other operand is untouched.
   defp float_scalar(%T{shape: {}} = scalar), do: Nx.as_type(scalar, {:f, 64})
   defp float_scalar(scalar), do: scalar
+
+  # For ops that pass an explicit output type to the NIF (add/subtract), a 0-d
+  # operand can go through OpenCV's scalar fast-path (float_scalar/1) instead of
+  # being broadcast to a full array; only genuinely different shapes need
+  # enforce_same_shape. The explicit output type keeps the f64 scalar from
+  # affecting the result dtype.
+  defp align_operands(%T{shape: {}} = l, r, _out_shape), do: {float_scalar(l), r}
+  defp align_operands(l, %T{shape: {}} = r, _out_shape), do: {l, float_scalar(r)}
+  defp align_operands(l, r, out_shape), do: enforce_same_shape(l, r, out_shape)
 
   defp maybe_cast_type_for_matrix_mul_div(%T{type: {:f, _}}=tensor) do
     from_nx(tensor)

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -396,6 +396,94 @@ defmodule Evision.Backend.Test do
     end
   end
 
+  describe "elementwise broadcasting semantics" do
+    # Broadcast-compatible shape pairs (numpy/Nx rules): scalar, equal, dim-1
+    # stretch, and rank-differing combinations. Elementwise binary ops must
+    # broadcast both operands to the output shape exactly like Nx.BinaryBackend,
+    # since OpenCV arithmetic only supports same-size or array-op-scalar.
+    @broadcast_pairs [
+      {{}, {3}}, {{3}, {}},
+      {{3}, {3}},
+      {{1}, {3}}, {{3}, {1}},
+      {{2, 3}, {2, 3}},
+      {{2, 1}, {2, 3}}, {{1, 3}, {2, 3}},
+      {{2, 1}, {1, 3}},
+      {{3}, {2, 3}}, {{2, 3}, {3}},
+      {{1, 1}, {2, 3}},
+      {{2, 3, 4}, {3, 4}}, {{2, 1, 4}, {1, 3, 1}}
+    ]
+
+    # multiply is excluded: for two non-scalar operands Evision.Backend
+    # intentionally does matrix mult rather than elementwise.
+    @elementwise_ops [:add, :subtract, :divide, :min, :max, :equal, :greater, :less]
+
+    test "OpenCV arithmetic itself does not broadcast" do
+      a = Evision.Backend.from_nx(ev(Nx.iota({2, 1}, type: :f32)))
+      b = Evision.Backend.from_nx(ev(Nx.iota({1, 3}, type: :f32)))
+      assert match?({:error, _}, Evision.Mat.add(a, b))
+    end
+
+    test "elementwise ops match Nx.BinaryBackend across broadcast-compatible shapes" do
+      gen = fn shape, off, dtype -> Nx.iota(shape, type: dtype) |> Nx.add(off + 1) end
+
+      failures =
+        for op <- @elementwise_ops, dtype <- [:f32, :s32], {sl, sr} <- @broadcast_pairs, reduce: [] do
+          acc ->
+            l = gen.(sl, 0, dtype)
+            r = gen.(sr, 7, dtype)
+            want = apply(Nx, op, [l, r])
+            label = "#{op} #{dtype} #{inspect(sl)} vs #{inspect(sr)}"
+
+            result =
+              try do
+                got = apply(Nx, op, [ev(l), ev(r)]) |> Nx.backend_copy(Nx.BinaryBackend)
+
+                cond do
+                  Nx.shape(got) != Nx.shape(want) -> {:shape, Nx.shape(got), Nx.shape(want)}
+                  Nx.to_number(Nx.all_close(got, want, atol: 1.0e-5, rtol: 1.0e-5)) != 1 -> :values
+                  true -> :ok
+                end
+              rescue
+                e -> {:raised, Exception.message(e) |> String.split("\n") |> hd()}
+              end
+
+            if result == :ok, do: acc, else: [{label, result} | acc]
+        end
+
+      assert failures == [], "broadcast mismatches:\n" <> Enum.map_join(Enum.reverse(failures), "\n", fn {l, r} -> "  #{l}: #{inspect(r)}" end)
+    end
+  end
+
+  describe "broadcast" do
+    @broadcast_to_cases [
+      {{1}, {3}}, {{3}, {3}},
+      {{1}, {2, 3}}, {{3}, {2, 3}},
+      {{1, 3}, {2, 3}}, {{2, 1}, {2, 3}}, {{1, 1}, {2, 3}}, {{2, 3}, {2, 3}},
+      {{4}, {2, 3, 4}}, {{3, 4}, {2, 3, 4}}, {{1}, {2, 3, 4}},
+      {{2, 1, 4}, {2, 3, 4}}, {{1, 3, 1}, {2, 3, 4}}, {{2, 3, 1}, {2, 3, 4}},
+      {{1, 1, 1}, {2, 3, 4}}, {{2, 3, 4}, {2, 3, 4}}
+    ]
+
+    test "matches Nx.BinaryBackend across ranks and dim-1 stretches for every dtype" do
+      for {from, to} <- @broadcast_to_cases, dtype <- [:f32, :f64, :s32, :s64, :u8] do
+        t = Nx.iota(from, type: dtype) |> Nx.add(1)
+        assert_same(Nx.broadcast(ev(t), to), Nx.broadcast(t, to))
+      end
+    end
+
+    test "matches Nx.BinaryBackend for explicit axes (including non-right-aligned)" do
+      v = Nx.tensor([1, 2, 3], type: :s32)
+      assert_same(Nx.broadcast(ev(v), {3, 2}, axes: [0]), Nx.broadcast(v, {3, 2}, axes: [0]))
+      assert_same(Nx.broadcast(ev(v), {2, 3}, axes: [1]), Nx.broadcast(v, {2, 3}, axes: [1]))
+
+      m = Nx.tensor([[1, 2], [3, 4]], type: :f32)
+
+      for axes <- [[0, 1], [0, 2], [1, 2]] do
+        assert_same(Nx.broadcast(ev(m), {2, 2, 2}, axes: axes), Nx.broadcast(m, {2, 2, 2}, axes: axes))
+      end
+    end
+  end
+
   describe "cumulative_sum / product / min / max" do
     test "match Nx.BinaryBackend exactly for integer dtypes across axes and :reverse" do
       tensors = [

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -365,6 +365,37 @@ defmodule Evision.Backend.Test do
     end
   end
 
+  describe "multiply / divide by a scalar" do
+    # Regression: multiplying or dividing by an integer scalar used to raise
+    # "no function clause matching in Evision.Backend.to_nx/2". The per-element
+    # branch handed a 1x1 integer scalar Mat to cv::multiply, whose scalar
+    # fast-path rejects non-float scalars; broadcasting the scalar to the output
+    # shape first turns it into a supported array-op-array call.
+    test "integer-tensor multiply by an integer scalar matches Nx.BinaryBackend exactly" do
+      for t <- [Nx.tensor([1, 2, 3], type: :s32), Nx.tensor([4, 9, 12], type: :s64)],
+          s <- [2, -3, 0] do
+        assert_same(Nx.multiply(ev(t), s), Nx.multiply(t, s))
+        assert_same(Nx.multiply(s, ev(t)), Nx.multiply(s, t))
+      end
+    end
+
+    test "float-tensor multiply by integer and float scalars matches Nx.BinaryBackend" do
+      for t <- [Nx.tensor([1.0, 2.0, 3.0], type: :f32), Nx.tensor([[1.0, 2.0], [3.0, 4.0]], type: :f64)],
+          s <- [2, -3, 0.5, -1.5] do
+        assert_close(Nx.multiply(ev(t), s), Nx.multiply(t, s))
+        assert_close(Nx.multiply(s, ev(t)), Nx.multiply(s, t))
+      end
+    end
+
+    test "divide by integer and float scalars matches Nx.BinaryBackend" do
+      for t <- [Nx.tensor([4, 9, 12], type: :s32), Nx.tensor([1.0, 2.0, 3.0], type: :f32)],
+          s <- [2, -4, 0.5] do
+        assert_close(Nx.divide(ev(t), s), Nx.divide(t, s))
+        assert_close(Nx.divide(s, ev(t)), Nx.divide(s, t))
+      end
+    end
+  end
+
   describe "cumulative_sum / product / min / max" do
     test "match Nx.BinaryBackend exactly for integer dtypes across axes and :reverse" do
       tensors = [

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -365,12 +365,24 @@ defmodule Evision.Backend.Test do
     end
   end
 
-  describe "multiply / divide by a scalar" do
+  describe "elementwise ops by a scalar operand" do
+    # add/subtract/multiply/divide route a 0-d operand through OpenCV's scalar
+    # fast-path (cast to f64, no full broadcast). The explicit output type keeps
+    # the result dtype correct even when the scalar promotes it.
+    test "add / subtract by integer and float scalars matches Nx.BinaryBackend" do
+      for t <- [Nx.tensor([1, 2, 3], type: :s32), Nx.tensor([1.0, 2.0, 3.0], type: :f32)],
+          s <- [2, -3, 0.5],
+          op <- [:add, :subtract] do
+        assert_close(apply(Nx, op, [ev(t), s]), apply(Nx, op, [t, s]))
+        assert_close(apply(Nx, op, [s, ev(t)]), apply(Nx, op, [s, t]))
+      end
+    end
+
     # Regression: multiplying or dividing by an integer scalar used to raise
     # "no function clause matching in Evision.Backend.to_nx/2". The per-element
     # branch handed a 1x1 integer scalar Mat to cv::multiply, whose scalar
-    # fast-path rejects non-float scalars; broadcasting the scalar to the output
-    # shape first turns it into a supported array-op-array call.
+    # fast-path rejects non-float scalars; casting the scalar to f64 first turns
+    # it into a supported array-op-scalar call.
     test "integer-tensor multiply by an integer scalar matches Nx.BinaryBackend exactly" do
       for t <- [Nx.tensor([1, 2, 3], type: :s32), Nx.tensor([4, 9, 12], type: :s64)],
           s <- [2, -3, 0] do
@@ -440,6 +452,7 @@ defmodule Evision.Backend.Test do
 
                 cond do
                   Nx.shape(got) != Nx.shape(want) -> {:shape, Nx.shape(got), Nx.shape(want)}
+                  Nx.type(got) != Nx.type(want) -> {:type, Nx.type(got), Nx.type(want)}
                   Nx.to_number(Nx.all_close(got, want, atol: 1.0e-5, rtol: 1.0e-5)) != 1 -> :values
                   true -> :ok
                 end

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -406,6 +406,28 @@ defmodule Evision.Backend.Test do
         assert_close(Nx.divide(s, ev(t)), Nx.divide(s, t))
       end
     end
+
+    # min/max derive their dtype from the result, so a fractional scalar must
+    # promote the array (e.g. s32 min 2.5 -> f32); these guard that promotion.
+    test "min / max by integer and float scalars matches Nx.BinaryBackend" do
+      for t <- [Nx.tensor([1, 5, 3], type: :s32), Nx.tensor([1.0, 5.0, 3.0], type: :f32)],
+          s <- [2, -1, 2.5],
+          op <- [:min, :max] do
+        assert_close(apply(Nx, op, [ev(t), s]), apply(Nx, op, [t, s]))
+        assert_close(apply(Nx, op, [s, ev(t)]), apply(Nx, op, [s, t]))
+      end
+    end
+
+    # comparisons happen in the merged type, so a fractional scalar vs an integer
+    # array must not truncate (s32 == 2.5 is always false, not == 2).
+    test "comparisons by integer and float scalars match Nx.BinaryBackend" do
+      for t <- [Nx.tensor([1, 2, 3], type: :s32), Nx.tensor([1.0, 2.0, 3.0], type: :f32)],
+          s <- [2, 2.5, -1],
+          op <- [:equal, :not_equal, :greater, :less, :greater_equal, :less_equal] do
+        assert_same(apply(Nx, op, [ev(t), s]), apply(Nx, op, [t, s]))
+        assert_same(apply(Nx, op, [s, ev(t)]), apply(Nx, op, [s, t]))
+      end
+    end
   end
 
   describe "elementwise broadcasting semantics" do
@@ -427,7 +449,10 @@ defmodule Evision.Backend.Test do
 
     # multiply is excluded: for two non-scalar operands Evision.Backend
     # intentionally does matrix mult rather than elementwise.
-    @elementwise_ops [:add, :subtract, :divide, :min, :max, :equal, :greater, :less]
+    @elementwise_ops [
+      :add, :subtract, :divide, :min, :max,
+      :equal, :not_equal, :greater, :less, :greater_equal, :less_equal
+    ]
 
     test "OpenCV arithmetic itself does not broadcast" do
       a = Evision.Backend.from_nx(ev(Nx.iota({2, 1}, type: :f32)))

--- a/test/evision_backend_test.exs
+++ b/test/evision_backend_test.exs
@@ -428,6 +428,67 @@ defmodule Evision.Backend.Test do
         assert_same(apply(Nx, op, [s, ev(t)]), apply(Nx, op, [s, t]))
       end
     end
+
+    # atan2/pow/quotient/remainder go through mat_binop, which broadcasts a
+    # 1-element operand (stride 0) rather than materializing it.
+    test "atan2 / pow / remainder by a float scalar match Nx.BinaryBackend" do
+      for t <- [Nx.tensor([1.0, 2.0, 3.0], type: :f32)],
+          s <- [2.0, 0.5],
+          op <- [:atan2, :pow, :remainder] do
+        assert_close(apply(Nx, op, [ev(t), s]), apply(Nx, op, [t, s]))
+        assert_close(apply(Nx, op, [s, ev(t)]), apply(Nx, op, [s, t]))
+      end
+    end
+
+    test "pow / quotient / remainder by an integer scalar match Nx.BinaryBackend exactly" do
+      for t <- [Nx.tensor([7, 8, 9], type: :s32)],
+          s <- [2, 3],
+          op <- [:pow, :quotient, :remainder] do
+        assert_same(apply(Nx, op, [ev(t), s]), apply(Nx, op, [t, s]))
+        assert_same(apply(Nx, op, [s, ev(t)]), apply(Nx, op, [s, t]))
+      end
+    end
+
+    test "left_shift / right_shift by a scalar match Nx.BinaryBackend" do
+      for t <- [Nx.tensor([1, 2, 3, 4], type: :s32)],
+          s <- [1, 2],
+          op <- [:left_shift, :right_shift] do
+        assert_same(apply(Nx, op, [ev(t), s]), apply(Nx, op, [t, s]))
+        assert_same(apply(Nx, op, [s, ev(t)]), apply(Nx, op, [s, t]))
+      end
+    end
+  end
+
+  describe "logical_and / or / xor (truthiness)" do
+    test "match Nx.BinaryBackend for non-boolean inputs" do
+      pairs = [
+        {Nx.tensor([2, 4, 6], type: :s32), Nx.tensor([1, 0, 1], type: :s32)},
+        {Nx.tensor([0, 1, 2], type: :s32), Nx.tensor([3, 0, 0], type: :s32)},
+        {Nx.tensor([0.0, 1.5, 0.0], type: :f32), Nx.tensor([2.0, 0.0, 0.0], type: :f32)}
+      ]
+
+      for {a, b} <- pairs, op <- [:logical_and, :logical_or, :logical_xor] do
+        assert_same(apply(Nx, op, [ev(a), ev(b)]), apply(Nx, op, [a, b]))
+      end
+    end
+
+    test "match Nx.BinaryBackend with scalar operands" do
+      for t <- [Nx.tensor([0, 2, 0, 5], type: :s32)],
+          s <- [0, 3],
+          op <- [:logical_and, :logical_or, :logical_xor] do
+        assert_same(apply(Nx, op, [ev(t), s]), apply(Nx, op, [t, s]))
+        assert_same(apply(Nx, op, [s, ev(t)]), apply(Nx, op, [s, t]))
+      end
+    end
+
+    test "broadcast non-scalar operands like Nx.BinaryBackend" do
+      a = Nx.tensor([[1], [0], [2]], type: :s32)
+      b = Nx.tensor([0, 1, 3], type: :s32)
+
+      for op <- [:logical_and, :logical_or, :logical_xor] do
+        assert_same(apply(Nx, op, [ev(a), ev(b)]), apply(Nx, op, [a, b]))
+      end
+    end
   end
 
   describe "elementwise broadcasting semantics" do


### PR DESCRIPTION
## Summary

Makes `Evision.Backend` agree with `Nx.BinaryBackend` across every elementwise binary op (correctness) and removes the scalar-operand broadcast overhead from all of them (perf). Everything is verified against `Nx.BinaryBackend` as the oracle.

## Correctness

- **`Nx.multiply/divide(tensor, integer_scalar)` raised** `no function clause matching in Evision.Backend.to_nx/2`. OpenCV's arithmetic only treats a 1x1 operand as a scalar when it is f64; an integer (or f32) 1x1 is rejected, so the NIF returned an error tuple `to_nx/2` had no clause for.

- **N-dimensional broadcasting returned wrong values** for rank-differing and multi-axis broadcasts (e.g. `{3,4} -> {2,3,4}`). The `mat_broadcast_to` tiling divided by zero for `ndims >= 3` when the trailing dim was not stretched; on AArch64 integer div-by-zero yields 0 (no trap), so it returned garbage. Rewrote it as a direct NumPy/Nx broadcast, and the `broadcast/4` callback now honours Nx's `:axes` (was right-align-only).

- **`logical_and` / `logical_xor` were wrong for non-boolean inputs**: they did bitwise `&`/`^` over the raw values, so `logical_and(2, 1)` gave 0 instead of 1, and `logical_xor` raised for any non-u8 type (it mixed an int operand with a u8 mask). Reimplemented all three as truthiness compositions over `!= 0` masks (`min`=and, `max`=or, `not_equal`=xor), correct for any dtype.

- Restored a `reject_error/1` that `less_equal` was silently missing.

## Performance

A 0-d operand no longer materializes a full broadcast array, across every elementwise binary op:
- **add/subtract/multiply/divide**: cast the scalar to f64 and use OpenCV's scalar fast-path (explicit output type keeps the result dtype correct).
- **min/max**: `cv::min/max(Mat, double)` with the array cast to the promoted output type.
- **comparisons**: `cv::compare`'s 1x1 broadcast with both operands cast to the merged type (so `s32 == 2.5` stays all-false instead of truncating).
- **atan2/pow/quotient/remainder** and **left_shift/right_shift**: the custom NIF kernels (`mat_binop`, `mat_shift`) broadcast a 1-element operand with stride 0.

Scalar elementwise ops on a 2048x2048 tensor drop from ~19ms to ~1.5-4.5ms (~4-13x); promotion cases pay one array cast.

## Testing

`mix test test/evision_backend_test.exs` -> 84 tests, 0 failures. New coverage:
- scalar operand for every elementwise binary op (int + float scalars, mixed dtypes, both operand positions);
- logical truthiness for non-boolean inputs, scalars, and broadcasting;
- a broadcasting matrix (elementwise ops x f32/s32 x 14 shape pairs) and direct `Nx.broadcast` across ranks/dtypes/explicit axes (incl. non-right-aligned);
- an assertion that OpenCV arithmetic itself does not broadcast.
