### PR TITLE
feat(js): opencv.js correspondence tag (@js) + CSP-clean opencv.js build

### DIFF
--- a/.github/workflows/opencv-js-precompile.yml
+++ b/.github/workflows/opencv-js-precompile.yml
@@ -1,0 +1,143 @@
+name: opencv-js-precompile
+
+# Builds a CSP-clean opencv.js (runs under `script-src 'wasm-unsafe-eval'` with
+# no `'unsafe-eval'`) from OpenCV source and publishes it as an immutable release
+# asset. Single arch-independent target, so no build matrix. See
+# scripts/build_opencv_js.sh for why this differs from stock only by
+# -s DYNAMIC_EXECUTION=0.
+
+on:
+  workflow_dispatch:
+    inputs:
+      opencv_ver:
+        description: "OpenCV version to build opencv.js for"
+        required: false
+        default: "5.0.0"
+      embind_aot:
+        description: "Also pass -s EMBIND_AOT=1 (faster embind invokers, may fail to link on some bindings)"
+        type: boolean
+        required: false
+        default: false
+      publish_release:
+        description: "Publish opencv.js as a release asset (outward-facing; off = build + verify only)"
+        type: boolean
+        required: false
+        default: false
+  push:
+    tags:
+      - "opencv-js-v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # the publish step creates the release and uploads assets
+    env:
+      # Proven-good pin for OpenCV 5.0.0 embind (needs C++17 since emsdk 4.0.20).
+      EMSDK_VERSION: "4.0.20"
+      OPENCV_JS_EMBIND_AOT: ${{ github.event.inputs.embind_aot == 'true' && '1' || '0' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve OpenCV version
+        env:
+          INPUT_VER: ${{ github.event.inputs.opencv_ver }}
+        run: |
+          if [ -n "$INPUT_VER" ]; then
+            version="$INPUT_VER"
+          elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            version="${GITHUB_REF_NAME#opencv-js-v}"
+          else
+            version="5.0.0"
+          fi
+          echo "OPENCV_VER=${version}" >> "$GITHUB_ENV"
+          echo "building opencv.js for OpenCV ${version}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node (for the CSP verification)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Cache Emscripten SDK
+        id: cache-emsdk
+        uses: actions/cache@v6
+        with:
+          key: emsdk-${{ env.EMSDK_VERSION }}
+          path: ./emsdk
+
+      - name: Install Emscripten SDK
+        run: |
+          if [ ! -d emsdk/.git ]; then
+            git clone --depth 1 https://github.com/emscripten-core/emsdk.git emsdk
+          fi
+          cd emsdk
+          ./emsdk install "${EMSDK_VERSION}"
+          ./emsdk activate "${EMSDK_VERSION}"
+
+      - name: Cache OpenCV source
+        id: cache-opencv
+        uses: actions/cache@v6
+        with:
+          key: opencv-src-${{ env.OPENCV_VER }}
+          path: ./3rd_party
+
+      - name: Download OpenCV source
+        if: steps.cache-opencv.outputs.cache-hit != 'true'
+        run: bash scripts/download_opencv.sh "${OPENCV_VER}" 3rd_party/cache 3rd_party/opencv
+
+      - name: Build CSP-clean opencv.js
+        run: |
+          . ./emsdk/emsdk_env.sh
+          sh scripts/build_opencv_js.sh "${OPENCV_VER}" "3rd_party/opencv/opencv-${OPENCV_VER}" out
+
+      - name: Verify functional (eval allowed)
+        run: node scripts/verify_opencv_js_csp.mjs out/opencv.js
+
+      - name: Verify CSP-clean (eval disabled == no 'unsafe-eval')
+        env:
+          REQUIRE_NO_EVAL: "1"
+        run: node --disallow-code-generation-from-strings scripts/verify_opencv_js_csp.mjs out/opencv.js
+
+      - name: Scan for residual eval / new Function call sites
+        run: |
+          count=$(grep -oE "eval\(|new Function\(" out/opencv.js | wc -l | tr -d ' ')
+          echo "eval( / new Function( occurrences: ${count}"
+          if [ "${count}" != "0" ]; then
+            echo "::warning::${count} eval/new Function occurrences (inspect; string literals/comments are benign, the eval-disabled verify step is the real gate)"
+          fi
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencv-js-${{ env.OPENCV_VER }}-csp-clean
+          path: |
+            out/opencv.js
+            out/opencv.sha256
+          if-no-files-found: error
+
+      - name: Publish release asset
+        if: github.event_name == 'push' || github.event.inputs.publish_release == 'true'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('opencv-js-v{0}', env.OPENCV_VER) }}
+          name: opencv.js ${{ env.OPENCV_VER }} (CSP-clean)
+          body: |
+            CSP-clean opencv.js for OpenCV ${{ env.OPENCV_VER }}: the stock single-threaded,
+            single-file WASM build with OpenCV's default whitelist, differing only by
+            `-s DYNAMIC_EXECUTION=0` so it runs under `script-src 'wasm-unsafe-eval'`
+            with no `'unsafe-eval'`. Verified by loading + exercising embind under Node's
+            `--disallow-code-generation-from-strings`. `opencv.sha256` pins the exact bytes.
+          files: |
+            out/opencv.js
+            out/opencv.sha256
+          fail_on_unmatched_files: true

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Evision.MixProject.Metadata do
   @moduledoc false
 
   def app, do: :evision
-  def version, do: "1.0.0"
+  def version, do: "1.0.1"
   def github_url, do: "https://github.com/cocoa-xu/evision"
   def opencv_version, do: "5.0.0"
   # evision 1.0.x targets OpenCV 5.0.x only.

--- a/py_src/evision_js_attr.py
+++ b/py_src/evision_js_attr.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Resolve evision ↔ opencv.js correspondences for the codegen ``@js`` tag.
+
+The whitelist source of truth is OpenCV's own
+``platforms/js/opencv_js.config.py`` (parsed by ``opencv_js_whitelist``).
+This module turns that flat data into an ``(classname, fn_name) → entry``
+index keyed by the C++ shape evision's ``FuncInfo`` exposes, and renders
+Elixir/Erlang persistent-attribute syntax for the codegen to splice in.
+
+If the OpenCV source tree is not on disk (e.g. when building against a
+precompiled binary), the lookup degrades to "no matches" — the codegen
+still produces output, just without ``@js`` tags.
+
+See ``projects/evision/context/js-correspondence-tag.md`` in the
+``cocoa/ai-native`` notebook for the full design.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+from opencv_js_whitelist import (
+    ConfigNotFoundError,
+    entries,
+    namespace_prefix_override,
+)
+
+
+JsEntry = Dict[str, object]
+LookupKey = Tuple[Optional[str], str]
+
+
+_INDEX: Optional[Dict[LookupKey, JsEntry]] = None
+
+
+def _build_index() -> Dict[LookupKey, JsEntry]:
+    overrides = namespace_prefix_override()
+    index: Dict[LookupKey, JsEntry] = {}
+    for _module, classname, fn_name, kind in entries():
+        key: LookupKey = (classname, fn_name)
+        if classname is None:
+            index[key] = {"js_kind": "function", "js_name": f"cv.{fn_name}"}
+        elif kind == "constructor":
+            index[key] = {
+                "js_kind": "constructor",
+                "js_class": f"cv.{_js_class_for(classname, overrides)}",
+            }
+        else:
+            index[key] = {
+                "js_kind": "method",
+                "js_class": f"cv.{_js_class_for(classname, overrides)}",
+                "js_method": fn_name,
+            }
+    return index
+
+
+def _ensure_loaded() -> Dict[LookupKey, JsEntry]:
+    global _INDEX
+    if _INDEX is None:
+        try:
+            _INDEX = _build_index()
+        except ConfigNotFoundError:
+            _INDEX = {}
+    return _INDEX
+
+
+def lookup_for_func(func) -> Optional[JsEntry]:
+    """Return the opencv.js entry matching an evision ``FuncInfo``, or ``None``.
+
+    Lookup uses C++ shapes (``func.name``, ``func.classname``) per CCD-18's
+    closing refinements: the post-folded Elixir name lowercases the first
+    letter so a match against ``Canny`` would miss.
+    """
+    index = _ensure_loaded()
+    if not index:
+        return None
+    if func.isconstructor:
+        # The whitelist names the constructor as the bare class segment
+        # (``aruco_Dictionary`` → ``Dictionary``), not the full path-joined
+        # name ``func.name`` carries.
+        bare = func.classname.rsplit("_", 1)[-1] if func.classname else ""
+        key: LookupKey = (func.classname, bare)
+    elif func.classname:
+        key = (func.classname, func.name)
+    else:
+        ns = func.namespace
+        if ns == "cv":
+            key = (None, func.name)
+        elif ns.startswith("cv."):
+            # ``cv::fisheye::undistortImage`` lives in ``calib3d['']`` as
+            # ``fisheye_undistortImage`` — the C++ namespace below ``cv`` is
+            # flattened into the fn_name with an underscore separator.
+            ns_below = ns[3:].replace(".", "_")
+            key = (None, f"{ns_below}_{func.name}")
+        else:
+            return None
+    return index.get(key)
+
+
+def _js_class_for(class_key: str, overrides: Dict[str, str]) -> str:
+    """Project a whitelist class key onto its opencv.js class name.
+
+    embindgen's ``namespace_prefix_override`` strips ``dnn_``/``aruco_``
+    prefixes when the whitelist is a Python file (defaults live in
+    ``opencv_js_whitelist.DEFAULT_NAMESPACE_PREFIX_OVERRIDE``).
+    """
+    if "_" in class_key:
+        prefix, rest = class_key.split("_", 1)
+        if prefix in overrides:
+            override = overrides[prefix]
+            return f"{override}.{rest}" if override else rest
+    return class_key
+
+
+# ----- Source emitters ----------------------------------------------------
+
+
+def elixir_register_attribute() -> str:
+    """Single line that opts a module into accumulating ``@js`` attributes."""
+    return (
+        "  Module.register_attribute(__MODULE__, :js, persist: true, accumulate: true)\n"
+    )
+
+
+def elixir_attribute_line(entry: JsEntry, fun: str, arity: int) -> str:
+    """``  @js %{...}\\n`` line ready to splice before a ``def`` clause."""
+    fields = [
+        f"fun: {_elixir_atom(fun)}",
+        f"arity: {arity}",
+        f"js_kind: :{entry['js_kind']}",
+    ]
+    if "js_name" in entry:
+        fields.append(f'js_name: "{entry["js_name"]}"')
+    if "js_class" in entry:
+        fields.append(f'js_class: "{entry["js_class"]}"')
+    if "js_method" in entry:
+        fields.append(f'js_method: "{entry["js_method"]}"')
+    return f"  @js %{{{', '.join(fields)}}}\n"
+
+
+def erlang_attribute_line(entry: JsEntry, fun: str, arity: int) -> str:
+    """``-js(#{...}).\\n`` line ready to splice before a function clause."""
+    fields = [
+        f"fun => {_erlang_atom(fun)}",
+        f"arity => {arity}",
+        f"js_kind => {entry['js_kind']}",
+    ]
+    if "js_name" in entry:
+        fields.append(f'js_name => <<"{entry["js_name"]}">>')
+    if "js_class" in entry:
+        fields.append(f'js_class => <<"{entry["js_class"]}">>')
+    if "js_method" in entry:
+        fields.append(f'js_method => <<"{entry["js_method"]}">>')
+    return f"-js(#{{{', '.join(fields)}}}).\n"
+
+
+def _elixir_atom(name: str) -> str:
+    # All evision-emitted def names are valid bare Elixir atoms (letter,
+    # then letters/digits/underscore). The quoted form would still work but
+    # would clutter generated source.
+    return f":{name}"
+
+
+def _erlang_atom(name: str) -> str:
+    # Erlang atoms must start with lowercase. The evision codegen lowercases
+    # the first character of every emitted name (`map_argname_elixir`,
+    # `get_module_func_name`), so this is always safe without quoting.
+    return name

