### PR TITLE
feat(js): precompile a CSP-clean opencv.js (-s DYNAMIC_EXECUTION=0)

### DIFF
--- a/.github/workflows/opencv-js-precompile.yml
+++ b/.github/workflows/opencv-js-precompile.yml
@@ -1,0 +1,143 @@
+name: opencv-js-precompile
+
+# Builds a CSP-clean opencv.js (runs under `script-src 'wasm-unsafe-eval'` with
+# no `'unsafe-eval'`) from OpenCV source and publishes it as an immutable release
+# asset. Single arch-independent target, so no build matrix. See
+# scripts/build_opencv_js.sh for why this differs from stock only by
+# -s DYNAMIC_EXECUTION=0.
+
+on:
+  workflow_dispatch:
+    inputs:
+      opencv_ver:
+        description: "OpenCV version to build opencv.js for"
+        required: false
+        default: "5.0.0"
+      embind_aot:
+        description: "Also pass -s EMBIND_AOT=1 (faster embind invokers, may fail to link on some bindings)"
+        type: boolean
+        required: false
+        default: false
+      publish_release:
+        description: "Publish opencv.js as a release asset (outward-facing; off = build + verify only)"
+        type: boolean
+        required: false
+        default: false
+  push:
+    tags:
+      - "opencv-js-v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # the publish step creates the release and uploads assets
+    env:
+      # Proven-good pin for OpenCV 5.0.0 embind (needs C++17 since emsdk 4.0.20).
+      EMSDK_VERSION: "4.0.20"
+      OPENCV_JS_EMBIND_AOT: ${{ github.event.inputs.embind_aot == 'true' && '1' || '0' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve OpenCV version
+        env:
+          INPUT_VER: ${{ github.event.inputs.opencv_ver }}
+        run: |
+          if [ -n "$INPUT_VER" ]; then
+            version="$INPUT_VER"
+          elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            version="${GITHUB_REF_NAME#opencv-js-v}"
+          else
+            version="5.0.0"
+          fi
+          echo "OPENCV_VER=${version}" >> "$GITHUB_ENV"
+          echo "building opencv.js for OpenCV ${version}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node (for the CSP verification)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Cache Emscripten SDK
+        id: cache-emsdk
+        uses: actions/cache@v6
+        with:
+          key: emsdk-${{ env.EMSDK_VERSION }}
+          path: ./emsdk
+
+      - name: Install Emscripten SDK
+        run: |
+          if [ ! -d emsdk/.git ]; then
+            git clone --depth 1 https://github.com/emscripten-core/emsdk.git emsdk
+          fi
+          cd emsdk
+          ./emsdk install "${EMSDK_VERSION}"
+          ./emsdk activate "${EMSDK_VERSION}"
+
+      - name: Cache OpenCV source
+        id: cache-opencv
+        uses: actions/cache@v6
+        with:
+          key: opencv-src-${{ env.OPENCV_VER }}
+          path: ./3rd_party
+
+      - name: Download OpenCV source
+        if: steps.cache-opencv.outputs.cache-hit != 'true'
+        run: bash scripts/download_opencv.sh "${OPENCV_VER}" 3rd_party/cache 3rd_party/opencv
+
+      - name: Build CSP-clean opencv.js
+        run: |
+          . ./emsdk/emsdk_env.sh
+          sh scripts/build_opencv_js.sh "${OPENCV_VER}" "3rd_party/opencv/opencv-${OPENCV_VER}" out
+
+      - name: Verify functional (eval allowed)
+        run: node scripts/verify_opencv_js_csp.mjs out/opencv.js
+
+      - name: Verify CSP-clean (eval disabled == no 'unsafe-eval')
+        env:
+          REQUIRE_NO_EVAL: "1"
+        run: node --disallow-code-generation-from-strings scripts/verify_opencv_js_csp.mjs out/opencv.js
+
+      - name: Scan for residual eval / new Function call sites
+        run: |
+          count=$(grep -oE "eval\(|new Function\(" out/opencv.js | wc -l | tr -d ' ')
+          echo "eval( / new Function( occurrences: ${count}"
+          if [ "${count}" != "0" ]; then
+            echo "::warning::${count} eval/new Function occurrences (inspect; string literals/comments are benign, the eval-disabled verify step is the real gate)"
+          fi
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencv-js-${{ env.OPENCV_VER }}-csp-clean
+          path: |
+            out/opencv.js
+            out/opencv.sha256
+          if-no-files-found: error
+
+      - name: Publish release asset
+        if: github.event_name == 'push' || github.event.inputs.publish_release == 'true'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('opencv-js-v{0}', env.OPENCV_VER) }}
+          name: opencv.js ${{ env.OPENCV_VER }} (CSP-clean)
+          body: |
+            CSP-clean opencv.js for OpenCV ${{ env.OPENCV_VER }}: the stock single-threaded,
+            single-file WASM build with OpenCV's default whitelist, differing only by
+            `-s DYNAMIC_EXECUTION=0` so it runs under `script-src 'wasm-unsafe-eval'`
+            with no `'unsafe-eval'`. Verified by loading + exercising embind under Node's
+            `--disallow-code-generation-from-strings`. `opencv.sha256` pins the exact bytes.
+          files: |
+            out/opencv.js
+            out/opencv.sha256
+          fail_on_unmatched_files: true

