### PR TITLE
fix: resolve Elixir 1.20.x compile-time warnings (#324)

### DIFF
--- a/lib/evision_mat.ex
+++ b/lib/evision_mat.ex
@@ -871,7 +871,7 @@ defmodule Evision.Mat do
   end
 
   def to_pointer(img, opts) when is_list(opts) do
-    opts = Keyword.validate!(opts || [], mode: :local)
+    opts = Keyword.validate!(opts, mode: :local)
     img = from_struct(img)
     :evision_nif.mat_to_pointer([img: img] ++ opts)
   end
@@ -1558,9 +1558,6 @@ defmodule Evision.Mat do
          {:is_binary, true, _} <- {:is_binary, is_binary(bin), bin} do
       Nx.reshape(Nx.from_binary(bin, mat_type, backend: backend), mat_shape)
     else
-      {:error, reason} ->
-        {:error, reason}
-
       {:not_empty_shape, false} ->
         {:error, "shape is {}"}
 
@@ -2384,7 +2381,7 @@ defmodule Evision.Mat do
       type when is_atom(type) ->
         :ok
 
-      true ->
+      _ ->
         raise_unsupported_type(type)
     end
 

--- a/lib/zoo/utils/http.ex
+++ b/lib/zoo/utils/http.ex
@@ -26,7 +26,7 @@ defmodule Evision.Zoo.Utils.HTTP do
     path = IO.chardata_to_string(path)
     headers = build_headers(opts[:headers] || [])
 
-    case File.open(path, [:write]) do
+    case File.open(path, [:write, :raw, :binary]) do
       {:ok, file} ->
         try do
           request = {url, headers}
@@ -72,7 +72,7 @@ defmodule Evision.Zoo.Utils.HTTP do
   end
 
   defp download_receive(state, {_, {{_, 200, _}, _headers, body}}) do
-    case IO.binwrite(state.file, body) do
+    case :file.write(state.file, body) do
       :ok ->
         :ok
 
@@ -91,7 +91,7 @@ defmodule Evision.Zoo.Utils.HTTP do
   end
 
   defp download_receive(state, {_, :stream, body_part}) do
-    case IO.binwrite(state.file, body_part) do
+    case :file.write(state.file, body_part) do
       :ok ->
         part_size = byte_size(body_part)
         state = update_in(state.size, &(&1 + part_size))

--- a/mix.exs
+++ b/mix.exs
@@ -933,8 +933,8 @@ defmodule Evision.MixProject do
       make_executable: make_executable(),
       make_makefile: make_makefile(),
       make_env: make_env,
-      xref: [
-        exclude: [
+      elixirc_options: [
+        no_warn_undefined: [
           :wx,
           :wxBitmap,
           :wxBoxSizer,

--- a/py_src/evision_extra_functions.py
+++ b/py_src/evision_extra_functions.py
@@ -39,7 +39,7 @@ gpumat_to_pointer_elixir = '''  @doc """
     {:ok, %Evision.IPCHandle.Local{} | %Evision.IPCHandle.CUDA{} | %Evision.IPCHandle.Host{}} | {:error, String.t()}
   def to_pointer(%{ref: ref}, [mode: mode] = opts)
   when is_list(opts) and mode in [:local, :cuda_ipc, :host_ipc] do
-    opts = Keyword.validate!(opts || [], [mode: :local])
+    opts = Keyword.validate!(opts, [mode: :local])
     with {:ok, handle} <- :evision_nif.cuda_cuda_GpuMat_to_pointer([img: ref] ++ opts) do
       mode = opts[:mode]
       case {mode, handle} do
@@ -205,7 +205,7 @@ gpumat_to_pointer_elixir = '''  @doc """
   """
   @spec from_pointer(list(integer()), atom() | {atom(), integer()}, tuple(), [device_id: non_neg_integer()]) :: Evision.CUDA.GpuMat.t() | {:error, String.t()}
   def from_pointer(device_pointer, dtype, shape, opts) when is_list(device_pointer) and is_tuple(shape) and is_list(opts) do
-    opts = Keyword.validate!(opts || [], [device_id: 0])
+    opts = Keyword.validate!(opts, [device_id: 0])
     positional = [
       device_pointer: device_pointer,
       dtype: compact_type(dtype),

--- a/py_src/fixes.py
+++ b/py_src/fixes.py
@@ -246,8 +246,6 @@ def evision_elixir_module_fixes():
             Nx.as_type(bboxes, :f64)
           Evision.Mat ->
             Evision.Mat.as_type(bboxes, :f64)
-          _ ->
-            raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
           bboxes: Evision.Mat.to_binary(bboxes),
@@ -330,8 +328,6 @@ def evision_elixir_module_fixes():
               Nx.as_type(bboxes, :f64)
           Evision.Mat ->
               Evision.Mat.as_type(bboxes, :f64)
-          _ ->
-              raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
           bboxes: Evision.Mat.to_binary(bboxes),
@@ -413,8 +409,6 @@ def evision_elixir_module_fixes():
               Nx.as_type(bboxes, :f64)
           Evision.Mat ->
               Evision.Mat.as_type(bboxes, :f64)
-          _ ->
-              raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
           bboxes: Evision.Mat.to_binary(bboxes),
@@ -504,8 +498,6 @@ def evision_elixir_module_fixes():
               Nx.as_type(bboxes, :s32)
           Evision.Mat ->
               Evision.Mat.as_type(bboxes, :s32)
-          _ ->
-              raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
           bboxes: Evision.Mat.to_binary(bboxes),
@@ -592,8 +584,6 @@ def evision_elixir_module_fixes():
               Nx.as_type(bboxes, :s32)
           Evision.Mat ->
               Evision.Mat.as_type(bboxes, :s32)
-          _ ->
-              raise "Invalid struct, expecting Nx.Tensor or Evision.Mat"
         end
         positional = [
           bboxes: Evision.Mat.to_binary(bboxes),

--- a/py_src/ir/variants.py
+++ b/py_src/ir/variants.py
@@ -147,6 +147,19 @@ class FuncVariant(object):
     def function_guard(self, kind: str):
         return list(filter(lambda x: x != '', [map_argtype_to_guard(kind, map_argname(kind, argname), argtype, classname=self.classname) for argname, _, argtype in self.py_arglist[:self.pos_end]]))
 
+    def normalized_guard(self, kind: str):
+        # Like function_guard/1 but with canonical positional argnames, and with one
+        # entry per positional arg (empty string when an arg has no guard) so the
+        # signature length equals the clause arity. Two clauses that differ only in
+        # argname, or in an argtype mapping to the same guard, yield identical
+        # signatures; keeping unguarded positions prevents a longer clause from
+        # looking like a shorter one. The emitter drops a clause an earlier same-arity
+        # clause already subsumes (Elixir 1.20 flags those as unreachable).
+        return [
+            map_argtype_to_guard(kind, f'__a{idx}', argtype, classname=self.classname)
+            for idx, (_, _, argtype) in enumerate(self.py_arglist[:self.pos_end])
+        ]
+
     def function_signature(self):
         return ''.join(filter(lambda x: x != '', [map_argtype_to_type(argtype, classname=self.classname) for _, _, argtype in self.py_arglist[:self.pos_end]]))
     

--- a/py_src/module_generator.py
+++ b/py_src/module_generator.py
@@ -19,6 +19,25 @@ else:
 unique_signatures = {}
 nif_declared = {}
 
+
+def _guard_subsumes(prior, current):
+    # Whether a clause guarded by `prior` makes a later clause guarded by `current`
+    # unreachable. True when, position by position, the guards are equal, or the
+    # earlier one is a bare `is_number(__aK)` (from a `double` arg) and the later is
+    # `is_integer(__aK)` / `is_float(__aK)`. Both lists use canonical argnames (see
+    # FunctionVariant.normalized_guard), so the comparison is argname-agnostic.
+    if len(prior) != len(current):
+        return False
+    for idx, (p, c) in enumerate(zip(prior, current)):
+        if p == c:
+            continue
+        canonical = f'__a{idx}'
+        if p == f'is_number({canonical})' and c in (f'is_integer({canonical})', f'is_float({canonical})'):
+            continue
+        return False
+    return True
+
+
 class ModuleGenerator(object):
     def __init__(self, module_name: str):
         self.module_name = module_name.strip()
@@ -404,6 +423,11 @@ class ModuleGenerator(object):
             func_guards_len_desc = list(reversed(argsort([len(g) for g in func_guards[kind]])))
             more_than_one_variant = len(func_guards_len_desc) > 1
             named_args_generated = False
+            # normalized guard signatures already emitted for each (name, arity), so a
+            # later clause an earlier one subsumes can be skipped. Scoped to this
+            # function's own overload group to avoid dropping look-alike clauses from
+            # unrelated overloads elsewhere.
+            emitted_guard_sigs = {}
             # start from the variant with the most number of constraints/guards
             for i in func_guards_len_desc:
                 # generated binding code will be written to this variable
@@ -487,10 +511,16 @@ class ModuleGenerator(object):
                     usign = kind + func.classname + function_sign
                 else:
                     usign = kind + function_sign
+                norm_guard = func_variant.normalized_guard(kind)
+                guard_key = (module_func_name, func_arity)
                 if unique_signatures.get(usign, None) is True:
+                    pass
+                elif kind == 'elixir' and any(_guard_subsumes(prev, norm_guard) for prev in emitted_guard_sigs.get(guard_key, [])):
                     pass
                 else:
                     unique_signatures[usign] = True
+                    if kind == 'elixir':
+                        emitted_guard_sigs.setdefault(guard_key, []).append(norm_guard)
                     inline_doc = func_variant.inline_docs(kind, is_instance_method, self.module_name)
                     func_when_guard = when_guard(kind, func_guard)
 

--- a/py_src/tests/test_guard_subsumes.py
+++ b/py_src/tests/test_guard_subsumes.py
@@ -1,0 +1,74 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from module_generator import _guard_subsumes
+from emit.elixir.helpers import map_argtype_to_guard_elixir
+
+
+class TestGuardSubsumes:
+    def test_identical_struct_guard_is_subsumed(self):
+        # Pattern 4: two GpuMat overloads emit the same struct guard.
+        g = ['is_struct(__a0, Evision.CUDA.GpuMat)']
+        assert _guard_subsumes(g, g) is True
+
+    def test_is_number_subsumes_is_integer(self):
+        # Pattern 3: a `double` clause (is_number) covers a later `int` clause.
+        assert _guard_subsumes(['is_number(__a0)'], ['is_integer(__a0)']) is True
+
+    def test_is_number_subsumes_is_float(self):
+        assert _guard_subsumes(['is_number(__a0)'], ['is_float(__a0)']) is True
+
+    def test_is_integer_does_not_subsume_is_number(self):
+        # Reverse order: the is_number clause stays reachable for floats.
+        assert _guard_subsumes(['is_integer(__a0)'], ['is_number(__a0)']) is False
+
+    def test_is_integer_does_not_subsume_is_float(self):
+        assert _guard_subsumes(['is_integer(__a0)'], ['is_float(__a0)']) is False
+
+    def test_different_arity_never_subsumes(self):
+        assert _guard_subsumes(['is_integer(__a0)'], ['is_integer(__a0)', 'is_binary(__a1)']) is False
+
+    def test_multi_arg_subsumption_is_per_position(self):
+        prior = ['is_binary(__a0)', 'is_number(__a1)']
+        current = ['is_binary(__a0)', 'is_integer(__a1)']
+        assert _guard_subsumes(prior, current) is True
+
+    def test_multi_arg_mismatch_blocks_subsumption(self):
+        prior = ['is_binary(__a0)', 'is_number(__a1)']
+        current = ['is_integer(__a0)', 'is_integer(__a1)']
+        assert _guard_subsumes(prior, current) is False
+
+    def test_empty_guards_same_arity_subsume(self):
+        # Two clauses with no guards and the same arity: the later is unreachable.
+        assert _guard_subsumes([], []) is True
+
+    def test_compound_mat_guard_is_not_a_bare_is_number_subsumer(self):
+        # Safety: the Mat guard contains `is_number(...)` but must never subsume an
+        # int clause, or a Mat+int overload pair would lose a reachable clause.
+        mat_guard = ['(is_struct(__a0, Evision.Mat) or is_struct(__a0, Nx.Tensor) or is_number(__a0) or is_tuple(__a0))']
+        assert _guard_subsumes(mat_guard, ['is_integer(__a0)']) is False
+
+    def test_shorter_clause_does_not_subsume_longer(self):
+        # Regression: a 1-arg Mat clause must not subsume a 2-arg (Mat, Vec3f) clause
+        # whose 2nd arg is unguarded. Signatures of different length never subsume, so
+        # the reachable longer clause is kept (this is why normalized_guard keeps an
+        # entry per positional arg instead of dropping empty guards).
+        mat = '(is_struct(__a0, Evision.Mat) or is_struct(__a0, Nx.Tensor) or is_number(__a0) or is_tuple(__a0))'
+        assert _guard_subsumes([mat], [mat, '']) is False
+        assert _guard_subsumes([mat, ''], [mat]) is False
+
+    def test_identical_including_unguarded_positions_subsume(self):
+        # Two clauses identical including an unguarded position: the later is dead.
+        assert _guard_subsumes(['is_binary(__a0)', ''], ['is_binary(__a0)', '']) is True
+
+    def test_unguarded_vs_guarded_position_blocks_subsumption(self):
+        assert _guard_subsumes(['is_binary(__a0)', ''], ['is_binary(__a0)', 'is_integer(__a1)']) is False
+
+    def test_guard_strings_match_subsumption_assumptions(self):
+        # Ties the predicate to the real guard emitter so a future change there
+        # cannot silently invalidate the is_number/is_integer/is_float assumptions.
+        assert map_argtype_to_guard_elixir('__a0', 'double') == 'is_number(__a0)'
+        assert map_argtype_to_guard_elixir('__a0', 'int') == 'is_integer(__a0)'
+        assert map_argtype_to_guard_elixir('__a0', 'float') == 'is_float(__a0)'


### PR DESCRIPTION
Addresses #324. Fixes 15 of the 16 Elixir 1.20.x compile-time warnings in evision's own code (dependency warnings from nx/complex/kino/elixir_make are upstream and out of scope). The one remaining warning is called out below.

## How the warnings were surfaced

`EVISION_FETCH_PRECOMPILED=true mix compile --force` drops the OpenCV build/download from the compiler chain (project config falls back to plain `Mix.compilers()`), so the Elixir type checker runs over `lib/` alone.

## Changes (3 commits)

**1. Hand-written modules** (`2e544f0`)
- `mix.exs`: `xref: [exclude: ...]` → `elixirc_options: [no_warn_undefined: ...]` (former is deprecated).
- `Evision.Mat.to_pointer/2`: drop dead `opts || []` (the `is_list(opts)` guard already guarantees a list).
- `Evision.Mat.to_nx/2`: remove an `{:error, reason}` `else` clause the `with` chain can never produce.
- `Evision.Mat.check_unsupported_type/1`: `true ->` in a `case` matched only the literal `true` and was shadowed by `is_atom/1`, so unsupported non-atom types raised `CaseClauseError`. `_ ->` fixes both the warning and the latent bug.
- `Evision.Zoo.Utils.HTTP`: `IO.binwrite/2` is spec'd `:ok` in 1.20, so its `{:error, _}` branches were unreachable. Switch to a raw binary file + `:file.write/2` (`:ok | {:error, posix}`), preserving disk-full handling and getting faster bulk writes.

**2. py_src templates** (`99c1cac`) — the emitted bindings are gitignored, so the fix lives in the generator
- `evision_extra_functions.py`: drop dead `opts || []` in the CUDA GpuMat `to_pointer/2` / `from_pointer/4` templates. The auto-generated opts path is untouched (its guard admits `nil`).
- `fixes.py`: remove the unreachable `_ -> raise` arm from the five `case bboxes.__struct__` blocks; each head already guards `is_struct(bboxes, Evision.Mat) or is_struct(bboxes, Nx.Tensor)`.

**3. Generator overload dedup** (`35dbb54`)
The clause emitter deduplicated only by *type* signature, so overloads with different types but subsuming *guards* both emitted (`FileStorage.write/3`, `DNN.DictValue.dictValue/1`: a `double`/`is_number` clause followed by a covered `int`/`is_integer` clause). Added an argname-normalized, per-position guard signature and a conservative same-arity subsumption skip (guards equal, or bare `is_number` covering `is_integer`/`is_float`).

## Validation (full regeneration)

Because the generator change touches all generated modules, I regenerated the bindings from the current OpenCV headers **both with and without** commit 3 (all 46 configured modules via `gen2.py`) and diffed them. This caught **two over-removal bugs** that unit tests alone did not — one where an unguarded 2nd arg (e.g. `Vec3f`) collapsed a clause's signature length, and one where global dedup state leaked across unrelated overloads. Both are fixed; the final diff removes **only** the two redundant `is_integer` clauses, nothing else. The subsumption predicate has unit tests (`py_src/tests/test_guard_subsumes.py`, 14 cases incl. the regressions). The full `py_src` suite is green (2 pre-existing tests need a `3rd_party/opencv` checkout).

Net effect on the isolated recompile: redundancy/type warnings **10 → 1**.

## One remaining warning (not fixed here)

`Evision.CUDA.GpuMat.gpuMat/1`: two copy-constructor overloads emit an identical `is_struct(_, Evision.CUDA.GpuMat)` clause, but from **separate overload groups**, so the per-function dedup above doesn't see them. Deduping across groups needs global state, which the regeneration diff showed drops reachable look-alike clauses elsewhere (e.g. in `fisheye`) — so I left this one clause rather than ship a risky change. It's a pre-existing duplicate in the generated bindings and safe to leave; a targeted cross-group pass can handle it separately.

The remaining `:evision_nif.*/1 is undefined` warnings in the isolated compile are an artifact of building Elixir without the NIF; they don't appear in a real build.