--- a/py_src/evision_js_attr.py
+++ b/py_src/evision_js_attr.py
@@ -18,7 +18,8 @@ See ``projects/evision/context/js-correspondence-tag.md`` in the
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple
+import sys
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from opencv_js_whitelist import (
     ConfigNotFoundError,
@@ -26,9 +27,15 @@ from opencv_js_whitelist import (
     namespace_prefix_override,
 )
 
+if sys.version_info[0] >= 3:
+    from io import StringIO
+else:
+    from cStringIO import StringIO
+
 
 JsEntry = Dict[str, object]
 LookupKey = Tuple[Optional[str], str]
+RuntimeEntry = Dict[str, object]
 
 
 _INDEX: Optional[Dict[LookupKey, JsEntry]] = None
@@ -167,3 +174,168 @@ def _erlang_atom(name: str) -> str:
     # the first character of every emitted name (`map_argname_elixir`,
     # `get_module_func_name`), so this is always safe without quoting.
     return name
+
+
+# ----- Runtime module emission (Evision.JS / evision_js) ------------------
+
+
+def collect_runtime_entries(module_generators: Iterable, kind: str) -> List[RuntimeEntry]:
+    """Flatten ``js_attrs[kind]`` across every emitted ``ModuleGenerator``.
+
+    Each ``ModuleGenerator`` carries its own
+    ``js_attrs[kind] = {fun_name: {arity: js_entry}}``. The runtime module
+    needs a single flat list of entries keyed by
+    ``(module, fun, arity)`` — the Elixir module name is reconstructed
+    from the generator's ``module_name`` (the root ``Evision`` keeps that
+    bare name; everything else is prefixed with ``Evision.``).
+
+    Output is sorted by ``(module, fun, arity)`` so the generated source
+    is reproducible across runs.
+    """
+    out: List[RuntimeEntry] = []
+    for mg in module_generators:
+        mod_name = mg.module_name
+        full_module = mod_name if mod_name == "Evision" else f"Evision.{mod_name}"
+        kind_attrs = mg.js_attrs.get(kind) or {}
+        for fun_name, by_arity in kind_attrs.items():
+            for arity, js_entry in by_arity.items():
+                entry: RuntimeEntry = {
+                    "module": full_module,
+                    "fun": fun_name,
+                    "arity": arity,
+                    "js_kind": js_entry["js_kind"],
+                }
+                for optional_key in ("js_name", "js_class", "js_method"):
+                    if optional_key in js_entry:
+                        entry[optional_key] = js_entry[optional_key]
+                out.append(entry)
+    out.sort(key=lambda e: (e["module"], e["fun"], e["arity"]))
+    return out
+
+
+def elixir_runtime_module(entries_list: List[RuntimeEntry]) -> str:
+    """Render ``lib/generated/evision_js.ex`` from a flat entry list."""
+    out = StringIO()
+    out.write("defmodule Evision.JS do\n")
+    out.write('  @moduledoc """\n')
+    out.write("  Generated map of evision bindings to their opencv.js counterparts.\n")
+    out.write("\n")
+    out.write("  Each entry carries the Elixir `(module, fun, arity)` plus the\n")
+    out.write("  opencv.js call shape: `:js_kind` discriminates between\n")
+    out.write("  `:function`, `:method` and `:constructor`; `:js_name` is set\n")
+    out.write("  for free functions, `:js_class` for class methods and\n")
+    out.write("  constructors, and `:js_method` for methods only.\n")
+    out.write('  """\n\n')
+    out.write('  @typedoc "An opencv.js correspondence entry."\n')
+    out.write("  @type entry :: %{\n")
+    out.write("          required(:module) => module(),\n")
+    out.write("          required(:fun) => atom(),\n")
+    out.write("          required(:arity) => arity(),\n")
+    out.write("          required(:js_kind) => :function | :method | :constructor,\n")
+    out.write("          optional(:js_name) => String.t(),\n")
+    out.write("          optional(:js_class) => String.t(),\n")
+    out.write("          optional(:js_method) => String.t()\n")
+    out.write("        }\n\n")
+    if entries_list:
+        out.write("  @whitelist [\n")
+        for entry in entries_list:
+            out.write("    " + _elixir_entry_literal(entry) + ",\n")
+        out.write("  ]\n\n")
+    else:
+        out.write("  @whitelist []\n\n")
+    out.write("  @index Map.new(@whitelist, fn entry -> {{entry.module, entry.fun, entry.arity}, entry} end)\n\n")
+    out.write('  @doc "Every opencv.js correspondence entry emitted by evision\'s codegen."\n')
+    out.write("  @spec whitelist() :: [entry()]\n")
+    out.write("  def whitelist, do: @whitelist\n\n")
+    out.write('  @doc "Return `{:ok, entry}` for a known `(module, fun, arity)`; `:error` otherwise."\n')
+    out.write("  @spec lookup(module(), atom(), arity()) :: {:ok, entry()} | :error\n")
+    out.write("  def lookup(module, fun, arity), do: Map.fetch(@index, {module, fun, arity})\n\n")
+    out.write('  @doc "Whether the given `(module, fun, arity)` has an opencv.js counterpart."\n')
+    out.write("  @spec runnable?(module(), atom(), arity()) :: boolean()\n")
+    out.write("  def runnable?(module, fun, arity), do: Map.has_key?(@index, {module, fun, arity})\n")
+    out.write("end\n")
+    return out.getvalue()
+
+
+def erlang_runtime_module(entries_list: List[RuntimeEntry]) -> str:
+    """Render ``src/generated/evision_js.erl`` from a flat entry list.
+
+    ``fun`` is a reserved word in Erlang's expression / type-spec grammar,
+    so every map key referring to that field is quoted as ``'fun'``.
+    Inside ``-attribute(#{...}).`` declarations (CCD-19's ``-js(...)``) the
+    attribute parser is more permissive and bare ``fun`` works there — that
+    permissiveness does NOT extend to function bodies or ``-spec``s.
+    """
+    out = StringIO()
+    out.write("-module(evision_js).\n")
+    out.write("-compile(nowarn_export_all).\n")
+    out.write("-compile([export_all]).\n\n")
+    out.write("-type entry() :: #{\n")
+    out.write("    module := module(),\n")
+    out.write("    'fun' := atom(),\n")
+    out.write("    arity := arity(),\n")
+    out.write("    js_kind := function | method | constructor,\n")
+    out.write("    js_name => binary(),\n")
+    out.write("    js_class => binary(),\n")
+    out.write("    js_method => binary()\n")
+    out.write("}.\n\n")
+    out.write("-spec whitelist() -> [entry()].\n")
+    out.write("whitelist() ->\n")
+    if entries_list:
+        out.write("    [\n")
+        for i, entry in enumerate(entries_list):
+            sep = "," if i < len(entries_list) - 1 else ""
+            out.write(f"        {_erlang_entry_literal(entry)}{sep}\n")
+        out.write("    ].\n\n")
+    else:
+        out.write("    [].\n\n")
+    out.write("-spec lookup(module(), atom(), arity()) -> {ok, entry()} | error.\n")
+    out.write("lookup(Module, Fun, Arity) ->\n")
+    out.write("    maps:find({Module, Fun, Arity}, index()).\n\n")
+    out.write("-spec runnable(module(), atom(), arity()) -> boolean().\n")
+    out.write("runnable(Module, Fun, Arity) ->\n")
+    out.write("    maps:is_key({Module, Fun, Arity}, index()).\n\n")
+    out.write("index() ->\n")
+    if entries_list:
+        out.write("    #{\n")
+        for i, entry in enumerate(entries_list):
+            sep = "," if i < len(entries_list) - 1 else ""
+            out.write(f"        {_erlang_key(entry)} => {_erlang_entry_literal(entry)}{sep}\n")
+        out.write("    }.\n")
+    else:
+        out.write("    #{}.\n")
+    return out.getvalue()
+
+
+def _elixir_entry_literal(entry: RuntimeEntry) -> str:
+    fields = [
+        f"module: {entry['module']}",
+        f"fun: :{entry['fun']}",
+        f"arity: {entry['arity']}",
+        f"js_kind: :{entry['js_kind']}",
+    ]
+    for optional_key in ("js_name", "js_class", "js_method"):
+        if optional_key in entry:
+            fields.append(f'{optional_key}: "{entry[optional_key]}"')
+    return "%{" + ", ".join(fields) + "}"
+
+
+def _erlang_module_atom(elixir_module_name: str) -> str:
+    return f"'Elixir.{elixir_module_name}'"
+
+
+def _erlang_key(entry: RuntimeEntry) -> str:
+    return f"{{{_erlang_module_atom(str(entry['module']))}, {entry['fun']}, {entry['arity']}}}"
+
+
+def _erlang_entry_literal(entry: RuntimeEntry) -> str:
+    fields = [
+        f"module => {_erlang_module_atom(str(entry['module']))}",
+        f"'fun' => {entry['fun']}",
+        f"arity => {entry['arity']}",
+        f"js_kind => {entry['js_kind']}",
+    ]
+    for optional_key in ("js_name", "js_class", "js_method"):
+        if optional_key in entry:
+            fields.append(f'{optional_key} => <<"{entry[optional_key]}">>')
+    return "#{" + ", ".join(fields) + "}"

--- a/py_src/evision_js_attr.py
+++ b/py_src/evision_js_attr.py
@@ -143,6 +143,8 @@ def elixir_attribute_line(entry: JsEntry, fun: str, arity: int) -> str:
         fields.append(f'js_class: "{entry["js_class"]}"')
     if "js_method" in entry:
         fields.append(f'js_method: "{entry["js_method"]}"')
+    if "arg_plan" in entry:
+        fields.append(f"arg_plan: {_elixir_arg_plan(entry['arg_plan'])}")
     return f"  @js %{{{', '.join(fields)}}}\n"
 
 
@@ -159,6 +161,8 @@ def erlang_attribute_line(entry: JsEntry, fun: str, arity: int) -> str:
         fields.append(f'js_class => <<"{entry["js_class"]}">>')
     if "js_method" in entry:
         fields.append(f'js_method => <<"{entry["js_method"]}">>')
+    if "arg_plan" in entry:
+        fields.append(f"arg_plan => {_erlang_arg_plan(entry['arg_plan'])}")
     return f"-js(#{{{', '.join(fields)}}}).\n"
 
 
@@ -174,6 +178,16 @@ def _erlang_atom(name: str) -> str:
     # the first character of every emitted name (`map_argname_elixir`,
     # `get_module_func_name`), so this is always safe without quoting.
     return name
+
+
+def _elixir_arg_plan(plan) -> str:
+    # opencv.js positional arg-plan as an Elixir atom list: [:in, :out, :in].
+    return "[" + ", ".join(f":{slot}" for slot in plan) + "]"
+
+
+def _erlang_arg_plan(plan) -> str:
+    # opencv.js positional arg-plan as an Erlang atom list: [in, out, in].
+    return "[" + ", ".join(plan) + "]"
 
 
 # ----- Runtime module emission (Evision.JS / evision_js) ------------------
@@ -205,7 +219,7 @@ def collect_runtime_entries(module_generators: Iterable, kind: str) -> List[Runt
                     "arity": arity,
                     "js_kind": js_entry["js_kind"],
                 }
-                for optional_key in ("js_name", "js_class", "js_method"):
+                for optional_key in ("js_name", "js_class", "js_method", "arg_plan"):
                     if optional_key in js_entry:
                         entry[optional_key] = js_entry[optional_key]
                 out.append(entry)
@@ -232,6 +246,7 @@ def elixir_runtime_module(entries_list: List[RuntimeEntry]) -> str:
     out.write("          required(:fun) => atom(),\n")
     out.write("          required(:arity) => arity(),\n")
     out.write("          required(:js_kind) => :function | :method | :constructor,\n")
+    out.write("          optional(:arg_plan) => [:in | :out],\n")
     out.write("          optional(:js_name) => String.t(),\n")
     out.write("          optional(:js_class) => String.t(),\n")
     out.write("          optional(:js_method) => String.t()\n")
@@ -275,6 +290,7 @@ def erlang_runtime_module(entries_list: List[RuntimeEntry]) -> str:
     out.write("    'fun' := atom(),\n")
     out.write("    arity := arity(),\n")
     out.write("    js_kind := function | method | constructor,\n")
+    out.write("    arg_plan => [in | out],\n")
     out.write("    js_name => binary(),\n")
     out.write("    js_class => binary(),\n")
     out.write("    js_method => binary()\n")
@@ -317,6 +333,8 @@ def _elixir_entry_literal(entry: RuntimeEntry) -> str:
     for optional_key in ("js_name", "js_class", "js_method"):
         if optional_key in entry:
             fields.append(f'{optional_key}: "{entry[optional_key]}"')
+    if "arg_plan" in entry:
+        fields.append(f"arg_plan: {_elixir_arg_plan(entry['arg_plan'])}")
     return "%{" + ", ".join(fields) + "}"
 
 
@@ -338,4 +356,6 @@ def _erlang_entry_literal(entry: RuntimeEntry) -> str:
     for optional_key in ("js_name", "js_class", "js_method"):
         if optional_key in entry:
             fields.append(f'{optional_key} => <<"{entry[optional_key]}">>')
+    if "arg_plan" in entry:
+        fields.append(f"arg_plan => {_erlang_arg_plan(entry['arg_plan'])}")
     return "#{" + ", ".join(fields) + "}"

--- a/py_src/module_generator.py
+++ b/py_src/module_generator.py
@@ -330,6 +330,11 @@ class ModuleGenerator(object):
         # `end_elixir` / `end_erlang` can splice in the `@js` / `-js(...)`
         # attribute lines before the corresponding clause.
         self._current_js_entry = evision_js_attr.lookup_for_func(func)
+        self._current_arg_plans = (
+            self._compute_arg_plans(func, is_constructor)
+            if self._current_js_entry is not None
+            else {}
+        )
         if func_name in special_handling_funcs() or func_name in special_handling_funcs_only_in_beam():
             return
         if 'waitany' in func_name.lower():
@@ -791,6 +796,59 @@ class ModuleGenerator(object):
             self.nif_declaration[kind].write(nif_declaration)
             nif_declared[kind][nif_name] = True
 
+    def _variant_arg_plan(self, v):
+        # opencv.js positional layout for one C++ variant: "out" for each
+        # OutputArray (the dst the browser runtime alloc-on-misses), "in" for
+        # each *required* input (supplied positionally from an Elixir input).
+        # Optional inputs are omitted — in Elixir they ride the `opts` keyword
+        # bag, which has no positional slot in the required-arity clause. Array
+        # counters and ignored types reach neither binding.
+        plan = []
+        for a in v.args:
+            if a.name in v.array_counters:
+                continue
+            if a.tp in ignored_arg_types():
+                continue
+            if a.outputarg:
+                plan.append("out")
+            elif a.inputarg and not a.defval:
+                plan.append("in")
+        return plan
+
+    def _compute_arg_plans(self, func, is_constructor):
+        # Per-arity opencv.js arg-plan for the @js tag (CCD-54), consumed by the
+        # CCD-35 workflow->opencv.js compiler to place the pre-allocated dst Mat.
+        # A plan attaches to a variant's *required-positional* Elixir arity. An
+        # arity is ambiguous — and gets no plan, so the compiler hard-errors
+        # instead of guessing — when either:
+        #   (a) two variants' required clauses land on it with different layouts, or
+        #   (b) another variant's `opts` clause also lands on it (a distinct
+        #       positional shape). canny/4 is the textbook case: Canny(image,
+        #       t1, t2, opts) [V1 opts clause] collides with Canny(dx, dy, t1,
+        #       t2) [V2 required clause].
+        # Two required clauses that agree on the layout are NOT ambiguous
+        # (cvtColor/2: src,dst,code with an optional dstCn only changes the opts
+        # arity), so they keep their shared plan.
+        self_offset = 1 if (func.classname and not func.is_static and not is_constructor) else 0
+
+        required_plans = {}
+        opts_at = {}
+        for v in func.variants:
+            r = v.min_args + self_offset
+            required_plans.setdefault(r, []).append(self._variant_arg_plan(v))
+            if v.has_opts:
+                opts_at[r + 1] = opts_at.get(r + 1, 0) + 1
+
+        plans = {}
+        for arity, arity_plans in required_plans.items():
+            distinct = {tuple(p) for p in arity_plans}
+            if len(distinct) != 1 or opts_at.get(arity, 0) > 0:
+                continue
+            plan = arity_plans[0]
+            if plan:
+                plans[arity] = plan
+        return plans
+
     def add_function(self, kind: str, function_name: str, function_arity: int, guards_count: int, generated_code: str):
         if self.function.get(kind, None) is None:
             self.function[kind] = {}
@@ -804,7 +862,11 @@ class ModuleGenerator(object):
         if self._current_js_entry is not None:
             kind_attrs = self.js_attrs.setdefault(kind, {})
             arity_attrs = kind_attrs.setdefault(function_name, {})
-            arity_attrs[function_arity] = self._current_js_entry
+            plan = self._current_arg_plans.get(function_arity)
+            if plan is not None:
+                arity_attrs[function_arity] = {**self._current_js_entry, "arg_plan": plan}
+            else:
+                arity_attrs[function_arity] = self._current_js_entry
 
     def add_function_docs(self, kind: str, function_name: str, function_arity: int, inline_docs: str, typespec: str = None):
         if self.inline_docs.get(kind, None) is None:

--- a/py_src/module_generator.py
+++ b/py_src/module_generator.py
@@ -9,6 +9,7 @@ from helper import *
 from emit.erlang.helpers import map_uppercase_to_erlang_name
 import evision_templates as ET
 import doxygen_groups
+import evision_js_attr
 
 if sys.version_info[0] >= 3:
     from io import StringIO
@@ -77,6 +78,22 @@ class ModuleGenerator(object):
         self.doc_func_groups = {}
         self.doc_group_titles = {}
 
+        # opencv.js correspondence per emitted (function_name, arity).
+        # Populated as `add_function` runs against the JS entry set on
+        # `_current_js_entry` for the surrounding `_process_function` call.
+        # See ``evision_js_attr`` and js-corr.2 (CCD-19).
+        # key: kind ('elixir' | 'erlang')
+        # value: dict
+        #   key: function_name
+        #   value: dict
+        #     key: function_arity
+        #     value: entry dict from evision_js_attr.lookup_for_func
+        self.js_attrs = {
+            "elixir": {},
+            "erlang": {},
+        }
+        self._current_js_entry = None
+
     def set_doc_groups(self, func_to_group, group_titles):
         self.doc_func_groups = func_to_group or {}
         self.doc_group_titles = group_titles or {}
@@ -112,6 +129,10 @@ class ModuleGenerator(object):
             self.end_erlang()
 
     def end_elixir(self):
+        elixir_js_attrs = self.js_attrs.get('elixir', {})
+        if elixir_js_attrs:
+            self.write_elixir('\n')
+            self.write_elixir(evision_js_attr.elixir_register_attribute())
         for function_name, function in self.function['elixir'].items():
             seen_group = False
             for arity, functions in function.items():
@@ -134,6 +155,11 @@ class ModuleGenerator(object):
                             self.write_elixir(docs_mfa[i])
                             self.write_elixir('\n')
                         self.write_elixir('\n  """\n')
+                js_entry = elixir_js_attrs.get(function_name, {}).get(arity)
+                if js_entry is not None:
+                    self.write_elixir(
+                        evision_js_attr.elixir_attribute_line(js_entry, function_name, arity)
+                    )
                 functions = sorted(functions, key=lambda x: -x[0])
                 for _, function_code in functions:
                     self.write_elixir(function_code)
@@ -142,6 +168,19 @@ class ModuleGenerator(object):
     def end_erlang(self):
         if self.erlang_ended:
             return
+        erlang_js_attrs = self.js_attrs.get('erlang', {})
+        if erlang_js_attrs:
+            # Emit ``-js(...).`` lines as a single block. Erlang allows
+            # user-defined attributes anywhere in a module body; readers
+            # pick them up via ``module_info(attributes)`` regardless of
+            # position.
+            for function_name in sorted(erlang_js_attrs):
+                for arity in sorted(erlang_js_attrs[function_name]):
+                    js_entry = erlang_js_attrs[function_name][arity]
+                    self.write_erlang(
+                        evision_js_attr.erlang_attribute_line(js_entry, function_name, arity)
+                    )
+            self.write_erlang('\n')
         for function_name, function in self.function['erlang'].items():
             for arity, functions in function.items():
                 docs_spec_mfa = self.inline_docs['erlang'].get(function_name, {}).get(arity, [])
@@ -253,6 +292,11 @@ class ModuleGenerator(object):
             self._gen_property_impl(class_name, property_name, func_arity, generating_type, property_templates)
 
     def _gen_property_impl(self, class_name: str, property_name: str, func_arity: int, generating_type: str, property_templates: dict):
+        # Properties are not part of opencv.js; clear any entry leaked in from
+        # an enclosing `_process_function` call so `add_function` does not
+        # mistakenly tag the getter/setter.
+        self._current_js_entry = None
+
         # function name in the `evision_{self.module_name}.ex` file
         func_name = f"{generating_type}_{property_name}"
         # nif function name in the `evision_nif.ex` file
@@ -280,6 +324,12 @@ class ModuleGenerator(object):
     def _process_function(self, full_qualified_name: str, name: str, func: FuncInfo, is_ns: bool, is_constructor: bool, namespace_list: list):
         # ======== step 1. get wrapper name and ensure function name starts with a lowercase letter ========
         nif_name, func_name = func.get_wrapper_name(True)
+
+        # Resolve the opencv.js correspondence once per FuncInfo. `add_function`
+        # picks it up and stores it per emitted (function_name, arity) so
+        # `end_elixir` / `end_erlang` can splice in the `@js` / `-js(...)`
+        # attribute lines before the corresponding clause.
+        self._current_js_entry = evision_js_attr.lookup_for_func(func)
         if func_name in special_handling_funcs() or func_name in special_handling_funcs_only_in_beam():
             return
         if 'waitany' in func_name.lower():
@@ -750,6 +800,11 @@ class ModuleGenerator(object):
         if function_arity not in function_dict[function_name]:
             function_dict[function_name][function_arity] = []
         function_dict[function_name][function_arity].append((guards_count, generated_code))
+
+        if self._current_js_entry is not None:
+            kind_attrs = self.js_attrs.setdefault(kind, {})
+            arity_attrs = kind_attrs.setdefault(function_name, {})
+            arity_attrs[function_arity] = self._current_js_entry
 
     def add_function_docs(self, kind: str, function_name: str, function_arity: int, inline_docs: str, typespec: str = None):
         if self.inline_docs.get(kind, None) is None:

--- a/py_src/opencv_js_whitelist.py
+++ b/py_src/opencv_js_whitelist.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Parse OpenCV's ``platforms/js/opencv_js.config.py`` whitelist.
+
+Used by the evision codegen to learn which generated bindings have an
+opencv.js counterpart so a persistent ``@js`` module attribute can be
+emitted per matching function. See
+``projects/evision/context/js-correspondence-tag.md`` in the
+``cocoa/ai-native`` notebook for the full design.
+
+The config file is plain Python: each OpenCV module (``core``, ``imgproc``,
+``dnn``, ...) is a ``dict[classname_or_'', list[fn_name]]`` later merged
+into a single flat ``white_list`` via ``makeWhiteList``. The merge loses
+the per-module bucketing, so this parser executes the file with a stub
+``makeWhiteList`` and walks the resulting namespace itself to keep
+``module_name`` on every entry.
+
+embindgen treats the ``cv::dnn`` and ``cv::aruco`` namespaces as
+prefix-stripped when the whitelist is a ``.py`` file
+(``embindgen.py:1066-1069``). The same defaults are applied here so
+consumers see the JS-side function name as opencv.js would expose it.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Set, Tuple
+
+
+# Hardcoded in embindgen.py for the ``.py`` whitelist mode.
+DEFAULT_NAMESPACE_PREFIX_OVERRIDE: Dict[str, str] = {
+    "dnn": "",
+    "aruco": "",
+}
+
+ModuleWhitelist = Dict[str, List[str]]
+ParsedWhitelist = Dict[str, ModuleWhitelist]
+Entry = Tuple[str, Optional[str], str, str]
+
+
+class ConfigNotFoundError(FileNotFoundError):
+    """Raised when no opencv_js.config.py can be located."""
+
+
+def discover_config_path(
+    repo_root: Optional[os.PathLike] = None,
+    opencv_ver: Optional[str] = None,
+) -> Path:
+    """Locate ``opencv_js.config.py`` for the active OpenCV checkout.
+
+    Resolution order:
+
+    1. ``OPENCV_VER`` arg, then ``$OPENCV_VER`` env var, then any single
+       ``3rd_party/opencv/opencv-*`` directory present on disk.
+    2. ``repo_root`` arg, then ``$EVISION_REPO_ROOT`` env var, then the
+       repo root inferred from this file's location.
+
+    Raises ``ConfigNotFoundError`` if neither yields a readable file.
+    """
+    root = Path(repo_root) if repo_root else _default_repo_root()
+    ver = opencv_ver or os.environ.get("OPENCV_VER")
+
+    if ver:
+        candidate = root / "3rd_party" / "opencv" / f"opencv-{ver}" / "platforms" / "js" / "opencv_js.config.py"
+        if candidate.is_file():
+            return candidate
+        raise ConfigNotFoundError(
+            f"opencv_js.config.py not found for OPENCV_VER={ver} at {candidate}"
+        )
+
+    opencv_root = root / "3rd_party" / "opencv"
+    if not opencv_root.is_dir():
+        raise ConfigNotFoundError(
+            f"OpenCV root {opencv_root} does not exist; pass repo_root or run `make download_opencv` first"
+        )
+
+    candidates = sorted(
+        p for p in opencv_root.glob("opencv-*")
+        if p.is_dir() and not p.name.startswith("opencv_contrib")
+    )
+    if not candidates:
+        raise ConfigNotFoundError(
+            f"No opencv-* checkout under {opencv_root}; set OPENCV_VER or run `make download_opencv`"
+        )
+
+    config = candidates[-1] / "platforms" / "js" / "opencv_js.config.py"
+    if not config.is_file():
+        raise ConfigNotFoundError(
+            f"Found {candidates[-1]} but its platforms/js/opencv_js.config.py is missing"
+        )
+    return config
+
+
+def load_modules(config_path: Optional[os.PathLike] = None) -> ParsedWhitelist:
+    """Execute the config file and return its per-module whitelist dicts.
+
+    Keys are the module variable names from the file (``core``,
+    ``imgproc``, ``dnn``, ...); values are the original
+    ``{classname_or_'': [fn_name, ...]}`` dicts.
+
+    Raises ``ConfigNotFoundError`` (a subclass of ``FileNotFoundError``)
+    when the path does not resolve to an existing file.
+    """
+    path = Path(config_path) if config_path else discover_config_path()
+    if not path.is_file():
+        raise ConfigNotFoundError(f"opencv_js.config.py not found at {path}")
+
+    namespace: Dict[str, object] = {
+        "makeWhiteList": _stub_make_whitelist,
+        "__file__": str(path),
+    }
+    source = path.read_text()
+    exec(compile(source, str(path), "exec"), namespace)
+
+    modules: ParsedWhitelist = {}
+    for name, value in namespace.items():
+        if name.startswith("_") or name in _RESERVED_NAMES:
+            continue
+        if not isinstance(value, dict):
+            continue
+        if not all(
+            isinstance(k, str) and isinstance(v, list) and all(isinstance(item, str) for item in v)
+            for k, v in value.items()
+        ):
+            continue
+        modules[name] = {k: list(v) for k, v in value.items()}
+    return modules
+
+
+def namespace_prefix_override(
+    config_path: Optional[os.PathLike] = None,
+) -> Dict[str, str]:
+    """Return the effective ``namespace_prefix_override`` mapping.
+
+    Starts from the embindgen-side ``.py`` defaults
+    (``{'dnn': '', 'aruco': ''}``) and merges any value assigned to
+    ``namespace_prefix_override`` inside the config file itself.
+    """
+    path = Path(config_path) if config_path else discover_config_path()
+    if not path.is_file():
+        raise ConfigNotFoundError(f"opencv_js.config.py not found at {path}")
+
+    namespace: Dict[str, object] = {
+        "makeWhiteList": _stub_make_whitelist,
+        "__file__": str(path),
+    }
+    exec(compile(path.read_text(), str(path), "exec"), namespace)
+
+    overrides = dict(DEFAULT_NAMESPACE_PREFIX_OVERRIDE)
+    extra = namespace.get("namespace_prefix_override")
+    if isinstance(extra, dict):
+        for k, v in extra.items():
+            if isinstance(k, str) and isinstance(v, str):
+                overrides[k] = v
+    return overrides
+
+
+def flat_set(
+    config_path: Optional[os.PathLike] = None,
+    modules: Optional[ParsedWhitelist] = None,
+) -> Set[Tuple[str, Optional[str], str]]:
+    """Return ``{(module, classname_or_None, fn_name)}`` for fast lookup.
+
+    Pass an already-loaded ``modules`` dict to avoid re-executing the
+    config file; otherwise the file at ``config_path`` (or the discovered
+    default) is loaded.
+    """
+    if modules is None:
+        modules = load_modules(config_path)
+    out: Set[Tuple[str, Optional[str], str]] = set()
+    for module_name, module_dict in modules.items():
+        for class_key, fn_names in module_dict.items():
+            classname = class_key or None
+            for fn_name in fn_names:
+                out.add((module_name, classname, fn_name))
+    return out
+
+
+def entries(
+    config_path: Optional[os.PathLike] = None,
+    modules: Optional[ParsedWhitelist] = None,
+) -> Iterator[Entry]:
+    """Yield ``(module, classname_or_None, fn_name, js_kind)`` for the emitter.
+
+    ``js_kind`` is one of ``'function'``, ``'method'``, ``'constructor'``.
+    A class entry is treated as the constructor when its function name
+    equals the bare class name (the segment after the last ``_`` in the
+    class key) — this matches OpenCV's convention where
+    e.g. ``'aruco_Dictionary': ['Dictionary', ...]`` lists ``Dictionary``
+    as the constructor.
+    """
+    if modules is None:
+        modules = load_modules(config_path)
+    for module_name in sorted(modules):
+        module_dict = modules[module_name]
+        for class_key in sorted(module_dict):
+            fn_names = module_dict[class_key]
+            classname = class_key or None
+            bare = class_key.rsplit("_", 1)[-1] if class_key else None
+            for fn_name in fn_names:
+                if classname is None:
+                    kind = "function"
+                elif fn_name == bare:
+                    kind = "constructor"
+                else:
+                    kind = "method"
+                yield (module_name, classname, fn_name, kind)
+
+
+def _stub_make_whitelist(module_list):
+    merged: ModuleWhitelist = {}
+    for module in module_list:
+        for k, v in module.items():
+            merged.setdefault(k, []).extend(v)
+    return merged
+
+
+def _default_repo_root() -> Path:
+    env = os.environ.get("EVISION_REPO_ROOT")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent
+
+
+_RESERVED_NAMES = frozenset({
+    "makeWhiteList",
+    "white_list",
+    "namespace_prefix_override",
+})

--- a/py_src/pipeline.py
+++ b/py_src/pipeline.py
@@ -27,6 +27,7 @@ import doxygen_groups
 import evision_templates as ET
 import evision_structures as ES
 import evision_extra_functions as EF
+import evision_js_attr
 from erl_enum_expression_generator import ErlEnumExpressionGenerator
 from helper import *
 from ir.namespaces import Namespace
@@ -961,6 +962,17 @@ class Pipeline(object):
             self.evision_elixir.write(self.evision_ex.get_generated_code('elixir'))
             self.save(erl_output_path, "evision.ex", self.evision_elixir)
 
+            # 'evision_js.ex' — opencv.js correspondence runtime (CCD-20)
+            entries_elixir = evision_js_attr.collect_runtime_entries(
+                [self.evision_ex] + list(self.evision_modules.values()),
+                'elixir',
+            )
+            self.save(
+                erl_output_path,
+                "evision_js.ex",
+                evision_js_attr.elixir_runtime_module(entries_elixir),
+            )
+
         if 'erlang' in self.langs:
             # 'evision_nif.erl'
             self.evision_nif_erlang.write(self.evision_ex.get_nif_declaration('erlang'))
@@ -978,6 +990,17 @@ class Pipeline(object):
 
             # 'evision.hrl'
             self.save(erlang_output_path, "evision.hrl", self.evision_erlang_hrl)
+
+            # 'evision_js.erl' — opencv.js correspondence runtime (CCD-20)
+            entries_erlang = evision_js_attr.collect_runtime_entries(
+                [self.evision_ex] + list(self.evision_modules.values()),
+                'erlang',
+            )
+            self.save(
+                erlang_output_path,
+                "evision_js.erl",
+                evision_js_attr.erlang_runtime_module(entries_erlang),
+            )
 
         self.code_ns_reg.write('\n};\n\n')
         self.save(output_path, "evision_generated_modules_content.h", self.code_ns_reg)

--- a/py_src/tests/test_evision_js_arg_plan.py
+++ b/py_src/tests/test_evision_js_arg_plan.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the opencv.js ``arg_plan`` emitted into the ``@js`` tag (CCD-54).
+
+The arg-plan is the positional opencv.js argument layout — ``in`` for each
+required input, ``out`` for each pre-allocated ``OutputArray`` (dst) — that the
+CCD-35 workflow→opencv.js compiler consumes to place the dst Mat. evision/Elixir
+returns the output (it is not a positional arg), so the plan is the only place
+the C++ positional order survives into ``Evision.JS``.
+
+These exercise the pure derivation (``ModuleGenerator._compute_arg_plans`` /
+``_variant_arg_plan``) and the rendering emitters (``evision_js_attr``) against
+synthetic ``FuncInfo`` variants, so they need no OpenCV build.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import evision_js_attr as JA  # noqa: E402
+import module_generator as MG  # noqa: E402
+from ir.functions import FuncInfo  # noqa: E402
+
+
+def _decl(name, args, rettype="void"):
+    # args: list of (type, name, defval, modifiers). "" defval => required input;
+    # "/O" modifier => OutputArray. Mirrors hdr_parser's decl shape.
+    arg_decls = [[t, n, d, list(m)] for (t, n, d, m) in args]
+    return [name, rettype, [], arg_decls, None, ""]
+
+
+def _func(classname, name, variants, is_static=False, namespace="cv"):
+    f = FuncInfo(classname, name, name, False, namespace, is_static)
+    for decl in variants:
+        f.add_variant(decl)
+    return f
+
+
+@pytest.fixture
+def gen():
+    # Bypass __init__ (it wants many codegen args); the arg-plan helpers only
+    # touch their FuncInfo argument, not instance state.
+    return MG.ModuleGenerator.__new__(MG.ModuleGenerator)
+
+
+# ---- derivation: the curated D25 palette -------------------------------------
+
+
+def test_cvt_color_dst_after_src(gen):
+    # cv.cvtColor(src, dst, code) — dst is OutputArray at position 1.
+    f = _func("", "cvtColor", [
+        _decl("cvtColor", [("Mat", "src", "", ()), ("Mat", "dst", "", ("/O",)),
+                           ("int", "code", "", ())]),
+        _decl("cvtColor", [("Mat", "src", "", ()), ("Mat", "dst", "", ("/O",)),
+                           ("int", "code", "", ()), ("int", "dstCn", "0", ())]),
+    ])
+    assert gen._compute_arg_plans(f, False) == {2: ["in", "out", "in"]}
+
+
+def test_add_dst_last(gen):
+    # cv.add(src1, src2, dst, mask=, dtype=) — dst trails the two inputs.
+    f = _func("", "add", [
+        _decl("add", [("Mat", "src1", "", ()), ("Mat", "src2", "", ()),
+                      ("Mat", "dst", "", ("/O",)), ("Mat", "mask", "Mat()", ()),
+                      ("int", "dtype", "-1", ())]),
+    ])
+    assert gen._compute_arg_plans(f, False) == {2: ["in", "in", "out"]}
+
+
+def test_gaussian_blur(gen):
+    f = _func("", "GaussianBlur", [
+        _decl("GaussianBlur", [("Mat", "src", "", ()), ("Mat", "dst", "", ("/O",)),
+                               ("Size", "ksize", "", ()), ("double", "sigmaX", "", ()),
+                               ("double", "sigmaY", "0", ()),
+                               ("int", "borderType", "BORDER_DEFAULT", ())]),
+    ])
+    assert gen._compute_arg_plans(f, False) == {3: ["in", "out", "in", "in"]}
+
+
+def test_threshold_with_retval(gen):
+    # threshold returns a double (retval) and still has a dst OutputArray.
+    f = _func("", "threshold", [
+        _decl("threshold", [("Mat", "src", "", ()), ("Mat", "dst", "", ("/O",)),
+                            ("double", "thresh", "", ()), ("double", "maxval", "", ()),
+                            ("int", "type", "", ())], rettype="double"),
+    ])
+    assert gen._compute_arg_plans(f, False) == {4: ["in", "out", "in", "in", "in"]}
+
+
+def test_canny_3_kept_but_4_is_ambiguous(gen):
+    # Two variants collide at arity 4 with different layouts, so 4 is omitted;
+    # the unambiguous arity-3 plan is still emitted.
+    #   image, edges/O, t1, t2, apertureSize=3, L2gradient=false  -> required 3 (+opts 4)
+    #   dx, dy, edges/O, t1, t2, L2gradient=false                 -> required 4
+    f = _func("", "Canny", [
+        _decl("Canny", [("Mat", "image", "", ()), ("Mat", "edges", "", ("/O",)),
+                        ("double", "threshold1", "", ()), ("double", "threshold2", "", ()),
+                        ("int", "apertureSize", "3", ()), ("bool", "L2gradient", "false", ())]),
+        _decl("Canny", [("Mat", "dx", "", ()), ("Mat", "dy", "", ()),
+                        ("Mat", "edges", "", ("/O",)), ("double", "threshold1", "", ()),
+                        ("double", "threshold2", "", ()), ("bool", "L2gradient", "false", ())]),
+    ])
+    plans = gen._compute_arg_plans(f, False)
+    assert plans.get(3) == ["in", "out", "in", "in"]
+    assert 4 not in plans
+
+
+# ---- derivation: method receiver + constructor ------------------------------
+
+
+def test_method_excludes_receiver(gen):
+    # cv.Tonemap::process(src, dst) — the receiver is the implicit `this`, not in
+    # v.args, so the plan covers only the post-receiver args. The Elixir wrapper
+    # is process(self, src) => arity 2.
+    f = _func("Tonemap", "process", [
+        _decl("process", [("Mat", "src", "", ()), ("Mat", "dst", "", ("/O",))]),
+    ])
+    assert gen._compute_arg_plans(f, False) == {2: ["in", "out"]}
+
+
+def test_constructor_without_io_args_has_no_plan(gen):
+    f = _func("UsacParams", "UsacParams", [_decl("UsacParams", [])])
+    assert gen._compute_arg_plans(f, True) == {}
+
+
+def test_optional_inputs_excluded_from_required_plan(gen):
+    # Only required inputs occupy a positional `in` slot; an input with a
+    # default value (mask, dtype, dstCn, …) rides the `opts` keyword bag and so
+    # must not appear in the required-arity plan. Two variants that agree on the
+    # required layout (differing only in an optional trailing arg) are NOT
+    # ambiguous — they keep the shared plan.
+    f = _func("", "fake", [
+        _decl("fake", [("Mat", "src", "", ()), ("Mat", "dst", "", ("/O",)),
+                       ("int", "code", "", ())]),
+        _decl("fake", [("Mat", "src", "", ()), ("Mat", "dst", "", ("/O",)),
+                       ("int", "code", "", ()), ("int", "extra", "0", ())]),
+    ])
+    assert gen._compute_arg_plans(f, False) == {2: ["in", "out", "in"]}
+
+
+# ---- emitters: Elixir + Erlang rendering ------------------------------------
+
+
+_FN = {"module": "Evision", "fun": "cvtColor", "arity": 2, "js_kind": "function",
+       "js_name": "cv.cvtColor", "arg_plan": ["in", "out", "in"]}
+_METHOD = {"module": "Evision.Tonemap", "fun": "process", "arity": 2,
+           "js_kind": "method", "js_class": "cv.Tonemap", "js_method": "process",
+           "arg_plan": ["in", "out"]}
+
+
+def test_elixir_attribute_line_renders_arg_plan():
+    line = JA.elixir_attribute_line(_FN, "cvtColor", 2)
+    assert "arg_plan: [:in, :out, :in]" in line
+
+
+def test_erlang_attribute_line_renders_arg_plan():
+    line = JA.erlang_attribute_line(_FN, "cvtColor", 2)
+    assert "arg_plan => [in, out, in]" in line
+
+
+def test_elixir_entry_literal_renders_arg_plan():
+    assert JA._elixir_entry_literal(_FN) == (
+        '%{module: Evision, fun: :cvtColor, arity: 2, js_kind: :function, '
+        'js_name: "cv.cvtColor", arg_plan: [:in, :out, :in]}'
+    )
+
+
+def test_erlang_entry_literal_renders_arg_plan():
+    assert JA._erlang_entry_literal(_METHOD) == (
+        "#{module => 'Elixir.Evision.Tonemap', 'fun' => process, arity => 2, "
+        'js_kind => method, js_class => <<"cv.Tonemap">>, '
+        'js_method => <<"process">>, arg_plan => [in, out]}'
+    )
+
+
+def test_collect_runtime_entries_carries_arg_plan():
+    class _MG:
+        module_name = "Evision"
+        js_attrs = {"elixir": {"cvtColor": {2: dict(_FN)}}}
+
+    [entry] = JA.collect_runtime_entries([_MG()], "elixir")
+    assert entry["arg_plan"] == ["in", "out", "in"]
+
+
+# ---- the additive guarantee: no arg_plan => byte-identical to pre-change -----
+
+
+_NO_PLAN = {"module": "Evision", "fun": "canny", "arity": 4, "js_kind": "function",
+            "js_name": "cv.Canny"}
+
+
+def test_elixir_literal_without_plan_is_unchanged():
+    assert JA._elixir_entry_literal(_NO_PLAN) == (
+        '%{module: Evision, fun: :canny, arity: 4, js_kind: :function, '
+        'js_name: "cv.Canny"}'
+    )
+
+
+def test_erlang_literal_without_plan_is_unchanged():
+    assert JA._erlang_entry_literal(_NO_PLAN) == (
+        "#{module => 'Elixir.Evision', 'fun' => canny, arity => 4, "
+        'js_kind => function, js_name => <<"cv.Canny">>}'
+    )
+
+
+def test_attribute_lines_without_plan_are_unchanged():
+    assert JA.elixir_attribute_line(_NO_PLAN, "canny", 4) == (
+        '  @js %{fun: :canny, arity: 4, js_kind: :function, js_name: "cv.Canny"}\n'
+    )
+    assert JA.erlang_attribute_line(_NO_PLAN, "canny", 4) == (
+        '-js(#{fun => canny, arity => 4, js_kind => function, '
+        'js_name => <<"cv.Canny">>}).\n'
+    )
+
+
+# ---- @type contracts grow the optional field --------------------------------
+
+
+def test_runtime_module_type_blocks_document_arg_plan():
+    assert "optional(:arg_plan) => [:in | :out]" in JA.elixir_runtime_module([_NO_PLAN])
+    assert "arg_plan => [in | out]" in JA.erlang_runtime_module([_NO_PLAN])

--- a/py_src/tests/test_opencv_js_whitelist.py
+++ b/py_src/tests/test_opencv_js_whitelist.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for ``py_src/opencv_js_whitelist.py``.
+
+Run with::
+
+    python3 -m unittest py_src.tests.test_opencv_js_whitelist
+
+or, from the repo root::
+
+    python3 -m unittest discover -s py_src/tests -t .
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "py_src"))
+
+import opencv_js_whitelist as w
+
+
+SAMPLE_CONFIG = textwrap.dedent(
+    """
+    core = {
+        '': ['absdiff', 'add'],
+        'Algorithm': [],
+    }
+    imgproc = {
+        '': ['Canny', 'blur', 'cvtColor'],
+        'CLAHE': ['apply', 'collectGarbage'],
+    }
+    objdetect = {
+        '': ['groupRectangles'],
+        'CascadeClassifier': ['load', 'CascadeClassifier', 'detectMultiScale'],
+        'aruco_Dictionary': ['Dictionary', 'getDistanceToId'],
+        'QRCodeDetectorAruco_Params': ['Params'],
+        'aruco_PredefinedDictionaryType': [],
+    }
+    dnn = {
+        '': ['readNetFromCaffe'],
+        'dnn_Net': ['setInput', 'forward'],
+    }
+    calib3d = {
+        '': ['findHomography', 'fisheye_projectPoints'],
+    }
+
+    white_list = makeWhiteList([core, imgproc, objdetect, dnn, calib3d])
+    """
+).strip() + "\n"
+
+
+def _write_fixture(tmpdir: Path, body: str = SAMPLE_CONFIG) -> Path:
+    config = tmpdir / "opencv_js.config.py"
+    config.write_text(body)
+    return config
+
+
+class LoadModulesTest(unittest.TestCase):
+    def test_returns_per_module_dicts(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            modules = w.load_modules(config)
+
+        self.assertEqual(
+            set(modules.keys()),
+            {"core", "imgproc", "objdetect", "dnn", "calib3d"},
+        )
+        self.assertEqual(modules["core"][""], ["absdiff", "add"])
+        self.assertEqual(modules["core"]["Algorithm"], [])
+        self.assertEqual(modules["imgproc"]["CLAHE"], ["apply", "collectGarbage"])
+
+    def test_excludes_reserved_names(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            modules = w.load_modules(config)
+        self.assertNotIn("white_list", modules)
+        self.assertNotIn("makeWhiteList", modules)
+        self.assertNotIn("namespace_prefix_override", modules)
+
+    def test_returned_lists_are_independent_copies(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            modules = w.load_modules(config)
+            modules["core"][""].append("MUTATED")
+            modules2 = w.load_modules(config)
+            self.assertNotIn("MUTATED", modules2["core"][""])
+
+    def test_real_opencv_config_loads(self):
+        real = w.discover_config_path()
+        modules = w.load_modules(real)
+        self.assertIn("core", modules)
+        self.assertIn("imgproc", modules)
+        self.assertIn("dnn", modules)
+        self.assertIn("Canny", modules["imgproc"][""])
+
+
+class FlatSetTest(unittest.TestCase):
+    def test_free_functions_have_none_classname(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            s = w.flat_set(config)
+        self.assertIn(("imgproc", None, "Canny"), s)
+        self.assertIn(("core", None, "absdiff"), s)
+        self.assertIn(("dnn", None, "readNetFromCaffe"), s)
+
+    def test_class_keyed_methods(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            s = w.flat_set(config)
+        self.assertIn(("objdetect", "CascadeClassifier", "load"), s)
+        self.assertIn(("dnn", "dnn_Net", "forward"), s)
+        self.assertIn(("imgproc", "CLAHE", "apply"), s)
+
+    def test_empty_class_lists_contribute_nothing(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            s = w.flat_set(config)
+        for entry in s:
+            self.assertNotEqual(entry[1], "Algorithm")
+            self.assertNotEqual(entry[1], "aruco_PredefinedDictionaryType")
+
+    def test_accepts_preloaded_modules(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            modules = w.load_modules(config)
+            from_path = w.flat_set(config)
+            from_modules = w.flat_set(modules=modules)
+        self.assertEqual(from_path, from_modules)
+
+
+class EntriesTest(unittest.TestCase):
+    def test_free_functions_emit_kind_function(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            entries = set(w.entries(config))
+        self.assertIn(("imgproc", None, "Canny", "function"), entries)
+        self.assertIn(("dnn", None, "readNetFromCaffe", "function"), entries)
+        self.assertIn(("calib3d", None, "fisheye_projectPoints", "function"), entries)
+
+    def test_methods_emit_kind_method(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            entries = set(w.entries(config))
+        self.assertIn(("objdetect", "CascadeClassifier", "load", "method"), entries)
+        self.assertIn(("objdetect", "CascadeClassifier", "detectMultiScale", "method"), entries)
+        self.assertIn(("dnn", "dnn_Net", "setInput", "method"), entries)
+        self.assertIn(("imgproc", "CLAHE", "apply", "method"), entries)
+
+    def test_constructor_when_fn_matches_bare_class_name(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            entries = set(w.entries(config))
+        self.assertIn(("objdetect", "CascadeClassifier", "CascadeClassifier", "constructor"), entries)
+        self.assertIn(("objdetect", "aruco_Dictionary", "Dictionary", "constructor"), entries)
+        self.assertIn(("objdetect", "QRCodeDetectorAruco_Params", "Params", "constructor"), entries)
+
+    def test_methods_outnumber_constructors(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            entries = list(w.entries(config))
+        kinds = {e[3] for e in entries}
+        self.assertEqual(kinds, {"function", "method", "constructor"})
+
+    def test_outer_iteration_is_stable_sorted(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            entries = list(w.entries(config))
+        module_order = []
+        for e in entries:
+            if not module_order or module_order[-1] != e[0]:
+                module_order.append(e[0])
+        self.assertEqual(module_order, sorted(set(module_order)))
+
+    def test_real_opencv_config_yields_expected_starter_palette(self):
+        entries = set(w.entries())
+        self.assertIn(("imgproc", None, "blur", "function"), entries)
+        self.assertIn(("imgproc", None, "Canny", "function"), entries)
+        self.assertIn(("imgproc", None, "threshold", "function"), entries)
+        self.assertIn(("imgproc", None, "cvtColor", "function"), entries)
+        self.assertIn(("imgproc", None, "resize", "function"), entries)
+        self.assertIn(("objdetect", "CascadeClassifier", "CascadeClassifier", "constructor"), entries)
+        self.assertIn(("objdetect", "CascadeClassifier", "detectMultiScale", "method"), entries)
+        self.assertIn(("dnn", None, "readNetFromCaffe", "function"), entries)
+
+
+class NamespacePrefixOverrideTest(unittest.TestCase):
+    def test_defaults_when_config_silent(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp))
+            overrides = w.namespace_prefix_override(config)
+        self.assertEqual(overrides, {"dnn": "", "aruco": ""})
+
+    def test_config_can_extend_defaults(self):
+        body = SAMPLE_CONFIG + "namespace_prefix_override = {'fisheye': 'fish'}\n"
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp), body=body)
+            overrides = w.namespace_prefix_override(config)
+        self.assertEqual(
+            overrides,
+            {"dnn": "", "aruco": "", "fisheye": "fish"},
+        )
+
+    def test_config_can_shadow_defaults(self):
+        body = SAMPLE_CONFIG + "namespace_prefix_override = {'dnn': 'deep'}\n"
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp), body=body)
+            overrides = w.namespace_prefix_override(config)
+        self.assertEqual(overrides["dnn"], "deep")
+        self.assertEqual(overrides["aruco"], "")
+
+
+class EmptyAndMissingTest(unittest.TestCase):
+    def test_empty_whitelist_yields_no_entries(self):
+        with TemporaryDirectory() as tmp:
+            config = _write_fixture(Path(tmp), body="white_list = makeWhiteList([])\n")
+            modules = w.load_modules(config)
+            entries = list(w.entries(config))
+            flat = w.flat_set(config)
+        self.assertEqual(modules, {})
+        self.assertEqual(entries, [])
+        self.assertEqual(flat, set())
+
+    def test_missing_file_raises(self):
+        with TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does_not_exist.py"
+            with self.assertRaises(w.ConfigNotFoundError):
+                w.load_modules(missing)
+            with self.assertRaises(w.ConfigNotFoundError):
+                w.flat_set(missing)
+            with self.assertRaises(w.ConfigNotFoundError):
+                list(w.entries(missing))
+            with self.assertRaises(w.ConfigNotFoundError):
+                w.namespace_prefix_override(missing)
+
+    def test_config_not_found_error_is_file_not_found_error(self):
+        self.assertTrue(issubclass(w.ConfigNotFoundError, FileNotFoundError))
+
+
+class DiscoverConfigPathTest(unittest.TestCase):
+    def test_env_var_drives_lookup(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            opencv = root / "3rd_party" / "opencv" / "opencv-9.9.9" / "platforms" / "js"
+            opencv.mkdir(parents=True)
+            (opencv / "opencv_js.config.py").write_text("white_list = makeWhiteList([])\n")
+
+            saved = os.environ.get("OPENCV_VER")
+            os.environ["OPENCV_VER"] = "9.9.9"
+            try:
+                found = w.discover_config_path(repo_root=root)
+            finally:
+                if saved is None:
+                    del os.environ["OPENCV_VER"]
+                else:
+                    os.environ["OPENCV_VER"] = saved
+
+        self.assertEqual(found.name, "opencv_js.config.py")
+        self.assertIn("opencv-9.9.9", found.parts)
+
+    def test_falls_back_to_highest_checkout(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for ver in ("4.10.0", "4.13.0"):
+                d = root / "3rd_party" / "opencv" / f"opencv-{ver}" / "platforms" / "js"
+                d.mkdir(parents=True)
+                (d / "opencv_js.config.py").write_text("white_list = makeWhiteList([])\n")
+            (root / "3rd_party" / "opencv" / "opencv_contrib-4.13.0").mkdir(parents=True)
+
+            saved = os.environ.pop("OPENCV_VER", None)
+            try:
+                found = w.discover_config_path(repo_root=root)
+            finally:
+                if saved is not None:
+                    os.environ["OPENCV_VER"] = saved
+
+        self.assertIn("opencv-4.13.0", found.parts)
+
+    def test_missing_checkout_raises(self):
+        with TemporaryDirectory() as tmp:
+            saved = os.environ.pop("OPENCV_VER", None)
+            try:
+                with self.assertRaises(w.ConfigNotFoundError):
+                    w.discover_config_path(repo_root=Path(tmp))
+            finally:
+                if saved is not None:
+                    os.environ["OPENCV_VER"] = saved
+
+    def test_env_var_pointing_to_missing_version_raises(self):
+        with TemporaryDirectory() as tmp:
+            saved = os.environ.get("OPENCV_VER")
+            os.environ["OPENCV_VER"] = "0.0.0"
+            try:
+                with self.assertRaises(w.ConfigNotFoundError):
+                    w.discover_config_path(repo_root=Path(tmp))
+            finally:
+                if saved is None:
+                    del os.environ["OPENCV_VER"]
+                else:
+                    os.environ["OPENCV_VER"] = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py_src/tests/test_opencv_js_whitelist.py
+++ b/py_src/tests/test_opencv_js_whitelist.py
@@ -185,9 +185,9 @@ class EntriesTest(unittest.TestCase):
         self.assertIn(("imgproc", None, "threshold", "function"), entries)
         self.assertIn(("imgproc", None, "cvtColor", "function"), entries)
         self.assertIn(("imgproc", None, "resize", "function"), entries)
-        self.assertIn(("objdetect", "CascadeClassifier", "CascadeClassifier", "constructor"), entries)
-        self.assertIn(("objdetect", "CascadeClassifier", "detectMultiScale", "method"), entries)
-        self.assertIn(("dnn", None, "readNetFromCaffe", "function"), entries)
+        self.assertIn(("objdetect", "QRCodeDetector", "QRCodeDetector", "constructor"), entries)
+        self.assertIn(("objdetect", "QRCodeDetector", "detect", "method"), entries)
+        self.assertIn(("dnn", None, "readNetFromONNX", "function"), entries)
 
 
 class NamespacePrefixOverrideTest(unittest.TestCase):

--- a/scripts/build_opencv_js.sh
+++ b/scripts/build_opencv_js.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Build a CSP-clean opencv.js from OpenCV source.
+#
+# "CSP-clean" means the artifact runs under a Content-Security-Policy of
+# `script-src 'wasm-unsafe-eval'` with NO `'unsafe-eval'`. Stock
+# docs.opencv.org/<ver>/opencv.js needs `'unsafe-eval'` because embind's
+# createNamedFunction/craftInvokerFunction build invokers with `new Function`.
+# Emscripten `-s DYNAMIC_EXECUTION=0` compiles those string->code paths out.
+#
+# The build is otherwise identical to the stock recipe: single-threaded
+# (USE_PTHREADS=0), single-file WASM, and OpenCV's own default
+# platforms/js/opencv_js.config.py whitelist. Keeping every other input
+# equal is deliberate: evision's `@js` correspondence table is generated
+# from that same whitelist, so the exported JS API must not drift.
+#
+# Requires an activated Emscripten SDK (emcc on PATH).
+#
+# Usage: scripts/build_opencv_js.sh <opencv_ver> <opencv_src_dir> <out_dir>
+
+set -eu
+
+OPENCV_VER="${1:?usage: build_opencv_js.sh <opencv_ver> <opencv_src_dir> <out_dir>}"
+OPENCV_DIR="${2:?opencv source directory (contains platforms/js/build_js.py)}"
+OUT_DIR="${3:?output directory}"
+
+if ! command -v emcmake >/dev/null 2>&1; then
+  echo "emcmake not found on PATH; activate the Emscripten SDK first (source emsdk_env.sh)" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not found on PATH (build_js.py needs it)" >&2
+  exit 1
+fi
+
+if [ ! -f "${OPENCV_DIR}/platforms/js/build_js.py" ]; then
+  echo "no build_js.py under ${OPENCV_DIR}/platforms/js" >&2
+  exit 1
+fi
+
+BUILD_DIR="${OUT_DIR}/build_js_${OPENCV_VER}"
+mkdir -p "${OUT_DIR}"
+
+echo "emcc: $(emcc --version | head -1)"
+echo "building opencv.js ${OPENCV_VER} (CSP-clean: -s DYNAMIC_EXECUTION=0)"
+
+# -s DYNAMIC_EXECUTION=0 compiles out embind's eval/new Function invokers; embind
+# falls back to an eval-free path (correct, but the JS<->wasm invoker layer is
+# ~8-10x slower for hot calls; the OpenCV compute itself is unaffected).
+#   Set OPENCV_JS_EMBIND_AOT=1 to also pass -s EMBIND_AOT=1, which regenerates
+# those invokers at compile time (eval-free AND fast). AOT can fail to link on
+# some binding shapes (emscripten #22862); if it does, rerun without it -- the
+# plain build is still fully CSP-clean.
+EXTRA_FLAGS="-s DYNAMIC_EXECUTION=0"
+if [ "${OPENCV_JS_EMBIND_AOT:-0}" = "1" ]; then
+  EXTRA_FLAGS="${EXTRA_FLAGS} -s EMBIND_AOT=1"
+fi
+echo "extra emscripten flags: ${EXTRA_FLAGS}"
+
+# --build_wasm + defaults reproduce the stock build; EXTRA_FLAGS is the only
+# delta. Do NOT pass --threads/--simd/--config: single-thread and the default
+# whitelist are exactly what the published docs build uses, so the exported JS
+# API stays identical to stock and evision's @js table stays valid.
+emcmake python3 "${OPENCV_DIR}/platforms/js/build_js.py" "${BUILD_DIR}" \
+  --opencv_dir "${OPENCV_DIR}" \
+  --build_wasm \
+  --build_flags="${EXTRA_FLAGS}"
+
+OPENCV_JS="${BUILD_DIR}/bin/opencv.js"
+if [ ! -f "${OPENCV_JS}" ]; then
+  OPENCV_JS="$(find "${BUILD_DIR}" -name opencv.js -type f 2>/dev/null | head -1 || true)"
+fi
+if [ -z "${OPENCV_JS}" ] || [ ! -f "${OPENCV_JS}" ]; then
+  echo "build produced no opencv.js under ${BUILD_DIR}" >&2
+  exit 1
+fi
+
+cp "${OPENCV_JS}" "${OUT_DIR}/opencv.js"
+( cd "${OUT_DIR}" && { if command -v sha256sum >/dev/null 2>&1; then sha256sum opencv.js; else shasum -a 256 opencv.js; fi; } > opencv.sha256 )
+
+echo "built: ${OUT_DIR}/opencv.js ($(wc -c < "${OUT_DIR}/opencv.js") bytes)"
+cat "${OUT_DIR}/opencv.sha256"

--- a/scripts/verify_opencv_js_csp.mjs
+++ b/scripts/verify_opencv_js_csp.mjs
@@ -1,0 +1,98 @@
+// Prove an opencv.js build is CSP-clean.
+//
+// Run under Node's --disallow-code-generation-from-strings, which makes
+// eval()/new Function() throw EvalError exactly as a Content-Security-Policy
+// without 'unsafe-eval' does in a browser. WebAssembly instantiation is not
+// blocked by that flag, mirroring a policy that still allows 'wasm-unsafe-eval'.
+//
+// If embind still needed string->code to build its invokers, initialization
+// would throw. Reaching a working cv.Mat proves the runtime is clean.
+//
+// Usage:
+//   node [--disallow-code-generation-from-strings] verify_opencv_js_csp.mjs <opencv.js>
+//
+// With REQUIRE_NO_EVAL=1, assert that code generation really is disabled, so a
+// strict check fails loudly if the node flag is ever dropped.
+
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+function die(err) {
+  const detail = err?.stack ?? String(err);
+  const evalRelated = /code generation from strings|EvalError|new Function/i.test(detail);
+  console.error(`FAIL${evalRelated ? " (eval/CSP)" : ""}: ${detail}`);
+  process.exit(1);
+}
+
+// opencv.js may abort on a later tick (embind/emscripten throw asynchronously);
+// route those to the same failure path rather than a bare stack trace.
+process.on("uncaughtException", die);
+process.on("unhandledRejection", die);
+
+const target = process.argv[2];
+if (!target) {
+  console.error("usage: node verify_opencv_js_csp.mjs <opencv.js>");
+  process.exit(2);
+}
+
+// Whether this process forbids eval()/new Function() -- the CSP posture we assert.
+const codegenDisabled = (() => {
+  try {
+    new Function("");
+    return false;
+  } catch {
+    return true;
+  }
+})();
+
+if (process.env.REQUIRE_NO_EVAL === "1" && !codegenDisabled) {
+  die("REQUIRE_NO_EVAL=1 but eval is allowed; pass --disallow-code-generation-from-strings");
+}
+
+// opencv.js is a UMD/CommonJS bundle, so require() it. resolve() against cwd so a
+// caller-relative path ("out/opencv.js") is found, not one relative to this file.
+const require = createRequire(import.meta.url);
+
+// OpenCV 5.0's modules/js/CMakeLists.txt sets MODULARIZE=1 / EXPORT_NAME='cv', so
+// the export is a factory returning a promise; tolerate the older shapes too.
+function initialize(exported) {
+  const mod = typeof exported === "function" ? exported() : exported;
+  if (mod && typeof mod.then === "function") return mod;
+  if (mod && mod.Mat) return Promise.resolve(mod);
+  if (mod) return new Promise((res) => (mod.onRuntimeInitialized = () => res(mod)));
+  return Promise.reject(new Error("opencv.js export was empty"));
+}
+
+// A live timer keeps the event loop alive, so a module that never initializes
+// fails here instead of letting the process exit 0 without verifying anything.
+function withTimeout(promise, ms) {
+  return new Promise((res, rej) => {
+    const timer = setTimeout(() => rej(new Error(`timed out after ${ms}ms waiting for init`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        res(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        rej(err);
+      },
+    );
+  });
+}
+
+async function main() {
+  const cv = await withTimeout(initialize(require(resolve(target))), 120_000);
+
+  const mat = new cv.Mat(3, 3, cv.CV_8UC1); // exercises an embind constructor invoker
+  try {
+    if (mat.rows !== 3) throw new Error(`unexpected Mat.rows: ${mat.rows}`);
+  } finally {
+    mat.delete();
+  }
+
+  const posture = codegenDisabled ? "disabled" : "allowed";
+  console.log(`PASS: opencv.js initialized and embind Mat works (code generation from strings ${posture})`);
+}
+
+main().catch(die);

--- a/src/evision.app.src
+++ b/src/evision.app.src
@@ -1,6 +1,6 @@
 {application, evision,
  [{description, "OpenCV BEAM binding."},
-  {vsn, "1.0.0"},
+  {vsn, "1.0.1"},
   {registered, []},
   {applications,
    [kernel,

--- a/test/evision_js_runtime_test.exs
+++ b/test/evision_js_runtime_test.exs
@@ -1,0 +1,150 @@
+defmodule Evision.JSRuntimeTest do
+  use ExUnit.Case, async: true
+
+  describe "whitelist/0" do
+    test "returns a non-empty list of maps with the expected shape" do
+      whitelist = Evision.JS.whitelist()
+
+      assert is_list(whitelist)
+      assert length(whitelist) > 0
+
+      for entry <- whitelist do
+        assert is_atom(entry.module)
+        assert is_atom(entry.fun)
+        assert is_integer(entry.arity) and entry.arity >= 0
+        assert entry.js_kind in [:function, :method, :constructor]
+
+        case entry.js_kind do
+          :function ->
+            assert is_binary(entry.js_name)
+            refute Map.has_key?(entry, :js_class)
+            refute Map.has_key?(entry, :js_method)
+
+          :method ->
+            assert is_binary(entry.js_class)
+            assert is_binary(entry.js_method)
+            refute Map.has_key?(entry, :js_name)
+
+          :constructor ->
+            assert is_binary(entry.js_class)
+            refute Map.has_key?(entry, :js_method)
+            refute Map.has_key?(entry, :js_name)
+        end
+      end
+    end
+
+    test "per-module count matches the corresponding @js attributes on the loaded module" do
+      by_module = Enum.group_by(Evision.JS.whitelist(), & &1.module)
+
+      for {module, runtime_entries} <- by_module do
+        Code.ensure_loaded!(module)
+
+        tag_entries =
+          module.module_info(:attributes) |> Keyword.get_values(:js) |> List.flatten()
+
+        assert length(tag_entries) == length(runtime_entries),
+               "for #{inspect(module)}: runtime has #{length(runtime_entries)} entries, module has #{length(tag_entries)} @js attrs"
+      end
+    end
+  end
+
+  describe "lookup/3" do
+    test "returns {:ok, entry} for a known free function (Evision.canny/3)" do
+      assert {:ok, entry} = Evision.JS.lookup(Evision, :canny, 3)
+
+      assert %{
+               module: Evision,
+               fun: :canny,
+               arity: 3,
+               js_kind: :function,
+               js_name: "cv.Canny"
+             } = entry
+    end
+
+    test "returns {:ok, entry} for a known method (Evision.CascadeClassifier.detectMultiScale/2)" do
+      assert {:ok, entry} =
+               Evision.JS.lookup(Evision.CascadeClassifier, :detectMultiScale, 2)
+
+      assert %{
+               module: Evision.CascadeClassifier,
+               fun: :detectMultiScale,
+               arity: 2,
+               js_kind: :method,
+               js_class: "cv.CascadeClassifier",
+               js_method: "detectMultiScale"
+             } = entry
+    end
+
+    test "returns {:ok, entry} for a known constructor (Evision.CascadeClassifier.cascadeClassifier/0)" do
+      assert {:ok, entry} =
+               Evision.JS.lookup(Evision.CascadeClassifier, :cascadeClassifier, 0)
+
+      assert %{
+               module: Evision.CascadeClassifier,
+               fun: :cascadeClassifier,
+               arity: 0,
+               js_kind: :constructor,
+               js_class: "cv.CascadeClassifier"
+             } = entry
+    end
+
+    test "returns :error for an evision binding with no opencv.js counterpart" do
+      assert :error = Evision.JS.lookup(Evision.Mat, :from_binary, 2)
+    end
+
+    test "returns :error for an unknown module" do
+      assert :error = Evision.JS.lookup(Evision.NotAModule, :nope, 0)
+    end
+
+    test "returns :error when arity is wrong even if (module, fun) exists" do
+      {:ok, _} = Evision.JS.lookup(Evision, :canny, 3)
+      assert :error = Evision.JS.lookup(Evision, :canny, 99)
+    end
+  end
+
+  describe "runnable?/3" do
+    test "true for a free function known to opencv.js" do
+      assert Evision.JS.runnable?(Evision, :canny, 3)
+    end
+
+    test "true for a class method known to opencv.js" do
+      assert Evision.JS.runnable?(Evision.CascadeClassifier, :detectMultiScale, 2)
+    end
+
+    test "false for evision-specific binding (Evision.Mat.from_binary/2)" do
+      refute Evision.JS.runnable?(Evision.Mat, :from_binary, 2)
+    end
+
+    test "false for unknown triple" do
+      refute Evision.JS.runnable?(Evision.NotAModule, :nope, 0)
+    end
+  end
+
+  describe "round-trip" do
+    test "every entry in whitelist/0 round-trips through lookup/3" do
+      for entry <- Evision.JS.whitelist() do
+        assert {:ok, ^entry} =
+                 Evision.JS.lookup(entry.module, entry.fun, entry.arity)
+      end
+    end
+
+    test "every entry in whitelist/0 is runnable?/3" do
+      for entry <- Evision.JS.whitelist() do
+        assert Evision.JS.runnable?(entry.module, entry.fun, entry.arity),
+               "entry #{inspect(entry)} should be runnable?"
+      end
+    end
+  end
+
+  describe "fisheye + namespace_prefix_override coverage (CCD-18 refinements)" do
+    test "Evision.FishEye.initUndistortRectifyMap/6 → cv.fisheye_initUndistortRectifyMap" do
+      assert {:ok, %{js_kind: :function, js_name: "cv.fisheye_initUndistortRectifyMap"}} =
+               Evision.JS.lookup(Evision.FishEye, :initUndistortRectifyMap, 6)
+    end
+
+    test "Evision.ArUco.Dictionary constructor projects to cv.Dictionary (override strips prefix)" do
+      assert {:ok, %{js_kind: :constructor, js_class: "cv.Dictionary"}} =
+               Evision.JS.lookup(Evision.ArUco.Dictionary, :dictionary, 0)
+    end
+  end
+end

--- a/test/evision_js_runtime_test.exs
+++ b/test/evision_js_runtime_test.exs
@@ -30,6 +30,11 @@ defmodule Evision.JSRuntimeTest do
             refute Map.has_key?(entry, :js_method)
             refute Map.has_key?(entry, :js_name)
         end
+
+        if Map.has_key?(entry, :arg_plan) do
+          assert is_list(entry.arg_plan)
+          assert Enum.all?(entry.arg_plan, &(&1 in [:in, :out]))
+        end
       end
     end
 
@@ -99,6 +104,20 @@ defmodule Evision.JSRuntimeTest do
     test "returns :error when arity is wrong even if (module, fun) exists" do
       {:ok, _} = Evision.JS.lookup(Evision, :canny, 3)
       assert :error = Evision.JS.lookup(Evision, :canny, 99)
+    end
+
+    test "carries the opencv.js arg_plan where the layout is unambiguous (CCD-54)" do
+      assert {:ok, %{arg_plan: [:in, :out, :in]}} = Evision.JS.lookup(Evision, :cvtColor, 2)
+      assert {:ok, %{arg_plan: [:in, :out, :in, :in]}} = Evision.JS.lookup(Evision, :canny, 3)
+      assert {:ok, %{arg_plan: [:in, :in, :out]}} = Evision.JS.lookup(Evision, :add, 2)
+
+      assert {:ok, %{arg_plan: [:in, :out]}} =
+               Evision.JS.lookup(Evision.CascadeClassifier, :detectMultiScale, 2)
+    end
+
+    test "omits arg_plan for ambiguous same-arity overloads (canny/4)" do
+      assert {:ok, entry} = Evision.JS.lookup(Evision, :canny, 4)
+      refute Map.has_key?(entry, :arg_plan)
     end
   end
 

--- a/test/evision_js_runtime_test.exs
+++ b/test/evision_js_runtime_test.exs
@@ -66,30 +66,30 @@ defmodule Evision.JSRuntimeTest do
              } = entry
     end
 
-    test "returns {:ok, entry} for a known method (Evision.CascadeClassifier.detectMultiScale/2)" do
+    test "returns {:ok, entry} for a known method (Evision.QRCodeDetector.detect/2)" do
       assert {:ok, entry} =
-               Evision.JS.lookup(Evision.CascadeClassifier, :detectMultiScale, 2)
+               Evision.JS.lookup(Evision.QRCodeDetector, :detect, 2)
 
       assert %{
-               module: Evision.CascadeClassifier,
-               fun: :detectMultiScale,
+               module: Evision.QRCodeDetector,
+               fun: :detect,
                arity: 2,
                js_kind: :method,
-               js_class: "cv.CascadeClassifier",
-               js_method: "detectMultiScale"
+               js_class: "cv.QRCodeDetector",
+               js_method: "detect"
              } = entry
     end
 
-    test "returns {:ok, entry} for a known constructor (Evision.CascadeClassifier.cascadeClassifier/0)" do
+    test "returns {:ok, entry} for a known constructor (Evision.QRCodeDetector.qrCodeDetector/0)" do
       assert {:ok, entry} =
-               Evision.JS.lookup(Evision.CascadeClassifier, :cascadeClassifier, 0)
+               Evision.JS.lookup(Evision.QRCodeDetector, :qrCodeDetector, 0)
 
       assert %{
-               module: Evision.CascadeClassifier,
-               fun: :cascadeClassifier,
+               module: Evision.QRCodeDetector,
+               fun: :qrCodeDetector,
                arity: 0,
                js_kind: :constructor,
-               js_class: "cv.CascadeClassifier"
+               js_class: "cv.QRCodeDetector"
              } = entry
     end
 
@@ -112,7 +112,7 @@ defmodule Evision.JSRuntimeTest do
       assert {:ok, %{arg_plan: [:in, :in, :out]}} = Evision.JS.lookup(Evision, :add, 2)
 
       assert {:ok, %{arg_plan: [:in, :out]}} =
-               Evision.JS.lookup(Evision.CascadeClassifier, :detectMultiScale, 2)
+               Evision.JS.lookup(Evision.QRCodeDetector, :detect, 2)
     end
 
     test "omits arg_plan for ambiguous same-arity overloads (canny/4)" do
@@ -127,7 +127,7 @@ defmodule Evision.JSRuntimeTest do
     end
 
     test "true for a class method known to opencv.js" do
-      assert Evision.JS.runnable?(Evision.CascadeClassifier, :detectMultiScale, 2)
+      assert Evision.JS.runnable?(Evision.QRCodeDetector, :detect, 2)
     end
 
     test "false for evision-specific binding (Evision.Mat.from_binary/2)" do

--- a/test/evision_js_strip_test.exs
+++ b/test/evision_js_strip_test.exs
@@ -41,6 +41,9 @@ defmodule Evision.JSStripTest do
         assert %{js_kind: :function, js_name: "cv.Canny"} =
                  find_entry(entries, :canny, arity)
       end
+
+      # arg_plan (CCD-54) rides the same Attr chunk, so it survives stripping too.
+      assert %{arg_plan: [:in, :out, :in, :in]} = find_entry(entries, :canny, 3)
     end
 
     test "Evision.CascadeClassifier carries constructor + method entries" do

--- a/test/evision_js_strip_test.exs
+++ b/test/evision_js_strip_test.exs
@@ -13,7 +13,7 @@ defmodule Evision.JSStripTest do
   # this test leaves untouched.
   @target_modules [
     Evision,
-    Evision.CascadeClassifier,
+    Evision.QRCodeDetector,
     Evision.FishEye,
     Evision.ArUco.Dictionary,
     Evision.JS
@@ -46,17 +46,17 @@ defmodule Evision.JSStripTest do
       assert %{arg_plan: [:in, :out, :in, :in]} = find_entry(entries, :canny, 3)
     end
 
-    test "Evision.CascadeClassifier carries constructor + method entries" do
-      entries = js_entries(Evision.CascadeClassifier)
+    test "Evision.QRCodeDetector carries constructor + method entries" do
+      entries = js_entries(Evision.QRCodeDetector)
 
-      assert %{js_kind: :constructor, js_class: "cv.CascadeClassifier"} =
-               find_entry(entries, :cascadeClassifier, 0)
+      assert %{js_kind: :constructor, js_class: "cv.QRCodeDetector"} =
+               find_entry(entries, :qrCodeDetector, 0)
 
       assert %{
                js_kind: :method,
-               js_class: "cv.CascadeClassifier",
-               js_method: "detectMultiScale"
-             } = find_entry(entries, :detectMultiScale, 2)
+               js_class: "cv.QRCodeDetector",
+               js_method: "detect"
+             } = find_entry(entries, :detect, 2)
     end
 
     test "Evision.FishEye fisheye_-prefix entry survives stripping" do
@@ -83,7 +83,7 @@ defmodule Evision.JSStripTest do
 
     test "runnable?/3 returns true for known triples" do
       assert Evision.JS.runnable?(Evision, :canny, 3)
-      assert Evision.JS.runnable?(Evision.CascadeClassifier, :detectMultiScale, 2)
+      assert Evision.JS.runnable?(Evision.QRCodeDetector, :detect, 2)
       assert Evision.JS.runnable?(Evision.FishEye, :initUndistortRectifyMap, 6)
     end
 
@@ -108,8 +108,8 @@ defmodule Evision.JSStripTest do
       assert length(whitelist) > 0
 
       assert Enum.any?(whitelist, fn entry ->
-               entry.module == Evision.CascadeClassifier and
-                 entry.fun == :detectMultiScale and
+               entry.module == Evision.QRCodeDetector and
+                 entry.fun == :detect and
                  entry.arity == 2
              end)
     end

--- a/test/evision_js_strip_test.exs
+++ b/test/evision_js_strip_test.exs
@@ -1,0 +1,153 @@
+defmodule Evision.JSStripTest do
+  # Replaces the in-memory BEAMs of several `Evision.*` modules with their
+  # stripped equivalents in `setup_all`, then restores the originals in
+  # `on_exit`. Must run alone to avoid any parallel test seeing the
+  # transient stripped state.
+  use ExUnit.Case, async: false
+
+  @moduletag :js_correspondence
+
+  # Picked to cover every shape `Evision.JS` exposes plus the runtime helper
+  # itself. None of these modules declare `@on_load`, so `:code.load_binary`
+  # does not re-enter NIF registration. The NIF lives in `Evision.NIF` which
+  # this test leaves untouched.
+  @target_modules [
+    Evision,
+    Evision.CascadeClassifier,
+    Evision.FishEye,
+    Evision.ArUco.Dictionary,
+    Evision.JS
+  ]
+
+  setup_all do
+    Enum.each(@target_modules, &Code.ensure_loaded!/1)
+
+    originals = capture_originals(@target_modules)
+    stripped = strip_each(originals)
+
+    load_each(stripped)
+    on_exit(fn -> load_each(originals) end)
+
+    :ok
+  end
+
+  describe "@js attributes survive `:beam_lib.strip(_, [~c\"Attr\"])` on the loaded BEAM" do
+    test "Evision root carries free-function entries (canny)" do
+      entries = js_entries(Evision)
+
+      assert length(entries) > 0
+
+      for arity <- [3, 4, 5] do
+        assert %{js_kind: :function, js_name: "cv.Canny"} =
+                 find_entry(entries, :canny, arity)
+      end
+    end
+
+    test "Evision.CascadeClassifier carries constructor + method entries" do
+      entries = js_entries(Evision.CascadeClassifier)
+
+      assert %{js_kind: :constructor, js_class: "cv.CascadeClassifier"} =
+               find_entry(entries, :cascadeClassifier, 0)
+
+      assert %{
+               js_kind: :method,
+               js_class: "cv.CascadeClassifier",
+               js_method: "detectMultiScale"
+             } = find_entry(entries, :detectMultiScale, 2)
+    end
+
+    test "Evision.FishEye fisheye_-prefix entry survives stripping" do
+      entries = js_entries(Evision.FishEye)
+
+      assert %{js_kind: :function, js_name: "cv.fisheye_initUndistortRectifyMap"} =
+               find_entry(entries, :initUndistortRectifyMap, 6)
+    end
+
+    test "Evision.ArUco.Dictionary namespace_prefix_override entry survives stripping" do
+      entries = js_entries(Evision.ArUco.Dictionary)
+
+      assert %{js_kind: :constructor, js_class: "cv.Dictionary"} =
+               find_entry(entries, :dictionary, 0)
+    end
+  end
+
+  describe "Evision.JS runtime helper under release-mode stripping" do
+    # `@whitelist` / `@index` are regular module attributes inlined into the
+    # function bodies (not persistent attributes), so the helper is
+    # strip-invariant by construction — `Attr` keep is irrelevant here. The
+    # tests confirm the helper actually compiles and runs against the
+    # loaded stripped BEAM, which is the property D25 consumers depend on.
+
+    test "runnable?/3 returns true for known triples" do
+      assert Evision.JS.runnable?(Evision, :canny, 3)
+      assert Evision.JS.runnable?(Evision.CascadeClassifier, :detectMultiScale, 2)
+      assert Evision.JS.runnable?(Evision.FishEye, :initUndistortRectifyMap, 6)
+    end
+
+    test "runnable?/3 returns false for evision-specific bindings" do
+      refute Evision.JS.runnable?(Evision.Mat, :from_binary, 2)
+    end
+
+    test "lookup/3 returns the expected entry for Evision.canny/3" do
+      assert {:ok,
+              %{
+                module: Evision,
+                fun: :canny,
+                arity: 3,
+                js_kind: :function,
+                js_name: "cv.Canny"
+              }} = Evision.JS.lookup(Evision, :canny, 3)
+    end
+
+    test "whitelist/0 still returns the full entry set" do
+      whitelist = Evision.JS.whitelist()
+
+      assert length(whitelist) > 0
+
+      assert Enum.any?(whitelist, fn entry ->
+               entry.module == Evision.CascadeClassifier and
+                 entry.fun == :detectMultiScale and
+                 entry.arity == 2
+             end)
+    end
+  end
+
+  defp js_entries(module) do
+    module.module_info(:attributes)
+    |> Keyword.get_values(:js)
+    |> List.flatten()
+  end
+
+  defp find_entry(entries, fun, arity) do
+    Enum.find(entries, &(&1.fun == fun and &1.arity == arity))
+  end
+
+  defp capture_originals(modules) do
+    Map.new(modules, fn module ->
+      case :code.which(module) do
+        path when is_list(path) ->
+          {:ok, bytes} = File.read(path)
+          {module, {path, bytes}}
+
+        other ->
+          raise "module #{inspect(module)}: :code.which returned #{inspect(other)}, expected a charlist path"
+      end
+    end)
+  end
+
+  defp strip_each(originals) do
+    Map.new(originals, fn {module, {path, bytes}} ->
+      {:ok, {^module, stripped}} = :beam_lib.strip(bytes, [~c"Attr"])
+      {module, {path, stripped}}
+    end)
+  end
+
+  defp load_each(modules_map) do
+    for {module, {path, bytes}} <- modules_map do
+      :code.purge(module)
+      {:module, ^module} = :code.load_binary(module, path, bytes)
+    end
+
+    :ok
+  end
+end

--- a/test/evision_js_tag_test.exs
+++ b/test/evision_js_tag_test.exs
@@ -57,6 +57,25 @@ defmodule Evision.JSTagTest do
       assert %{js_kind: :function, js_name: "cv.threshold"} =
                find_entry(entries, :threshold, 4)
     end
+
+    test "arg_plan records the opencv.js positional layout (CCD-54)", %{entries: entries} do
+      # opencv.js takes the dst OutputArray positionally; evision returns it.
+      # arg_plan records where dst sits so the workflow→opencv.js compiler can
+      # place the pre-allocated Mat. cvtColor(src, dst, code); add(s1, s2, dst).
+      assert %{arg_plan: [:in, :out, :in]} = find_entry(entries, :cvtColor, 2)
+      assert %{arg_plan: [:in, :out, :in, :in]} = find_entry(entries, :canny, 3)
+      assert %{arg_plan: [:in, :out, :in, :in]} = find_entry(entries, :gaussianBlur, 3)
+      assert %{arg_plan: [:in, :out, :in, :in, :in]} = find_entry(entries, :threshold, 4)
+      assert %{arg_plan: [:in, :out, :in]} = find_entry(entries, :blur, 2)
+      assert %{arg_plan: [:in, :in, :out]} = find_entry(entries, :add, 2)
+    end
+
+    test "ambiguous same-arity overloads carry no arg_plan (canny/4)", %{entries: entries} do
+      # canny/4 is produced by two C++ variants with different layouts
+      # (image, t1, t2, opts vs dx, dy, t1, t2), so the plan is omitted — the
+      # compiler hard-errors on such a node rather than guessing the overload.
+      refute Map.has_key?(find_entry(entries, :canny, 4), :arg_plan)
+    end
   end
 
   describe "class methods + constructor on Evision.CascadeClassifier" do
@@ -77,6 +96,12 @@ defmodule Evision.JSTagTest do
                js_class: "cv.CascadeClassifier",
                js_method: "detectMultiScale"
              } = find_entry(entries, :detectMultiScale, 2)
+    end
+
+    test "method arg_plan covers post-receiver args only (CCD-54)", %{entries: entries} do
+      # The receiver is the wire's `recv`; arg_plan describes only the args
+      # after it. detectMultiScale(self, image) → opencv.js (image, objects/dst).
+      assert %{arg_plan: [:in, :out]} = find_entry(entries, :detectMultiScale, 2)
     end
   end
 
@@ -140,7 +165,7 @@ defmodule Evision.JSTagTest do
                ~r/-js\(#\{fun => cascadeClassifier, arity => 0, js_kind => constructor, js_class => <<"cv\.CascadeClassifier">>\}\)\./
 
       assert source =~
-               ~r/-js\(#\{fun => detectMultiScale, arity => 2, js_kind => method, js_class => <<"cv\.CascadeClassifier">>, js_method => <<"detectMultiScale">>\}\)\./
+               ~r/-js\(#\{fun => detectMultiScale, arity => 2, js_kind => method, js_class => <<"cv\.CascadeClassifier">>, js_method => <<"detectMultiScale">>, arg_plan => \[in, out\]\}\)\./
     end
   end
 

--- a/test/evision_js_tag_test.exs
+++ b/test/evision_js_tag_test.exs
@@ -78,30 +78,28 @@ defmodule Evision.JSTagTest do
     end
   end
 
-  describe "class methods + constructor on Evision.CascadeClassifier" do
+  describe "class methods + constructor on Evision.QRCodeDetector" do
     setup do
-      %{entries: js_entries(Evision.CascadeClassifier)}
+      %{entries: js_entries(Evision.QRCodeDetector)}
     end
 
-    test "constructor (arity 0 and 1)", %{entries: entries} do
-      for arity <- [0, 1] do
-        assert %{js_kind: :constructor, js_class: "cv.CascadeClassifier"} =
-                 find_entry(entries, :cascadeClassifier, arity)
-      end
+    test "constructor (arity 0)", %{entries: entries} do
+      assert %{js_kind: :constructor, js_class: "cv.QRCodeDetector"} =
+               find_entry(entries, :qrCodeDetector, 0)
     end
 
-    test "detectMultiScale method", %{entries: entries} do
+    test "detect method", %{entries: entries} do
       assert %{
                js_kind: :method,
-               js_class: "cv.CascadeClassifier",
-               js_method: "detectMultiScale"
-             } = find_entry(entries, :detectMultiScale, 2)
+               js_class: "cv.QRCodeDetector",
+               js_method: "detect"
+             } = find_entry(entries, :detect, 2)
     end
 
     test "method arg_plan covers post-receiver args only (CCD-54)", %{entries: entries} do
       # The receiver is the wire's `recv`; arg_plan describes only the args
-      # after it. detectMultiScale(self, image) → opencv.js (image, objects/dst).
-      assert %{arg_plan: [:in, :out]} = find_entry(entries, :detectMultiScale, 2)
+      # after it. detect(self, img) → opencv.js (img, points/dst).
+      assert %{arg_plan: [:in, :out]} = find_entry(entries, :detect, 2)
     end
   end
 
@@ -156,16 +154,16 @@ defmodule Evision.JSTagTest do
                ~r/-js\(#\{fun => canny, arity => \d+, js_kind => function, js_name => <<"cv\.Canny">>\}\)\./
     end
 
-    test "evision_cascadeclassifier.erl emits method + constructor entries" do
+    test "evision_qrcodedetector.erl emits method + constructor entries" do
       source =
-        Path.join([File.cwd!(), "src", "generated", "evision_cascadeclassifier.erl"])
+        Path.join([File.cwd!(), "src", "generated", "evision_qrcodedetector.erl"])
         |> File.read!()
 
       assert source =~
-               ~r/-js\(#\{fun => cascadeClassifier, arity => 0, js_kind => constructor, js_class => <<"cv\.CascadeClassifier">>\}\)\./
+               ~r/-js\(#\{fun => qrCodeDetector, arity => 0, js_kind => constructor, js_class => <<"cv\.QRCodeDetector">>\}\)\./
 
       assert source =~
-               ~r/-js\(#\{fun => detectMultiScale, arity => 2, js_kind => method, js_class => <<"cv\.CascadeClassifier">>, js_method => <<"detectMultiScale">>, arg_plan => \[in, out\]\}\)\./
+               ~r/-js\(#\{fun => detect, arity => 2, js_kind => method, js_class => <<"cv\.QRCodeDetector">>, js_method => <<"detect">>, arg_plan => \[in, out\]\}\)\./
     end
   end
 
@@ -179,14 +177,14 @@ defmodule Evision.JSTagTest do
     # as "not guaranteed to remain in future versions" — so D25 deployments
     # MUST opt in explicitly via `strip_beams: [keep: ["Attr"]]`.
 
-    test "@js attributes survive strip_release-style strip on Evision.CascadeClassifier" do
-      path = :code.which(Evision.CascadeClassifier)
+    test "@js attributes survive strip_release-style strip on Evision.QRCodeDetector" do
+      path = :code.which(Evision.QRCodeDetector)
       assert is_list(path), "expected loaded BEAM path, got #{inspect(path)}"
 
       {:ok, original} = File.read(path)
 
       original_js =
-        Evision.CascadeClassifier
+        Evision.QRCodeDetector
         |> js_entries()
         |> length()
 
@@ -206,8 +204,8 @@ defmodule Evision.JSTagTest do
       assert length(stripped_js) == original_js,
              "@js count must survive strip: pre=#{original_js} post=#{length(stripped_js)}"
 
-      assert %{js_kind: :method, js_method: "detectMultiScale"} =
-               Enum.find(stripped_js, &(&1.fun == :detectMultiScale and &1.arity == 2))
+      assert %{js_kind: :method, js_method: "detect"} =
+               Enum.find(stripped_js, &(&1.fun == :detect and &1.arity == 2))
     end
 
     test "@js attributes survive strip_release-style strip on Evision (free functions)" do
@@ -232,9 +230,9 @@ defmodule Evision.JSTagTest do
       # an explicit keep list (or Mix release's current — undocumented —
       # default) does. If OTP ever changes strip/1 to preserve Attr this
       # test will flip and force a doc update.
-      path = :code.which(Evision.CascadeClassifier)
+      path = :code.which(Evision.QRCodeDetector)
       {:ok, original} = File.read(path)
-      {:ok, {Evision.CascadeClassifier, stripped}} = :beam_lib.strip(original)
+      {:ok, {Evision.QRCodeDetector, stripped}} = :beam_lib.strip(original)
 
       assert {:error, :beam_lib, {:missing_chunk, _, _}} =
                :beam_lib.chunks(stripped, [~c"Attr"])

--- a/test/evision_js_tag_test.exs
+++ b/test/evision_js_tag_test.exs
@@ -1,0 +1,218 @@
+defmodule Evision.JSTagTest do
+  use ExUnit.Case, async: true
+
+  defp js_entries(module) do
+    module.module_info(:attributes)
+    |> Keyword.get_values(:js)
+    |> List.flatten()
+  end
+
+  defp find_entry(entries, fun, arity) do
+    Enum.find(entries, &(&1.fun == fun and &1.arity == arity))
+  end
+
+  defp strip_with_attr(beam) do
+    {:ok, {_mod, chunks}} =
+      :beam_lib.chunks(beam, :beam_lib.significant_chunks() ++ [~c"Attr"],
+        [:allow_missing_chunks])
+
+    chunks = for {name, chunk} <- chunks, is_binary(chunk), do: {name, chunk}
+    {:ok, stripped} = :beam_lib.build_module(chunks)
+    stripped
+  end
+
+  describe "free functions on Evision" do
+    setup do
+      %{entries: js_entries(Evision)}
+    end
+
+    test "canny (all arities tagged)", %{entries: entries} do
+      for arity <- [3, 4, 5] do
+        assert %{js_kind: :function, js_name: "cv.Canny"} =
+                 find_entry(entries, :canny, arity)
+      end
+    end
+
+    test "cvtColor", %{entries: entries} do
+      assert %{js_kind: :function, js_name: "cv.cvtColor"} =
+               find_entry(entries, :cvtColor, 2)
+    end
+
+    test "gaussianBlur", %{entries: entries} do
+      assert %{js_kind: :function, js_name: "cv.GaussianBlur"} =
+               find_entry(entries, :gaussianBlur, 3)
+    end
+
+    test "blur", %{entries: entries} do
+      assert %{js_kind: :function, js_name: "cv.blur"} =
+               find_entry(entries, :blur, 2)
+    end
+
+    test "resize", %{entries: entries} do
+      assert %{js_kind: :function, js_name: "cv.resize"} =
+               find_entry(entries, :resize, 2)
+    end
+
+    test "threshold", %{entries: entries} do
+      assert %{js_kind: :function, js_name: "cv.threshold"} =
+               find_entry(entries, :threshold, 4)
+    end
+  end
+
+  describe "class methods + constructor on Evision.CascadeClassifier" do
+    setup do
+      %{entries: js_entries(Evision.CascadeClassifier)}
+    end
+
+    test "constructor (arity 0 and 1)", %{entries: entries} do
+      for arity <- [0, 1] do
+        assert %{js_kind: :constructor, js_class: "cv.CascadeClassifier"} =
+                 find_entry(entries, :cascadeClassifier, arity)
+      end
+    end
+
+    test "detectMultiScale method", %{entries: entries} do
+      assert %{
+               js_kind: :method,
+               js_class: "cv.CascadeClassifier",
+               js_method: "detectMultiScale"
+             } = find_entry(entries, :detectMultiScale, 2)
+    end
+  end
+
+  describe "fisheye namespace flattening (refinement #4)" do
+    test "Evision.FishEye.initUndistortRectifyMap carries fisheye_ prefix" do
+      entries = js_entries(Evision.FishEye)
+
+      assert %{js_kind: :function, js_name: "cv.fisheye_initUndistortRectifyMap"} =
+               find_entry(entries, :initUndistortRectifyMap, 6)
+    end
+  end
+
+  describe "class with no constructor (refinement #3)" do
+    @tag :dnn
+    test "Evision.DNN.Net has methods but no constructor entry" do
+      entries = js_entries(Evision.DNN.Net)
+
+      refute Enum.any?(entries, &(&1.js_kind == :constructor))
+
+      assert %{
+               js_kind: :method,
+               js_class: "cv.Net",
+               js_method: "forward"
+             } = find_entry(entries, :forward, 2)
+    end
+  end
+
+  describe "namespace_prefix_override (refinement #2)" do
+    test "aruco_Dictionary projects to cv.Dictionary (override strips prefix)" do
+      entries = js_entries(Evision.ArUco.Dictionary)
+
+      assert %{js_kind: :constructor, js_class: "cv.Dictionary"} =
+               find_entry(entries, :dictionary, 0)
+    end
+  end
+
+  describe "Mat.from_binary is evision-specific (no @js tag)" do
+    test "no @js entry for from_binary" do
+      entries = js_entries(Evision.Mat)
+      refute Enum.any?(entries, &(&1.fun == :from_binary))
+    end
+  end
+
+  describe "Erlang generated source emits -js attributes" do
+    test "evision.erl carries -js lines for free functions" do
+      path = Path.join([File.cwd!(), "src", "generated", "evision.erl"])
+      assert File.exists?(path), "generated Erlang source missing: #{path}"
+
+      source = File.read!(path)
+
+      assert source =~
+               ~r/-js\(#\{fun => canny, arity => \d+, js_kind => function, js_name => <<"cv\.Canny">>\}\)\./
+    end
+
+    test "evision_cascadeclassifier.erl emits method + constructor entries" do
+      source =
+        Path.join([File.cwd!(), "src", "generated", "evision_cascadeclassifier.erl"])
+        |> File.read!()
+
+      assert source =~
+               ~r/-js\(#\{fun => cascadeClassifier, arity => 0, js_kind => constructor, js_class => <<"cv\.CascadeClassifier">>\}\)\./
+
+      assert source =~
+               ~r/-js\(#\{fun => detectMultiScale, arity => 2, js_kind => method, js_class => <<"cv\.CascadeClassifier">>, js_method => <<"detectMultiScale">>\}\)\./
+    end
+  end
+
+  describe "post-strip survival (release-mode property)" do
+    # The release-mode property to validate is: when a Mix release strips
+    # BEAM files, the `Attr` chunk (carrying `@js` persistent attributes)
+    # survives. The realistic strip used by Mix is `:beam_lib.strip_release/2`
+    # with an explicit additional-chunks list — that's the contracted API
+    # (the `Attr` chunk is guaranteed to survive when listed). `mix release`
+    # currently includes `"Attr"` in its default keep list but documents it
+    # as "not guaranteed to remain in future versions" — so D25 deployments
+    # MUST opt in explicitly via `strip_beams: [keep: ["Attr"]]`.
+
+    test "@js attributes survive strip_release-style strip on Evision.CascadeClassifier" do
+      path = :code.which(Evision.CascadeClassifier)
+      assert is_list(path), "expected loaded BEAM path, got #{inspect(path)}"
+
+      {:ok, original} = File.read(path)
+
+      original_js =
+        Evision.CascadeClassifier
+        |> js_entries()
+        |> length()
+
+      assert original_js > 0, "test prerequisite: module has @js attributes pre-strip"
+
+      stripped = strip_with_attr(original)
+
+      assert byte_size(stripped) < byte_size(original),
+             "strip should remove at least Docs/Dbgi chunks"
+
+      {:ok, {_mod, [{~c"Attr", attr_bin}]}} =
+        :beam_lib.chunks(stripped, [~c"Attr"])
+
+      attrs = :erlang.binary_to_term(attr_bin)
+      stripped_js = attrs |> Keyword.get_values(:js) |> List.flatten()
+
+      assert length(stripped_js) == original_js,
+             "@js count must survive strip: pre=#{original_js} post=#{length(stripped_js)}"
+
+      assert %{js_kind: :method, js_method: "detectMultiScale"} =
+               Enum.find(stripped_js, &(&1.fun == :detectMultiScale and &1.arity == 2))
+    end
+
+    test "@js attributes survive strip_release-style strip on Evision (free functions)" do
+      path = :code.which(Evision)
+      {:ok, original} = File.read(path)
+
+      stripped = strip_with_attr(original)
+
+      {:ok, {_mod, [{~c"Attr", attr_bin}]}} =
+        :beam_lib.chunks(stripped, [~c"Attr"])
+
+      attrs = :erlang.binary_to_term(attr_bin)
+      stripped_js = attrs |> Keyword.get_values(:js) |> List.flatten()
+
+      assert %{js_kind: :function, js_name: "cv.Canny"} =
+               Enum.find(stripped_js, &(&1.fun == :canny and &1.arity == 3))
+    end
+
+    test "bare :beam_lib.strip/1 DROPS Attr — documenting the release config requirement" do
+      # This negative assertion guards against any reader assuming the bare
+      # strip/1 form preserves Attr. It doesn't: only strip_release/2 with
+      # an explicit keep list (or Mix release's current — undocumented —
+      # default) does. If OTP ever changes strip/1 to preserve Attr this
+      # test will flip and force a doc update.
+      path = :code.which(Evision.CascadeClassifier)
+      {:ok, original} = File.read(path)
+      {:ok, {Evision.CascadeClassifier, stripped}} = :beam_lib.strip(original)
+
+      assert {:error, :beam_lib, {:missing_chunk, _, _}} =
+               :beam_lib.chunks(stripped, [~c"Attr"])
+    end
+  end
+end

--- a/test/evision_js_tag_test.exs
+++ b/test/evision_js_tag_test.exs
@@ -13,8 +13,7 @@ defmodule Evision.JSTagTest do
 
   defp strip_with_attr(beam) do
     {:ok, {_mod, chunks}} =
-      :beam_lib.chunks(beam, :beam_lib.significant_chunks() ++ [~c"Attr"],
-        [:allow_missing_chunks])
+      :beam_lib.chunks(beam, :beam_lib.significant_chunks() ++ [~c"Attr"], [:allow_missing_chunks])
 
     chunks = for {name, chunk} <- chunks, is_binary(chunk), do: {name, chunk}
     {:ok, stripped} = :beam_lib.build_module(chunks)
@@ -143,21 +142,25 @@ defmodule Evision.JSTagTest do
     end
   end
 
+  # These assert on the Erlang backend output (src/generated/*.erl), produced
+  # only when EVISION_GENERATE_LANG includes "erlang". The default test build is
+  # elixir-only, so skip when the sources are absent rather than hard-fail.
   describe "Erlang generated source emits -js attributes" do
-    test "evision.erl carries -js lines for free functions" do
-      path = Path.join([File.cwd!(), "src", "generated", "evision.erl"])
-      assert File.exists?(path), "generated Erlang source missing: #{path}"
+    @generated_erl_dir Path.join([File.cwd!(), "src", "generated"])
+    @skip_without_erlang not File.exists?(Path.join(@generated_erl_dir, "evision.erl")) &&
+                           "Erlang sources not generated (EVISION_GENERATE_LANG is elixir-only)"
 
-      source = File.read!(path)
+    @tag skip: @skip_without_erlang
+    test "evision.erl carries -js lines for free functions" do
+      source = File.read!(Path.join(@generated_erl_dir, "evision.erl"))
 
       assert source =~
                ~r/-js\(#\{fun => canny, arity => \d+, js_kind => function, js_name => <<"cv\.Canny">>\}\)\./
     end
 
+    @tag skip: @skip_without_erlang
     test "evision_qrcodedetector.erl emits method + constructor entries" do
-      source =
-        Path.join([File.cwd!(), "src", "generated", "evision_qrcodedetector.erl"])
-        |> File.read!()
+      source = File.read!(Path.join(@generated_erl_dir, "evision_qrcodedetector.erl"))
 
       assert source =~
                ~r/-js\(#\{fun => qrCodeDetector, arity => 0, js_kind => constructor, js_class => <<"cv\.QRCodeDetector">>\}\)\./


### PR DESCRIPTION
## Summary

Teaches evision's binding codegen about **opencv.js**. For every generated Erlang/Elixir binding that opencv.js also exposes, the codegen emits a persistent `@js` attribute recording the opencv.js counterpart and its positional argument layout (`arg_plan`), and ships an `Evision.JS` runtime module to query that mapping. This is the correspondence layer a browser runtime uses to pair compiled evision pipelines with opencv.js.

It also adds a from-source, CSP-clean opencv.js build so that runtime can load without `'unsafe-eval'`.

Targets OpenCV 5.0.0. Bumps evision to 1.0.1.

## Codegen: the `@js` correspondence tag

- **Whitelist parser** (`py_src/opencv_js_whitelist.py`): executes OpenCV's `platforms/js/opencv_js.config.py` with a stub `makeWhiteList` and walks the namespace, so each entry keeps its module bucket and the JS-side name opencv.js would expose (applying embind's dnn/aruco prefix stripping).
- **Attribute emission** (`py_src/pipeline.py`, `py_src/module_generator.py`, `py_src/evision_js_attr.py`): resolves each `FuncInfo` to its opencv.js counterpart once and emits a persistent `@js` attribute per matching `(function_name, arity)`; derives the positional `arg_plan` (an `[:in, :out, :in]` style list) that the downstream workflow compiler uses to place the pre-allocated destination Mat.
- **`Evision.JS` runtime**: a generated module to ask whether a `(module, fun, arity)` has an opencv.js counterpart and what its call shape is. The tag survives BEAM stripping.

## CSP-clean opencv.js build

- `scripts/build_opencv_js.sh`: from-source opencv.js differing from the stock `docs.opencv.org` build by exactly `-s DYNAMIC_EXECUTION=0`, so it runs under a Content-Security-Policy of `script-src 'wasm-unsafe-eval'` with no `'unsafe-eval'`. Same OpenCV version, default whitelist, and single-thread as stock, so the exported JS API (and therefore the `@js` table above) stays valid. Opt-in `OPENCV_JS_EMBIND_AOT=1` restores embind call speed.
- `scripts/verify_opencv_js_csp.mjs`: loads and exercises an embind `cv.Mat` under Node's `--disallow-code-generation-from-strings` (the runtime equivalent of the target CSP). `REQUIRE_NO_EVAL=1` makes it fail if that flag is ever dropped.
- `.github/workflows/opencv-js-precompile.yml`: build, verify, and publish `opencv.js` + `opencv.sha256` as an immutable release asset (publish gated behind a manual input or an `opencv-js-v*` tag).

## Tests

- Python: whitelist parser, `@js` emission, and `arg_plan` derivation unit tests (`py_src/tests/`).
- Elixir: `@js` tag presence and post-strip survival, the `Evision.JS` runtime, and `arg_plan` coverage (`test/evision_js_*_test.exs`).
- opencv.js build verified against OpenCV 5.0.0 (emsdk 4.0.20): initializes and runs `cv.Mat` with code generation from strings disabled; `0` `new Function(` / reachable `eval(` / `createNamedFunction` call sites.
