### PR TITLE
fix(gen2): resolve flann/defines.h for installed-tree OpenCV layouts

### DIFF
--- a/py_src/gen2.py
+++ b/py_src/gen2.py
@@ -55,15 +55,16 @@ if __name__ == "__main__":
                 for l in f.readlines():
                     srcfiles.append(l.strip())
 
-        # OpenCV's header list omits modules/flann/include/opencv2/flann/defines.h,
-        # but the cvflann enums (flann_algorithm_t, flann_distance_t,
-        # flann_centers_init_t) live there. pipeline.add_const() relies on
-        # them to emit Evision.Flann.Algorithm, Evision.Flann.CentersInit,
-        # and friends, so inject the file explicitly when flann.hpp is in
-        # the list.
+        # OpenCV omits the flann defines header from the list, but the cvflann
+        # enums (flann_algorithm_t, flann_distance_t, flann_centers_init_t) live
+        # there and pipeline.add_const() needs them for Evision.Flann.Algorithm etc.
+        # Inject it beside flann.hpp, matching on the opencv2/flann.hpp suffix so
+        # both a source tree (modules/flann/include/opencv2/flann.hpp) and an
+        # installed tree (include/opencv4/opencv2/flann.hpp, e.g. a system/Nix
+        # OpenCV) resolve it.
         for l in list(srcfiles):
-            if l.endswith("modules/flann/include/opencv2/flann.hpp"):
-                flann_defines = l.replace("modules/flann/include/opencv2/flann.hpp", "modules/flann/include/opencv2/flann/defines.h")
+            if l.endswith("opencv2/flann.hpp"):
+                flann_defines = l[:-len("flann.hpp")] + "flann/defines.h"
                 if os.path.exists(flann_defines) and flann_defines not in srcfiles:
                     srcfiles.append(flann_defines)
                 break


### PR DESCRIPTION
## Problem

Building evision against an **installed/system OpenCV** (headers under `include/opencv4/opencv2/…`) rather than evision's own from-source tree fails to compile the flann `Index` binding:

> error: 'cvflann_flann_distance_t' was not declared in this scope

Reported in #326 (nixpkgs `opencv-4.13.0`).

## Root cause

`gen2.py` injects `flann/defines.h` (where the cvflann enums live) so their `Evision.Flann.*` constants and `CV_ERL_*_ENUM` converters get emitted. It located the header by matching the **source-tree** suffix `modules/flann/include/opencv2/flann.hpp`. A system/installed OpenCV lists it as `.../include/opencv4/opencv2/flann.hpp`, so the match fails, `defines.h` is never parsed, the `cvflann_flann_distance_t` typedef is never emitted, and the generated Index binding references an undeclared type.

Stock evision builds OpenCV from source (source-tree layout), which is why CI and precompiled builds never hit this. It only bites builds pointed at a system OpenCV (Nix; a distro `libopencv-dev` in principle).

## Fix

Match on the `opencv2/flann.hpp` suffix and derive `defines.h` beside it, so both layouts resolve. The `os.path.exists` guard is unchanged.

```python
for l in list(srcfiles):
    if l.endswith("opencv2/flann.hpp"):
        flann_defines = l[:-len("flann.hpp")] + "flann/defines.h"
        if os.path.exists(flann_defines) and flann_defines not in srcfiles:
            srcfiles.append(flann_defines)
        break
```

## Verification (real nixpkgs `opencv-4.13.0` on a Nix VM)

- flann headers at `include/opencv4/opencv2/flann.hpp`; **0** paths match the old source-tree suffix.
- Old logic injects nothing; new logic injects the real `include/opencv4/opencv2/flann/defines.h` (exists on disk).
- Reproduced the reporter's **exact** compile error against the real headers; adding the typedef gen2 now emits → compiles.
- **No regression:** the new match still resolves `defines.h` on the real source tree.

Draft for review.