--- a/scripts/build_opencv_js.sh
+++ b/scripts/build_opencv_js.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Build a CSP-clean opencv.js from OpenCV source.
+#
+# "CSP-clean" means the artifact runs under a Content-Security-Policy of
+# `script-src 'wasm-unsafe-eval'` with NO `'unsafe-eval'`. Stock
+# docs.opencv.org/<ver>/opencv.js needs `'unsafe-eval'` because embind's
+# createNamedFunction/craftInvokerFunction build invokers with `new Function`.
+# Emscripten `-s DYNAMIC_EXECUTION=0` compiles those string->code paths out.
+#
+# The build is otherwise identical to the stock recipe: single-threaded
+# (USE_PTHREADS=0), single-file WASM, and OpenCV's own default
+# platforms/js/opencv_js.config.py whitelist. Keeping every other input
+# equal is deliberate: evision's `@js` correspondence table is generated
+# from that same whitelist, so the exported JS API must not drift.
+#
+# Requires an activated Emscripten SDK (emcc on PATH).
+#
+# Usage: scripts/build_opencv_js.sh <opencv_ver> <opencv_src_dir> <out_dir>
+
+set -eu
+
+OPENCV_VER="${1:?usage: build_opencv_js.sh <opencv_ver> <opencv_src_dir> <out_dir>}"
+OPENCV_DIR="${2:?opencv source directory (contains platforms/js/build_js.py)}"
+OUT_DIR="${3:?output directory}"
+
+if ! command -v emcmake >/dev/null 2>&1; then
+  echo "emcmake not found on PATH; activate the Emscripten SDK first (source emsdk_env.sh)" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not found on PATH (build_js.py needs it)" >&2
+  exit 1
+fi
+
+if [ ! -f "${OPENCV_DIR}/platforms/js/build_js.py" ]; then
+  echo "no build_js.py under ${OPENCV_DIR}/platforms/js" >&2
+  exit 1
+fi
+
+BUILD_DIR="${OUT_DIR}/build_js_${OPENCV_VER}"
+mkdir -p "${OUT_DIR}"
+
+echo "emcc: $(emcc --version | head -1)"
+echo "building opencv.js ${OPENCV_VER} (CSP-clean: -s DYNAMIC_EXECUTION=0)"
+
+# -s DYNAMIC_EXECUTION=0 compiles out embind's eval/new Function invokers; embind
+# falls back to an eval-free path (correct, but the JS<->wasm invoker layer is
+# ~8-10x slower for hot calls; the OpenCV compute itself is unaffected).
+#   Set OPENCV_JS_EMBIND_AOT=1 to also pass -s EMBIND_AOT=1, which regenerates
+# those invokers at compile time (eval-free AND fast). AOT can fail to link on
+# some binding shapes (emscripten #22862); if it does, rerun without it -- the
+# plain build is still fully CSP-clean.
+EXTRA_FLAGS="-s DYNAMIC_EXECUTION=0"
+if [ "${OPENCV_JS_EMBIND_AOT:-0}" = "1" ]; then
+  EXTRA_FLAGS="${EXTRA_FLAGS} -s EMBIND_AOT=1"
+fi
+echo "extra emscripten flags: ${EXTRA_FLAGS}"
+
+# --build_wasm + defaults reproduce the stock build; EXTRA_FLAGS is the only
+# delta. Do NOT pass --threads/--simd/--config: single-thread and the default
+# whitelist are exactly what the published docs build uses, so the exported JS
+# API stays identical to stock and evision's @js table stays valid.
+emcmake python3 "${OPENCV_DIR}/platforms/js/build_js.py" "${BUILD_DIR}" \
+  --opencv_dir "${OPENCV_DIR}" \
+  --build_wasm \
+  --build_flags="${EXTRA_FLAGS}"
+
+OPENCV_JS="${BUILD_DIR}/bin/opencv.js"
+if [ ! -f "${OPENCV_JS}" ]; then
+  OPENCV_JS="$(find "${BUILD_DIR}" -name opencv.js -type f 2>/dev/null | head -1 || true)"
+fi
+if [ -z "${OPENCV_JS}" ] || [ ! -f "${OPENCV_JS}" ]; then
+  echo "build produced no opencv.js under ${BUILD_DIR}" >&2
+  exit 1
+fi
+
+cp "${OPENCV_JS}" "${OUT_DIR}/opencv.js"
+( cd "${OUT_DIR}" && { if command -v sha256sum >/dev/null 2>&1; then sha256sum opencv.js; else shasum -a 256 opencv.js; fi; } > opencv.sha256 )
+
+echo "built: ${OUT_DIR}/opencv.js ($(wc -c < "${OUT_DIR}/opencv.js") bytes)"
+cat "${OUT_DIR}/opencv.sha256"

--- a/scripts/verify_opencv_js_csp.mjs
+++ b/scripts/verify_opencv_js_csp.mjs
@@ -1,0 +1,98 @@
+// Prove an opencv.js build is CSP-clean.
+//
+// Run under Node's --disallow-code-generation-from-strings, which makes
+// eval()/new Function() throw EvalError exactly as a Content-Security-Policy
+// without 'unsafe-eval' does in a browser. WebAssembly instantiation is not
+// blocked by that flag, mirroring a policy that still allows 'wasm-unsafe-eval'.
+//
+// If embind still needed string->code to build its invokers, initialization
+// would throw. Reaching a working cv.Mat proves the runtime is clean.
+//
+// Usage:
+//   node [--disallow-code-generation-from-strings] verify_opencv_js_csp.mjs <opencv.js>
+//
+// With REQUIRE_NO_EVAL=1, assert that code generation really is disabled, so a
+// strict check fails loudly if the node flag is ever dropped.
+
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+function die(err) {
+  const detail = err?.stack ?? String(err);
+  const evalRelated = /code generation from strings|EvalError|new Function/i.test(detail);
+  console.error(`FAIL${evalRelated ? " (eval/CSP)" : ""}: ${detail}`);
+  process.exit(1);
+}
+
+// opencv.js may abort on a later tick (embind/emscripten throw asynchronously);
+// route those to the same failure path rather than a bare stack trace.
+process.on("uncaughtException", die);
+process.on("unhandledRejection", die);
+
+const target = process.argv[2];
+if (!target) {
+  console.error("usage: node verify_opencv_js_csp.mjs <opencv.js>");
+  process.exit(2);
+}
+
+// Whether this process forbids eval()/new Function() -- the CSP posture we assert.
+const codegenDisabled = (() => {
+  try {
+    new Function("");
+    return false;
+  } catch {
+    return true;
+  }
+})();
+
+if (process.env.REQUIRE_NO_EVAL === "1" && !codegenDisabled) {
+  die("REQUIRE_NO_EVAL=1 but eval is allowed; pass --disallow-code-generation-from-strings");
+}
+
+// opencv.js is a UMD/CommonJS bundle, so require() it. resolve() against cwd so a
+// caller-relative path ("out/opencv.js") is found, not one relative to this file.
+const require = createRequire(import.meta.url);
+
+// OpenCV 5.0's modules/js/CMakeLists.txt sets MODULARIZE=1 / EXPORT_NAME='cv', so
+// the export is a factory returning a promise; tolerate the older shapes too.
+function initialize(exported) {
+  const mod = typeof exported === "function" ? exported() : exported;
+  if (mod && typeof mod.then === "function") return mod;
+  if (mod && mod.Mat) return Promise.resolve(mod);
+  if (mod) return new Promise((res) => (mod.onRuntimeInitialized = () => res(mod)));
+  return Promise.reject(new Error("opencv.js export was empty"));
+}
+
+// A live timer keeps the event loop alive, so a module that never initializes
+// fails here instead of letting the process exit 0 without verifying anything.
+function withTimeout(promise, ms) {
+  return new Promise((res, rej) => {
+    const timer = setTimeout(() => rej(new Error(`timed out after ${ms}ms waiting for init`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        res(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        rej(err);
+      },
+    );
+  });
+}
+
+async function main() {
+  const cv = await withTimeout(initialize(require(resolve(target))), 120_000);
+
+  const mat = new cv.Mat(3, 3, cv.CV_8UC1); // exercises an embind constructor invoker
+  try {
+    if (mat.rows !== 3) throw new Error(`unexpected Mat.rows: ${mat.rows}`);
+  } finally {
+    mat.delete();
+  }
+
+  const posture = codegenDisabled ? "disabled" : "allowed";
+  console.log(`PASS: opencv.js initialized and embind Mat works (code generation from strings ${posture})`);
+}
+
+main().catch(die);


### PR DESCRIPTION
## What

Adds a from-source `opencv.js` build that differs from the stock `docs.opencv.org/<ver>/opencv.js` build by exactly one flag, `-s DYNAMIC_EXECUTION=0`, so the artifact runs under a Content-Security-Policy of `script-src 'wasm-unsafe-eval'` with no `'unsafe-eval'`.

Stock `opencv.js` needs `'unsafe-eval'` because embind builds its invokers with `new Function`. `-s DYNAMIC_EXECUTION=0` compiles those string-to-code paths out and embind falls back to an eval-free path.

Everything else is kept identical to stock on purpose: same OpenCV version, the default `platforms/js/opencv_js.config.py` whitelist, and single-threaded (no pthreads, so no COOP/COEP/`worker-src`). Keeping the exported JS API equal to stock is what lets evision's generated `@js` correspondence table stay valid.

## Files

- `scripts/build_opencv_js.sh`: build wrapper around `build_js.py`. Opt-in `OPENCV_JS_EMBIND_AOT=1` also passes `-s EMBIND_AOT=1`, which restores embind call speed with no eval. AOT can fail to link on some bindings, so it stays opt-in and the plain build is the safe default.
- `scripts/verify_opencv_js_csp.mjs`: loads and exercises an embind `cv.Mat` under Node's `--disallow-code-generation-from-strings`, which blocks `eval`/`new Function` while still allowing WebAssembly, i.e. the exact runtime equivalent of the target CSP. `REQUIRE_NO_EVAL=1` makes it fail if that flag is ever dropped, so the strict check cannot silently degrade.
- `.github/workflows/opencv-js-precompile.yml`: install pinned emsdk, build, run both verifies, and publish `opencv.js` + `opencv.sha256` as an immutable release asset. The release publish is gated behind a manual `publish_release` input or an `opencv-js-v*` tag, so a dispatch can build and verify without publishing.

## Verified

Built against OpenCV 5.0.0 with emsdk 4.0.20:

- initializes and runs `cv.Mat` with code generation from strings disabled;
- `0` `new Function(` / reachable `eval(` / `createNamedFunction` call sites in the output;
- verifier exercised in 5 modes (functional, strict, guard-trips, relative-path, missing-arg); shellcheck clean; workflow YAML validated.

## Notes

- `-s DYNAMIC_EXECUTION=0` alone slows embind's JS/wasm invoker layer for hot calls (the OpenCV compute is unaffected). `OPENCV_JS_EMBIND_AOT=1` recovers it.
- Emscripten output is not bit-reproducible across environments, so a consumer should pin against the checksum of the published asset, not a local build.
